### PR TITLE
Offset patch

### DIFF
--- a/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -314,7 +314,7 @@ module ActiveRecord
       end
 
       def add_limit_offset!(sql, options)
-        limit, offset = options.fetch(:limit, 99999999999), options[:offset]
+        limit, offset = options.fetch(:limit, 18446744073709551615), options[:offset]
         if limit && offset
           sql << " LIMIT #{offset.to_i}, #{sanitize_limit(limit)}"
         elsif limit


### PR DESCRIPTION
If you try to query an object with an offset (but no specified limit), the gem should automatically insert a limit as well into the sql syntax (limit is requred for an offset).

Not sure if there's a better way than just putting `999999999` as the limit - any better ideas?
