### PR TITLE
Raise errors instead of return errors when running the em_mysql2 adapter in a fiber

### DIFF
--- a/lib/active_record/connection_adapters/em_mysql2_adapter.rb
+++ b/lib/active_record/connection_adapters/em_mysql2_adapter.rb
@@ -52,7 +52,9 @@ module Mysql2
           deferable.errback do |err|
             fiber.resume(err)
           end
-          Fiber.yield
+          result = Fiber.yield
+          raise result if result.is_a?(Exception)
+          result
         else
           super(sql, opts)
         end


### PR DESCRIPTION
This simple patch will actually raise an error instead of returning the exception instance if one occurs while executing the query.
