### PR TITLE
Use string key for alternative hostname

### DIFF
--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -293,13 +293,17 @@ describe Mysql2::Client do
 
       it "threaded queries should be supported" do
         threads, results = [], {}
+        lock = Mutex.new
         connect = lambda{
           Mysql2::Client.new(DatabaseCredentials['root'])
         }
         Timeout.timeout(0.7) do
           5.times {
             threads << Thread.new do
-              results[Thread.current.object_id] = connect.call.query("SELECT sleep(0.5) as result")
+              result = connect.call.query("SELECT sleep(0.5) as result")
+              lock.synchronize do
+                results[Thread.current.object_id] = result
+              end
             end
           }
         end


### PR DESCRIPTION
When using symbol keys, this creates non deterministic behavior. It
creates a hash with both a symbol and string key for host, which means
that it depends on hash ordering which hosts it uses.

Since in 1.8 hash ordering is not defined, this creates random errors.

Fixes that sometimes it fails on Rubinius and REE in #334

Also fix a race condition in the specs that sometimes causes a failure on Rubinius
