### PR TITLE
Remove the check for SSL CA or Key being set.

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1051,14 +1051,12 @@ static VALUE set_charset_name(VALUE self, VALUE value) {
 static VALUE set_ssl_options(VALUE self, VALUE key, VALUE cert, VALUE ca, VALUE capath, VALUE cipher) {
   GET_CLIENT(self);
 
-  if(!NIL_P(ca) || !NIL_P(key)) {
-    mysql_ssl_set(wrapper->client,
-        NIL_P(key) ? NULL : StringValuePtr(key),
-        NIL_P(cert) ? NULL : StringValuePtr(cert),
-        NIL_P(ca) ? NULL : StringValuePtr(ca),
-        NIL_P(capath) ? NULL : StringValuePtr(capath),
-        NIL_P(cipher) ? NULL : StringValuePtr(cipher));
-  }
+  mysql_ssl_set(wrapper->client,
+      NIL_P(key) ? NULL : StringValuePtr(key),
+      NIL_P(cert) ? NULL : StringValuePtr(cert),
+      NIL_P(ca) ? NULL : StringValuePtr(ca),
+      NIL_P(capath) ? NULL : StringValuePtr(capath),
+      NIL_P(cipher) ? NULL : StringValuePtr(cipher));
 
   return self;
 }

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -36,7 +36,8 @@ module Mysql2
       # force the encoding to utf8
       self.charset_name = opts[:encoding] || 'utf8'
 
-      ssl_set(*opts.values_at(:sslkey, :sslcert, :sslca, :sslcapath, :sslcipher))
+      ssl_options = opts.values_at(:sslkey, :sslcert, :sslca, :sslcapath, :sslcipher)
+      ssl_set(*ssl_options) if ssl_options.any?
 
       if [:user,:pass,:hostname,:dbname,:db,:sock].any?{|k| @query_options.has_key?(k) }
         warn "============= WARNING FROM mysql2 ============="


### PR DESCRIPTION
Currently, the C bindings for the mysql2 gem enforce specifying either
the ssl-ca or ssl-key option, in order to set any of the SSL flags.
This makes the usage of mysql client worse for a few reasons. For one,
it's impossible to specify the ssl-capath flag by itself. This is
troubling if the server certificate is signed by a trusted authority,
whose certificate is present in /etc/ssl/certs, for example.

The other issue is that --ssl-cipher may not be specified on itsown.
The reason it may be desired is that it forces the client to use SSL
to connect to the server, however, the client does not validate the
server certificate. In certain situations that may actually be
desirable (e.g. self-signed certificates).

Fixes: #355
