### PR TITLE
Make :reconnect= a public method on client

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1046,11 +1046,11 @@ void init_mysql2_client() {
   rb_define_method(cMysql2Client, "next_result", rb_mysql_client_next_result, 0);
   rb_define_method(cMysql2Client, "store_result", rb_mysql_client_store_result, 0);
   rb_define_method(cMysql2Client, "options", rb_mysql_client_options, 2);
+  rb_define_method(cMysql2Client, "reconnect=", set_reconnect, 1);
 #ifdef HAVE_RUBY_ENCODING_H
   rb_define_method(cMysql2Client, "encoding", rb_mysql_client_encoding, 0);
 #endif
 
-  rb_define_private_method(cMysql2Client, "reconnect=", set_reconnect, 1);
   rb_define_private_method(cMysql2Client, "connect_timeout=", set_connect_timeout, 1);
   rb_define_private_method(cMysql2Client, "read_timeout=", set_read_timeout, 1);
   rb_define_private_method(cMysql2Client, "write_timeout=", set_write_timeout, 1);

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -245,6 +245,34 @@ describe Mysql2::Client do
         }.should_not raise_error(Mysql2::Error)
       end
 
+      it "should handle Timeouts without leaving the connection hanging if reconnect is set to true after construction true" do
+        client = Mysql2::Client.new(DatabaseCredentials['root'])
+        begin
+          Timeout.timeout(1) do
+            client.query("SELECT sleep(2)")
+          end
+        rescue Timeout::Error
+        end
+
+        lambda {
+          client.query("SELECT 1")
+        }.should raise_error(Mysql2::Error)
+
+        client.reconnect = true
+
+        begin
+          Timeout.timeout(1) do
+            client.query("SELECT sleep(2)")
+          end
+        rescue Timeout::Error
+        end
+
+        lambda {
+          client.query("SELECT 1")
+        }.should_not raise_error(Mysql2::Error)
+
+      end
+
       it "threaded queries should be supported" do
         threads, results = [], {}
         connect = lambda{


### PR DESCRIPTION
This is needed for Sequel because it does not allow you to pass options
to the constructed mysql2 client at construction time so you must be able to
set it later.

Sequel usage:

``` ruby
Sequel.connect(sql_config.merge(:after_connect => lambda {|c| c.reconnect = true}))
```
