### PR TITLE
Re-request for installing with MariaDB on Windows

### DIFF
--- a/ext/mysql2/mysql2_ext.h
+++ b/ext/mysql2/mysql2_ext.h
@@ -4,6 +4,12 @@
 #include <ruby.h>
 #include <fcntl.h>
 
+#ifndef HAVE_UINT
+#define HAVE_UINT
+typedef unsigned short    ushort;
+typedef unsigned int    uint;
+#endif
+
 #ifdef HAVE_MYSQL_H
 #include <mysql.h>
 #include <mysql_com.h>


### PR DESCRIPTION
Only fix below, to  install with MariaDB on Windows

ext/mysql2/mysql2_ext.h
    #ifndef HAVE_UINT
    #define HAVE_UINT
    typedef unsigned short    ushort;
    typedef unsigned int    uint;
    #endif
