### PR TITLE
Detach before executing EM callbacks

### DIFF
--- a/lib/mysql2/em.rb
+++ b/lib/mysql2/em.rb
@@ -13,12 +13,12 @@ module Mysql2
         end
 
         def notify_readable
+          detach
           begin
             @deferable.succeed(@client.async_result)
           rescue Exception => e
             @deferable.fail(e)
           end
-          detach
         end
       end
 

--- a/spec/em/em_spec.rb
+++ b/spec/em/em_spec.rb
@@ -19,8 +19,27 @@ describe Mysql2::EM::Client do
         results << result.first
       end
     end
-    
+
     results[0].keys.should include("second_query")
     results[1].keys.should include("first_query")
+  end
+
+  it "should support queries in callbacks" do
+    results = []
+    EM.run do
+      client = Mysql2::EM::Client.new
+      defer1 = client.query "SELECT sleep(0.025) as first_query"
+      defer1.callback do |result|
+        results << result.first
+        defer2 = client.query "SELECT sleep(0.025) as second_query"
+        defer2.callback do |result|
+          results << result.first
+          EM.stop_event_loop
+        end
+      end
+    end
+
+    results[0].keys.should include("first_query")
+    results[1].keys.should include("second_query")
   end
 end


### PR DESCRIPTION
I think it might be useful to execute queries from callbacks, for example if the order of execution is important.
