### PR TITLE
Fix for issue #238

### DIFF
--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -17,6 +17,7 @@ dirs = ENV['PATH'].split(File::PATH_SEPARATOR) + %w[
   /opt/local/mysql
   /opt/local/lib/mysql5
   /usr
+  /usr/mysql
   /usr/local
   /usr/local/mysql
   /usr/local/mysql-*


### PR DESCRIPTION
Fix for [issue #238](https://github.com/brianmario/mysql2/issues/238), "Solaris 11 MySQL binary uses /usr/mysql as main directory". Just adds /usr/mysql to path search list.
