### PR TITLE
active_record: Delegate BigDecimal quoting to abstract adapter.

### DIFF
--- a/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -149,8 +149,6 @@ module ActiveRecord
         if value.kind_of?(String) && column && column.type == :binary && column.class.respond_to?(:string_to_binary)
           s = column.class.string_to_binary(value).unpack("H*")[0]
           "x'#{s}'"
-        elsif value.kind_of?(BigDecimal)
-          value.to_s("F")
         else
           super
         end


### PR DESCRIPTION
## Problem

The abstract connection adapter already supports BigDecimal quoting, so quoting it in the mysql2 adapter is redundant, and prevents proper quoting of BigDecimal numbers being compared to strings as proposed in the rails pull request https://github.com/rails/rails/pull/9207.
## Solution

Remove the case for quoting BigDecimal in the mysql2 adapter and let it be done in the abstract adapter where it is already supported.

source: https://github.com/rails/rails/blob/3-0-stable/activerecord/lib/active_record/connection_adapters/abstract/quoting.rb#L28

This is needed to fix the following test in the backport of the numeric quoting patch to activerecord 3.0.

https://github.com/rails/rails/pull/9210/files#L4R54
