### PR TITLE
Invert boolean casting logic

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -223,7 +223,7 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, ID db_timezone, ID app_timezo
           break;
         case MYSQL_TYPE_TINY:       // TINYINT field
           if (castBool && fields[i].length == 1) {
-            val = *row[i] == '1' ? Qtrue : Qfalse;
+            val = *row[i] != '0' ? Qtrue : Qfalse;
             break;
           }
         case MYSQL_TYPE_SHORT:      // SMALLINT field

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -154,13 +154,17 @@ describe Mysql2::Result do
       id1 = @client.last_id
       @client.query 'INSERT INTO mysql2_test (bool_cast_test) VALUES (0)'
       id2 = @client.last_id
+      @client.query 'INSERT INTO mysql2_test (bool_cast_test) VALUES (-1)'
+      id3 = @client.last_id
 
       result1 = @client.query 'SELECT bool_cast_test FROM mysql2_test WHERE bool_cast_test = 1 LIMIT 1', :cast_booleans => true
       result2 = @client.query 'SELECT bool_cast_test FROM mysql2_test WHERE bool_cast_test = 0 LIMIT 1', :cast_booleans => true
+      result3 = @client.query 'SELECT bool_cast_test FROM mysql2_test WHERE bool_cast_test = -1 LIMIT 1', :cast_booleans => true
       result1.first['bool_cast_test'].should be_true
       result2.first['bool_cast_test'].should be_false
+      result3.first['bool_cast_test'].should be_true
 
-      @client.query "DELETE from mysql2_test WHERE id IN(#{id1},#{id2})"
+      @client.query "DELETE from mysql2_test WHERE id IN(#{id1},#{id2},#{id3})"
     end
 
     it "should return Fixnum for a SMALLINT value" do


### PR DESCRIPTION
Change the logic of casting tinyints to boolean from == 1 being
true to != 0 being true. Whilst it's universally accepted that 0
is equivalent to false some database access libraries
(MS Access/ODBC for example) will write a -1 for a true value.
This is actually more consistent with Ruby behaviour where anything
other than nil or false is truthy.
