### PR TITLE
EM::Client previous result still active on connection, retry later logic

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -3,7 +3,7 @@
 #include <errno.h>
 
 VALUE cMysql2Client;
-extern VALUE mMysql2, cMysql2Error;
+extern VALUE mMysql2, cMysql2Error, cMysql2AlreadyActiveError;
 static VALUE intern_encoding_from_charset;
 static VALUE sym_id, sym_version, sym_async, sym_symbolize_keys, sym_as, sym_array;
 static ID intern_merge, intern_error_number_eql, intern_sql_state_eql;
@@ -303,7 +303,7 @@ static VALUE rb_mysql_client_query(int argc, VALUE * argv, VALUE self) {
     // mark this connection active
     wrapper->active = 1;
   } else {
-    rb_raise(cMysql2Error, "This connection is still waiting for a result, try again once you have the result");
+    rb_raise(cMysql2AlreadyActiveError, "This connection is still waiting for a result, try again once you have the result");
   }
 
   defaults = rb_iv_get(self, "@query_options");

--- a/ext/mysql2/mysql2_ext.c
+++ b/ext/mysql2/mysql2_ext.c
@@ -1,11 +1,12 @@
 #include <mysql2_ext.h>
 
-VALUE mMysql2, cMysql2Error;
+VALUE mMysql2, cMysql2Error, cMysql2AlreadyActiveError;
 
 /* Ruby Extension initializer */
 void Init_mysql2() {
   mMysql2      = rb_define_module("Mysql2");
   cMysql2Error = rb_const_get(mMysql2, rb_intern("Error"));
+  cMysql2AlreadyActiveError = rb_const_get(mMysql2, rb_intern("AlreadyActiveError"));
 
   init_mysql2_client();
   init_mysql2_result();

--- a/lib/mysql2/error.rb
+++ b/lib/mysql2/error.rb
@@ -12,4 +12,7 @@ module Mysql2
     alias_method :errno, :error_number
     alias_method :error, :message
   end
+
+  class AlreadyActiveError < Error
+  end
 end

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -120,7 +120,7 @@ describe Mysql2::Client do
       @client.query("SELECT 1", :async => true)
       lambda {
         @client.query("SELECT 1")
-      }.should raise_error(Mysql2::Error)
+      }.should raise_error(Mysql2::AlreadyActiveError)
     end
 
     it "should require an open connection" do


### PR DESCRIPTION
Hi,

We've recently discovered a problem requesting multiple quick selects via EventMachine, it seems we're not getting the result from mysql before sending the next query. This might be better solved by a connection pool like in https://github.com/brianmario/mysql2/pull/132
But we've currently solved it here by putting the query back onto the event queue. No tests yet sorry since we're having trouble creating the failure other than in production where the server is faster than the database (amazon EC2 and RDS)

I'd like to know what you think is the best approach?

Thanks
Adam
