### PR TITLE
Only warn when requiring mysql2 if no adapter is found

### DIFF
--- a/lib/mysql2.rb
+++ b/lib/mysql2.rb
@@ -16,11 +16,15 @@ module Mysql2
 end
 
 if defined?(ActiveRecord::VERSION::STRING) && ActiveRecord::VERSION::STRING < "3.1"
-  warn "============= WARNING FROM mysql2 ============="
-  warn "This version of mysql2 (#{Mysql2::VERSION}) doesn't ship with the ActiveRecord adapter."
-  warn "In Rails version 3.1.0 and up, the mysql2 ActiveRecord adapter is included with rails."
-  warn "If you want to use the mysql2 gem with Rails <= 3.0.x, please use the latest mysql2 in the 0.2.x series."
-  warn "============= END WARNING FROM mysql2 ============="
+  begin
+    require 'active_record/connection_adapters/mysql2_adapter'
+  rescue LoadError
+    warn "============= WARNING FROM mysql2 ============="
+    warn "This version of mysql2 (#{Mysql2::VERSION}) doesn't ship with the ActiveRecord adapter."
+    warn "In Rails version 3.1.0 and up, the mysql2 ActiveRecord adapter is included with rails."
+    warn "If you want to use the mysql2 gem with Rails <= 3.0.x, please use the latest mysql2 in the 0.2.x series."
+    warn "============= END WARNING FROM mysql2 ============="
+  end
 end
 
 # For holding utility methods


### PR DESCRIPTION
When mysql2 is loaded inside ActiveRecord 2.3, first try to load a connection
adapter to see if it has been provided by something else.
