### PR TITLE
Add Client#query_info

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -245,6 +245,25 @@ static VALUE rb_mysql_client_warning_count(VALUE self) {
   return UINT2NUM(warning_count);
 }
 
+static VALUE rb_mysql_info(VALUE self) {
+  const char *info;
+  VALUE rb_str;
+  GET_CLIENT(self);
+
+  info = mysql_info(wrapper->client);
+
+  if (info == NULL) {
+    return Qnil;
+  }
+
+  rb_str = rb_str_new2(info);
+#ifdef HAVE_RUBY_ENCODING_H
+  rb_enc_associate(rb_str, rb_utf8_encoding());
+#endif
+
+  return rb_str;
+}
+
 static VALUE rb_connect(VALUE self, VALUE user, VALUE pass, VALUE host, VALUE port, VALUE database, VALUE socket, VALUE flags) {
   struct nogvl_connect_args args;
   VALUE rv;
@@ -1120,6 +1139,7 @@ void init_mysql2_client() {
   rb_define_method(cMysql2Client, "store_result", rb_mysql_client_store_result, 0);
   rb_define_method(cMysql2Client, "reconnect=", set_reconnect, 1);
   rb_define_method(cMysql2Client, "warning_count", rb_mysql_client_warning_count, 0);
+  rb_define_method(cMysql2Client, "query_info", rb_mysql_info, 0);
 #ifdef HAVE_RUBY_ENCODING_H
   rb_define_method(cMysql2Client, "encoding", rb_mysql_client_encoding, 0);
 #endif

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -128,6 +128,40 @@ describe Mysql2::Client do
     end
   end
 
+  it "should respond to #query_info" do
+    @client.should respond_to(:query_info)
+  end
+
+  context "#query_info" do
+    context "when no info present" do
+      before(:each) do
+        @client.query('select 1')
+      end
+      it "should 0" do
+        @client.query_info.should be_nil
+      end
+    end
+    context "when has some info" do
+      before(:each) do
+        @client.query "USE test"
+        @client.query "CREATE TABLE IF NOT EXISTS infoTest (`id` int(11) NOT NULL AUTO_INCREMENT, blah INT(11), PRIMARY KEY (`id`))"
+      end
+
+      after(:each) do
+        @client.query "DROP TABLE infoTest"
+      end
+
+      before(:each) do
+        # http://dev.mysql.com/doc/refman/5.0/en/mysql-info.html says
+        # # Note that mysql_info() returns a non-NULL value for INSERT ... VALUES only for the multiple-row form of the statement (that is, only if multiple value lists are specified).
+        @client.query("INSERT INTO infoTest (blah) VALUES (1234),(4535)")
+      end
+      it "should retrieve it" do
+        @client.query_info.should eq 'Records: 2  Duplicates: 0  Warnings: 0'
+      end
+    end
+  end
+
   it "should expect connect_timeout to be a positive integer" do
     lambda {
       Mysql2::Client.new(:connect_timeout => -1)


### PR DESCRIPTION
Hey,

It's basically a direct mapping to [mysql_info](http://dev.mysql.com/doc/refman/5.5/en/mysql-info.html). I didn't use #info, because #info is taken by mysql_client_info.

I'm using this function to get the number of skipped rows after LOAD DATA INFILE. I didn't find another way to obtain that counter. So it could be useful for somebody else.

Thanks
