### PR TITLE
Fix misplaced period in warn

### DIFF
--- a/lib/mysql2.rb
+++ b/lib/mysql2.rb
@@ -19,6 +19,6 @@ if defined?(ActiveRecord::VERSION::STRING) && ActiveRecord::VERSION::STRING < "3
   warn "============= WARNING FROM mysql2 ============="
   warn "This version of mysql2 (#{Mysql2::VERSION}) doesn't ship with the ActiveRecord adapter."
   warn "In Rails version 3.1.0 and up, the mysql2 ActiveRecord adapter is included with rails."
-  warn "If you want to use the mysql2 gem with Rails <= 3.0.x, please use the latest mysql2 in the 0.2.x series".
+  warn "If you want to use the mysql2 gem with Rails <= 3.0.x, please use the latest mysql2 in the 0.2.x series."
   warn "============= END WARNING FROM mysql2 ============="
 end


### PR DESCRIPTION
Moves the `.` inside of the quotes
