### PR TITLE
Fix backport of table_exists? in 14accdf8d1

### DIFF
--- a/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -378,9 +378,13 @@ module ActiveRecord
         show_variable 'collation_database'
       end
 
-      def tables(name = nil)
+      def tables(name = nil, database = nil)
         tables = []
-        execute("SHOW TABLES", name).each do |field|
+
+        sql = "SHOW TABLES "
+        sql << "IN #{quote_table_name(database)} " if database
+
+        execute(sql, 'SCHEMA').each do |field|
           tables << field.first
         end
         tables


### PR DESCRIPTION
The backport of table_exists? expects tables to accept an arity of 2,
whereas the version in the Mysql2Adapter only has an arity of 1. The
second parameter provides for querying tables in databases other than
the currently selected database.

This commit fixes this by backporting the tables method from the
MysqlAdapter in Rails 3.0.x.
