### PR TITLE
Add secure source to Gemfile and Gemfile.lock

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,4 +1,4 @@
-source :rubygems
+source 'https://rubygems.org'
 
 gemspec
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -4,7 +4,7 @@ PATH
     mysql2 (0.3.12b6)
 
 GEM
-  remote: http://rubygems.org/
+  remote: https://rubygems.org/
   specs:
     activemodel (3.2.1)
       activesupport (= 3.2.1)


### PR DESCRIPTION
The source :rubygems is deprecated because HTTP requests are insecure.

```
modified:   Gemfile
modified:   Gemfile.lock
```
