### PR TITLE
symbolize keys in mysql2_connection sooner

### DIFF
--- a/lib/active_record/connection_adapters/mysql2_adapter.rb
+++ b/lib/active_record/connection_adapters/mysql2_adapter.rb
@@ -5,13 +5,15 @@ require 'mysql2'
 module ActiveRecord
   class Base
     def self.mysql2_connection(config)
+      config = config.symbolize_keys
+
       config[:username] = 'root' if config[:username].nil?
 
       if Mysql2::Client.const_defined? :FOUND_ROWS
         config[:flags] = Mysql2::Client::FOUND_ROWS
       end
 
-      client = Mysql2::Client.new(config.symbolize_keys)
+      client = Mysql2::Client.new(config)
       options = [config[:host], config[:username], config[:password], config[:database], config[:port], config[:socket], 0]
       ConnectionAdapters::Mysql2Adapter.new(client, logger, options, config)
     end


### PR DESCRIPTION
Having troubles with my rails 2.3.x setups and mysql2 -- we're setting the default username to "root" before we symbolize the keys in the hash, so passing in a hash with string keys causes problems.
