### PR TITLE
Cast connection options to correct datatype.

### DIFF
--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -23,7 +23,14 @@ module Mysql2
       # Set MySQL connection options (each one is a call to mysql_options())
       [:reconnect, :connect_timeout, :local_infile, :read_timeout, :write_timeout].each do |key|
         next unless opts.key?(key)
-        send(:"#{key}=", opts[key])
+        case key
+        when :reconnect, :local_infile
+          send(:"#{key}=", !!opts[key])
+        when :connect_timeout, :read_timeout, :write_timeout
+          send(:"#{key}=", opts[key].to_i)
+        else
+          send(:"#{key}=", opts[key])
+        end
       end
 
       # force the encoding to utf8


### PR DESCRIPTION
In order to set database connection options on Heroku using the Amazon RDS add-on, we need to specify the connection options via the DATABASE_URL as such:

```
mysql2://username:password@...rds.amazonaws.com/database?reconnect=true&read_timeout=2&connect_timeout=2&write_timeout=2
```

However, these connection options are interpreted as strings when initializing the mysql2 client which results in failures like:

```
2012-10-04T23:13:05+00:00 app[web.1]: /app/vendor/bundle/ruby/1.9.1/gems/mysql2-0.3.12b4/lib/mysql2/client.rb:26:in `connect_timeout=': wrong argument type String (expected Fixnum) (TypeError)
2012-10-04T23:13:05+00:00 app[web.1]:   from /app/vendor/bundle/ruby/1.9.1/gems/mysql2-0.3.12b4/lib/mysql2/client.rb:26:in `block in initialize'
2012-10-04T23:13:05+00:00 app[web.1]:   from /app/vendor/bundle/ruby/1.9.1/gems/mysql2-0.3.12b4/lib/mysql2/client.rb:24:in `each'
2012-10-04T23:13:05+00:00 app[web.1]:   from /app/vendor/bundle/ruby/1.9.1/gems/mysql2-0.3.12b4/lib/mysql2/client.rb:24:in `initialize'
...
```

This pull casts the connection option values to the desired types.
