### PR TITLE
Allow rbx 1.8 & 1.9 modes to fail on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,3 @@ rvm:
   - ree
   - rbx-18mode
   - rbx-19mode
-matrix:
-  allow_failures:
-    - rvm: rbx-18mode
-    - rvm: rbx-19mode


### PR DESCRIPTION
In support of rubinius/rubinius#2006 we're trying to get important gems with C-extensions to test on Rubinius.

Thanks for your consideration!
