### PR TITLE
Fix compilation of native extensions against libmysqlclient in mysql 5.5+

### DIFF
--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -31,10 +31,12 @@ if RUBY_PLATFORM =~ /mswin|mingw/
   exit 1 unless have_library("libmysql")
 elsif mc = (with_config('mysql-config') || Dir[GLOB].first) then
   mc = Dir[GLOB].first if mc == true
+  ver = `#{mc} --version`.chomp.to_f
   cflags = `#{mc} --cflags`.chomp
   exit 1 if $? != 0
   libs = `#{mc} --libs_r`.chomp
-  if libs.empty?
+  # MySQL 5.5 and above already have re-entrant code in libmysqlclient (no _r).
+  if ver >= 5.5 || libs.empty?
     libs = `#{mc} --libs`.chomp
   end
   exit 1 if $? != 0


### PR DESCRIPTION
In new MySQL releases we don't have _r versions of libraries to link against (the re-entrant code was merged into the standard versions).

Change the lookup procedure to always use --libs output of mysql_config in this circumstance.
