### PR TITLE
move magic values to default query options

### DIFF
--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -10,7 +10,10 @@ module Mysql2
       :application_timezone => nil,   # timezone Mysql2 will convert to before handing the object back to the caller
       :cache_rows => true,            # tells Mysql2 to use it's internal row cache for results
       :connect_flags => REMEMBER_OPTIONS | LONG_PASSWORD | LONG_FLAG | TRANSACTIONS | PROTOCOL_41 | SECURE_CONNECTION,
-      :cast => true
+      :cast => true,
+      :encoding => 'utf8',
+      :host => 'localhost',
+      :port => 3306
     }
 
     def initialize(opts = {})
@@ -33,8 +36,7 @@ module Mysql2
         end
       end
 
-      # force the encoding to utf8
-      self.charset_name = opts[:encoding] || 'utf8'
+      self.charset_name = opts[:encoding]
 
       ssl_set(*opts.values_at(:sslkey, :sslcert, :sslca, :sslcapath, :sslcipher))
 
@@ -47,8 +49,8 @@ module Mysql2
 
       user     = opts[:username] || opts[:user]
       pass     = opts[:password] || opts[:pass]
-      host     = opts[:host] || opts[:hostname] || 'localhost'
-      port     = opts[:port] || 3306
+      host     = opts[:host] || opts[:hostname]
+      port     = opts[:port]
       database = opts[:database] || opts[:dbname] || opts[:db]
       socket   = opts[:socket] || opts[:sock]
       flags    = opts[:flags] ? opts[:flags] | @query_options[:connect_flags] : @query_options[:connect_flags]


### PR DESCRIPTION
Move the default values for the options `:encoding`, `:host` and `:port` to `@@default_query_options` to get rid of implicit defaults (magic values).
This also simplifies the code without a change in functionality.
