### PR TITLE
Use mysql's own read timeout option too 

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -613,6 +613,11 @@ static VALUE _mysql_client_options(VALUE self, int opt, VALUE value) {
       retval = &intval;
       break;
 
+    case MYSQL_OPT_READ_TIMEOUT:
+      intval = NUM2INT(value);
+      retval = &intval;
+      break;
+
     case MYSQL_OPT_LOCAL_INFILE:
       intval = (value == Qfalse ? 0 : 1);
       retval = &intval;
@@ -907,6 +912,20 @@ static VALUE set_connect_timeout(VALUE self, VALUE value) {
   return _mysql_client_options(self, MYSQL_OPT_CONNECT_TIMEOUT, value);
 }
 
+static VALUE set_read_timeout(VALUE self, VALUE value) {
+  long int sec;
+  Check_Type(value, T_FIXNUM);
+  sec = FIX2INT(value);
+  if (sec < 0) {
+    rb_raise(cMysql2Error, "read_timeout must be a positive integer, you passed %ld", sec);
+  }
+  // Set the instance variable here even though _mysql_client_options
+  // might not succeed, because the timeout is used in other ways
+  // elsewhere
+  rb_iv_set(self, "@read_timeout", value);
+  return _mysql_client_options(self, MYSQL_OPT_READ_TIMEOUT, value);
+}
+
 static VALUE set_charset_name(VALUE self, VALUE value) {
   char * charset_name;
 #ifdef HAVE_RUBY_ENCODING_H
@@ -1012,6 +1031,7 @@ void init_mysql2_client() {
 
   rb_define_private_method(cMysql2Client, "reconnect=", set_reconnect, 1);
   rb_define_private_method(cMysql2Client, "connect_timeout=", set_connect_timeout, 1);
+  rb_define_private_method(cMysql2Client, "read_timeout=", set_read_timeout, 1);
   rb_define_private_method(cMysql2Client, "local_infile=", set_local_infile, 1);
   rb_define_private_method(cMysql2Client, "charset_name=", set_charset_name, 1);
   rb_define_private_method(cMysql2Client, "ssl_set", set_ssl_options, 5);

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -21,18 +21,13 @@ module Mysql2
       initialize_ext
 
       # Set MySQL connection options (each one is a call to mysql_options())
-      [:reconnect, :connect_timeout, :local_infile].each do |key|
+      [:reconnect, :connect_timeout, :local_infile, :read_timeout].each do |key|
         next unless opts.key?(key)
         send(:"#{key}=", opts[key])
       end
 
       # force the encoding to utf8
       self.charset_name = opts[:encoding] || 'utf8'
-
-      @read_timeout = opts[:read_timeout]
-      if @read_timeout and @read_timeout < 0
-        raise Mysql2::Error, "read_timeout must be a positive integer, you passed #{@read_timeout}"
-      end
 
       ssl_set(*opts.values_at(:sslkey, :sslcert, :sslca, :sslcapath, :sslcipher))
       


### PR DESCRIPTION
do_query implements its own read timeout using rb_wait_for_single_fd,
but blocking operations, like mysql_ping, will still block until the
tcp connection expires if there is a problem (multiple minutes
usually).

ActiveRecord's connection pool makes liberal use of ping, so an
unresponsive mysql server can cause rails apps to hang even if
read_timeout has been configured.

We fix this by using the mysql library's own MYSQL_OPT_READ_TIMEOUT
option. It fixes mysql_ping and seems not to interfere with with
do_query.

I don't think writing a test case for this is practical - it requires
dropping packets to/from the mysql server after establishing the
connection. I've tested it like this manually though and it makes all
your fast fail dreams come true.
