### PR TITLE
Change mysql error detection strategy

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -311,9 +311,10 @@ static VALUE rb_mysql_client_async_result(VALUE self) {
   result = (MYSQL_RES *)rb_thread_blocking_region(nogvl_store_result, wrapper, RUBY_UBF_IO, 0);
 
   if (result == NULL) {
-    if (mysql_field_count(wrapper->client) != 0) {
+    if (mysql_errno(wrapper->client) != 0) {
       rb_raise_mysql2_error(wrapper);
     }
+    // no data and no error, so query was not a SELECT
     return Qnil;
   }
 


### PR DESCRIPTION
Previous to this commit, some mysql connection errors were not detected
by the client.

This commit changes from implicit error detection via checking
mysql_field_count() to explicit detection via mysql_errno().

http://dev.mysql.com/doc/refman/5.0/en/null-mysql-store-result.html

Note that this was discovered while investigating https://github.com/brianmario/mysql2/issues/66

Also, from the bottom of [the mysql_field_count() docs](http://dev.mysql.com/doc/refman/5.0/en/mysql-field-count.html), it notes:

```
An alternative is to replace the mysql_field_count(&mysql)
call with mysql_errno(&mysql). In this case, you are checking
directly for an error from mysql_store_result() rather than
inferring from the value of mysql_field_count() whether the
statement was a SELECT.
```

While neither documentation says it explicitly, it seems that mysql_errno() will return errors that the strategy based on mysql_field_count() won't.

It is certainly my experience that there are connection errors happening that only checking mysql_errno() detects (see https://github.com/brianmario/mysql2/issues/66)
