### PR TITLE
Mysql SSL test: Needs to verify it is using ssl

### DIFF
--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -81,11 +81,13 @@ describe Mysql2::Client do
     results = ssl_client.query("SHOW STATUS WHERE Variable_name = \"Ssl_version\" OR Variable_name = \"Ssl_cipher\"").to_a
     results[0]['Variable_name'].should eql('Ssl_cipher')
     results[0]['Value'].should_not be_nil
-    results[0]['Value'].class.should eql(String)
+    results[0]['Value'].should be_kind_of(String)
+    results[0]['Value'].should_not be_empty
 
     results[1]['Variable_name'].should eql('Ssl_version')
     results[1]['Value'].should_not be_nil
-    results[1]['Value'].class.should eql(String)
+    results[1]['Value'].should be_kind_of(String)
+    results[1]['Value'].should_not be_empty
   end
 
   it "should respond to #close" do


### PR DESCRIPTION
The MySQL SSL test was not actually testing that SSL was enabled.  It
was previously only detecting if SSL was enabled on the Server.

Specifically, even if it wasn't connecting via SSL it would return a string for `ssl_version` and `ssl_cipher`.  But the string was empty.

Ciao!
