### PR TITLE
Add a `:discard_result` option

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -355,14 +355,14 @@ static VALUE nogvl_use_result(void *ptr) {
 }
 
 /* call-seq:
- *    client.abandon_results!
+ *    client.discard_results!
  *
  * When using MULTI_STATEMENTS support, calling this will throw
  * away any unprocessed results as fast as it can in order to
  * put the connection back into a state where queries can be issued
  * again.
  */
-static VALUE rb_mysql_client_abandon_results(VALUE self) {
+static VALUE rb_mysql_client_discard_results(VALUE self) {
   GET_CLIENT(self);
 
   MYSQL_RES *result;
@@ -434,7 +434,7 @@ static VALUE rb_mysql_client_async_result(VALUE self) {
 
   if (discard_result) {
     mysql_free_result(result);
-    (void)rb_mysql_client_abandon_results(self);
+    (void)rb_mysql_client_discard_results(self);
     return Qnil;
   } else {
     resultObj = rb_mysql_result_to_obj(result);
@@ -1117,7 +1117,7 @@ void init_mysql2_client() {
 
   rb_define_method(cMysql2Client, "close", rb_mysql_client_close, 0);
   rb_define_method(cMysql2Client, "query", rb_mysql_client_query, -1);
-  rb_define_method(cMysql2Client, "abandon_results!", rb_mysql_client_abandon_results, 0);
+  rb_define_method(cMysql2Client, "discard_results!", rb_mysql_client_discard_results, 0);
   rb_define_method(cMysql2Client, "escape", rb_mysql_client_real_escape, 1);
   rb_define_method(cMysql2Client, "info", rb_mysql_client_info, 0);
   rb_define_method(cMysql2Client, "server_info", rb_mysql_client_server_info, 0);

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -418,9 +418,9 @@ describe Mysql2::Client do
         }.should raise_error(Mysql2::Error)
       end
 
-      it "#abandon_results! should work" do
+      it "#discard_results! should work" do
         @multi_client.query("SELECT 1; SELECT 2; SELECT 3")
-        @multi_client.abandon_results!
+        @multi_client.discard_results!
         lambda {
           @multi_client.query("SELECT 4")
         }.should_not raise_error(Mysql2::Error)


### PR DESCRIPTION
This will immediately discard any results returned meaning and makes it so `Mysql2::Client#query` will return `nil`. Like the other query options you can set it globally, per client or per query.

Using this in combination with `:streaming => true` is the most efficient way to send a query without libmysql or mysql2 parsing the result at all.

/cc @tmm1
