### PR TITLE
Add license to gemspec

### DIFF
--- a/mysql2.gemspec
+++ b/mysql2.gemspec
@@ -4,6 +4,7 @@ Gem::Specification.new do |s|
   s.name = %q{mysql2}
   s.version = Mysql2::VERSION
   s.authors = ["Brian Lopez"]
+  s.license = "MIT"
   s.email = %q{seniorlopez@gmail.com}
   s.extensions = ["ext/mysql2/extconf.rb"]
   s.homepage = %q{http://github.com/brianmario/mysql2}


### PR DESCRIPTION
Prior to this commit, the gemspec did not include the license, which
means that one can't use the rubygems API to automatically determine
licensing of vendored gems. This commit adds the licensing to the
gemspec.
