### PR TITLE
Fix the connection exception spec

### DIFF
--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -8,7 +8,9 @@ describe Mysql2::Client do
 
   it "should raise an exception upon connection failure" do
     lambda {
-      Mysql2::Client.new DatabaseCredentials['root'].merge(:port => 999999)
+      # The odd local host IP address forces the mysql client library to
+      # use a TCP socket rather than a domain socket.
+      Mysql2::Client.new DatabaseCredentials['root'].merge(:host => '127.0.0.2', :port => 999999)
     }.should raise_error(Mysql2::Error)
   end
 


### PR DESCRIPTION
Fix the connection exception spec by forcing mysql library to use TCP to localhost in a way that will fail.

This should get us green again on Travis.
