### PR TITLE
Rails 3.1 compatible connection pool for em_mysql2

### DIFF
--- a/lib/active_record/fiber_patches.rb
+++ b/lib/active_record/fiber_patches.rb
@@ -89,6 +89,12 @@ module ActiveRecord
             [col.name, col]
           }]
         end
+        
+        @column_defaults = Hash.new do |h, table_name|
+          h[table_name] = Hash[columns[table_name].map { |col|
+            [col.name, col.default]
+          }]
+        end
 
         @primary_keys = Hash.new do |h, table_name|
           h[table_name] = with_connection do |conn|


### PR DESCRIPTION
the column_defaults hash was added in rails 3.1.
any concerns adding this directly? compatibility issues?
