### PR TITLE
Fix returns the number of rows processed after an stream: true query.

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -541,7 +541,12 @@ static VALUE rb_mysql_result_count(VALUE self) {
   GetMysql2Result(self, wrapper);
   if(wrapper->resultFreed) {
     if (wrapper->streamingComplete){
-      return LONG2NUM(wrapper->numberOfRows);
+      if(wrapper->numberOfRows > 0){
+        // -1 is necessary because the final nil row is yielded
+        return LONG2NUM(wrapper->numberOfRows - 1);
+      }else{
+        return LONG2NUM(0);
+      }
     } else {
       return LONG2NUM(RARRAY_LEN(wrapper->rows));
     }

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -23,7 +23,15 @@ describe Mysql2::Result do
       result = @client.query("SELECT * FROM mysql2_test", :stream => true, :cache_rows => false)
       result.count.should eql(0)
       result.each {|r|  }
-      result.count.should eql(1)
+      result.count.should eql(1) 
+  end
+
+  it "#count should be zero for rows after streaming when there were no results " do
+      @client.query "USE test"
+      result = @client.query("SELECT * FROM mysql2_test WHERE null_test IS NOT NULL", :stream => true, :cache_rows => false)
+      result.count.should eql(0)
+      result.each {|r|  }
+      result.count.should eql(0) 
   end
 
   it "should have included Enumerable" do


### PR DESCRIPTION
As of now when using the `:stream => true` after all the results have been
fetched Result#count would still return 0.

This patch attempts to read the value from numberOfRows when the result has
finished streaming.
