### PR TITLE
Streaming query, fixes count and removes extraneous nil 

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -478,7 +478,7 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
       do {
         row = rb_mysql_result_fetch_row(self, db_timezone, app_timezone, symbolizeKeys, asArray, castBool, cast, fields);
 
-        if (block != Qnil) {
+        if (block != Qnil && row != Qnil) {
           rb_yield(row);
           wrapper->lastRowProcessed++;
         }
@@ -541,12 +541,7 @@ static VALUE rb_mysql_result_count(VALUE self) {
   GetMysql2Result(self, wrapper);
   if(wrapper->resultFreed) {
     if (wrapper->streamingComplete){
-      if(wrapper->numberOfRows > 0){
-        // -1 is necessary because the final nil row is yielded
-        return LONG2NUM(wrapper->numberOfRows - 1);
-      }else{
-        return LONG2NUM(0);
-      }
+      return LONG2NUM(wrapper->numberOfRows);
     } else {
       return LONG2NUM(RARRAY_LEN(wrapper->rows));
     }

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -26,6 +26,11 @@ describe Mysql2::Result do
       result.count.should eql(1) 
   end
 
+  it "should not yield nil at the end of streaming" do
+    result = @client.query('SELECT * FROM mysql2_test', :stream => true)
+    result.each { |r| r.should_not be_nil}
+  end
+
   it "#count should be zero for rows after streaming when there were no results " do
       @client.query "USE test"
       result = @client.query("SELECT * FROM mysql2_test WHERE null_test IS NOT NULL", :stream => true, :cache_rows => false)


### PR DESCRIPTION
1. Queries using `:stream => true` will not yield an extra `nil` value at the end of the result set.
2. After using stream the number or results in the result set will be properly reported.
