### PR TITLE
:connect_timeout does not work due to EINTR loop

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -223,7 +223,7 @@ static VALUE rb_connect(VALUE self, VALUE user, VALUE pass, VALUE host, VALUE po
 
   rv = rb_thread_blocking_region(nogvl_connect, &args, RUBY_UBF_IO, 0);
   if (rv == Qfalse) {
-    while (rv == Qfalse && errno == EINTR) {
+    while (rv == Qfalse && errno == EINTR && !mysql_errno(wrapper->client)) {
       errno = 0;
       rv = rb_thread_blocking_region(nogvl_connect, &args, RUBY_UBF_IO, 0);
     }


### PR DESCRIPTION
Fixes #189

I'm not sure what the intent of the EINTR loop was, so I'm not sure if this patch actually makes sense. It does fix the issue in my testing. I'd be happy to modify it as needed.
