### PR TITLE
Don't fail deferrables when callbacks raise exceptions

### DIFF
--- a/lib/mysql2/em.rb
+++ b/lib/mysql2/em.rb
@@ -18,8 +18,9 @@ module Mysql2
             result = @client.async_result
           rescue Exception => e
             @deferable.fail(e)
+          else
+            @deferable.succeed(result)
           end
-          @deferable.succeed(result)
         end
       end
 


### PR DESCRIPTION
With the current implementation, any exception raised by an EM callback will be rescue by Mysql2::EM::Client::Watcher, and the deferrable will be failed. While I'm certainly not the most qualified person to make this judgement, I don't _think_ that is very idiomatic. I do know that this has made my life rather difficult in trying to work with these deferrables.

Here is an example:

``` ruby
EM.run do
  client = Mysql2::EM::Client.new
  defer = client.query "INSERT INTO `messages` (`content`) VALUES ('what up?')"
  defer.callback do |result|
    publish_to_queue
  end
  defer.errback do |err|
    LOGGER.error "Problem inserting into database: #{err.inspect}"
  end
end
```

But what if `publish_to_queue` fails because my queue server is down? With the current implementation, I'll also see an error in my log file saying that there was a problem inserting into the database; however, the database INSERT worked just fine.

With this patch, the above will not write a message to the log when `publish_to_queue` raises an exception.
