### PR TITLE
Make :cast_booleans also cast BIT(1)

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -223,7 +223,11 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, ID db_timezone, ID app_timezo
           val = Qnil;
           break;
         case MYSQL_TYPE_BIT:        /* BIT field (MySQL 5.0.3 and up) */
-          val = rb_str_new(row[i], fieldLengths[i]);
+          if (castBool && fields[i].length == 1) {
+            val = *row[i] == 1 ? Qtrue : Qfalse;
+          }else{
+            val = rb_str_new(row[i], fieldLengths[i]);
+          }
           break;
         case MYSQL_TYPE_TINY:       /* TINYINT field */
           if (castBool && fields[i].length == 1) {

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -160,9 +160,14 @@ describe Mysql2::Result do
       @test_result['null_test'].should eql(nil)
     end
 
-    it "should return Fixnum for a BIT value" do
+    it "should return String for a BIT(64) value" do
       @test_result['bit_test'].class.should eql(String)
       @test_result['bit_test'].should eql("\000\000\000\000\000\000\000\005")
+    end
+
+    it "should return String for a BIT(1) value" do
+      @test_result['single_bit_test'].class.should eql(String)
+      @test_result['single_bit_test'].should eql("\001")
     end
 
     it "should return Fixnum for a TINYINT value" do
@@ -186,6 +191,20 @@ describe Mysql2::Result do
       result3.first['bool_cast_test'].should be_true
 
       @client.query "DELETE from mysql2_test WHERE id IN(#{id1},#{id2},#{id3})"
+    end
+
+    it "should return TrueClass or FalseClass for a BIT(1) value if :cast_booleans is enabled" do
+      @client.query 'INSERT INTO mysql2_test (single_bit_test) VALUES (1)'
+      id1 = @client.last_id
+      @client.query 'INSERT INTO mysql2_test (single_bit_test) VALUES (0)'
+      id2 = @client.last_id
+
+      result1 = @client.query "SELECT single_bit_test FROM mysql2_test WHERE id = #{id1}", :cast_booleans => true
+      result2 = @client.query "SELECT single_bit_test FROM mysql2_test WHERE id = #{id2}", :cast_booleans => true
+      result1.first['single_bit_test'].should be_true
+      result2.first['single_bit_test'].should be_false
+
+      @client.query "DELETE from mysql2_test WHERE id IN(#{id1},#{id2})"
     end
 
     it "should return Fixnum for a SMALLINT value" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -14,6 +14,7 @@ RSpec.configure do |config|
         id MEDIUMINT NOT NULL AUTO_INCREMENT,
         null_test VARCHAR(10),
         bit_test BIT(64),
+        single_bit_test BIT(1),
         tiny_int_test TINYINT,
         bool_cast_test TINYINT(1),
         small_int_test SMALLINT,
@@ -50,7 +51,7 @@ RSpec.configure do |config|
     client.query "DELETE FROM mysql2_test;"
     client.query %[
       INSERT INTO mysql2_test (
-        null_test, bit_test, tiny_int_test, bool_cast_test, small_int_test, medium_int_test, int_test, big_int_test,
+        null_test, bit_test, single_bit_test, tiny_int_test, bool_cast_test, small_int_test, medium_int_test, int_test, big_int_test,
         float_test, float_zero_test, double_test, decimal_test, decimal_zero_test, date_test, date_time_test, timestamp_test, time_test,
         year_test, char_test, varchar_test, binary_test, varbinary_test, tiny_blob_test,
         tiny_text_test, blob_test, text_test, medium_blob_test, medium_text_test,
@@ -58,7 +59,7 @@ RSpec.configure do |config|
       )
 
       VALUES (
-        NULL, b'101', 1, 1, 10, 10, 10, 10,
+        NULL, b'101', b'1', 1, 1, 10, 10, 10, 10,
         10.3, 0, 10.3, 10.3, 0, '2010-4-4', '2010-4-4 11:44:00', '2010-4-4 11:44:00', '11:44:00',
         2009, "test", "test", "test", "test", "test",
         "test", "test", "test", "test", "test",


### PR DESCRIPTION
Using `BIT(1)` to represent booleans is a common pattern within MySQL. This makes the existing `cast_booleans` switch cast `BIT(1)` as `TrueClass` or `FalseClass`
