### PR TITLE
Add two refactor commits to the refcount branch

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -364,9 +364,6 @@ static VALUE nogvl_use_result(void *ptr) {
 static VALUE rb_mysql_client_async_result(VALUE self) {
   MYSQL_RES * result;
   VALUE resultObj;
-#ifdef HAVE_RUBY_ENCODING_H
-  mysql2_result_wrapper * result_wrapper;
-#endif
   GET_CLIENT(self);
 
   /* if we're not waiting on a result, do nothing */
@@ -396,14 +393,7 @@ static VALUE rb_mysql_client_async_result(VALUE self) {
     return Qnil;
   }
 
-  resultObj = rb_mysql_result_to_obj(self, result);
-  /* pass-through query options for result construction later */
-  rb_iv_set(resultObj, "@query_options", rb_hash_dup(rb_iv_get(self, "@current_query_options")));
-
-#ifdef HAVE_RUBY_ENCODING_H
-  GetMysql2Result(resultObj, result_wrapper);
-  result_wrapper->encoding = wrapper->encoding;
-#endif
+  resultObj = rb_mysql_result_to_obj(self, wrapper->encoding, rb_hash_dup(rb_iv_get(self, "@current_query_options")), result);
   return resultObj;
 }
 
@@ -929,10 +919,6 @@ static VALUE rb_mysql_client_store_result(VALUE self)
 {
   MYSQL_RES * result;
   VALUE resultObj;
-#ifdef HAVE_RUBY_ENCODING_H
-  mysql2_result_wrapper * result_wrapper;
-#endif
-
   GET_CLIENT(self);
 
   result = (MYSQL_RES *)rb_thread_blocking_region(nogvl_store_result, wrapper, RUBY_UBF_IO, 0);
@@ -945,14 +931,7 @@ static VALUE rb_mysql_client_store_result(VALUE self)
     return Qnil;
   }
 
-  resultObj = rb_mysql_result_to_obj(self, result);
-  /* pass-through query options for result construction later */
-  rb_iv_set(resultObj, "@query_options", rb_hash_dup(rb_iv_get(self, "@current_query_options")));
-
-#ifdef HAVE_RUBY_ENCODING_H
-  GetMysql2Result(resultObj, result_wrapper);
-  result_wrapper->encoding = wrapper->encoding;
-#endif
+  resultObj = rb_mysql_result_to_obj(self, wrapper->encoding, rb_hash_dup(rb_iv_get(self, "@current_query_options")), result);
   return resultObj;
 
 }

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -573,7 +573,7 @@ static VALUE rb_mysql_result_count(VALUE self) {
 }
 
 /* Mysql2::Result */
-VALUE rb_mysql_result_to_obj(VALUE client, MYSQL_RES *r) {
+VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_RES *r) {
   VALUE obj;
   mysql2_result_wrapper * wrapper;
   obj = Data_Make_Struct(cMysql2Result, mysql2_result_wrapper, rb_mysql_result_mark, rb_mysql_result_free, wrapper);
@@ -584,13 +584,16 @@ VALUE rb_mysql_result_to_obj(VALUE client, MYSQL_RES *r) {
   wrapper->result = r;
   wrapper->fields = Qnil;
   wrapper->rows = Qnil;
-  wrapper->encoding = Qnil;
+  wrapper->encoding = encoding;
   wrapper->streamingComplete = 0;
   wrapper->client = client;
   wrapper->client_wrapper = DATA_PTR(client);
   wrapper->client_wrapper->refcount++;
 
   rb_obj_call_init(obj, 0, NULL);
+
+  rb_iv_set(obj, "@query_options", options);
+
   return obj;
 }
 

--- a/ext/mysql2/result.h
+++ b/ext/mysql2/result.h
@@ -2,7 +2,7 @@
 #define MYSQL2_RESULT_H
 
 void init_mysql2_result();
-VALUE rb_mysql_result_to_obj(VALUE client, MYSQL_RES * r);
+VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_RES *r);
 
 typedef struct {
   VALUE fields;


### PR DESCRIPTION
First is a refactor of the refcount, adding a reference to the Client that spawns each Result. This will help prevent shutting down the client connection if there is still a result outstanding, and prevent the GC for collecting a client prior to collecting a Result. It is still possible that the Result and Client are collected in the same run, and that is accounted for here as well.

Second is a refactor of the rb_mysql_result_to_obj function, passing the encoding and query options as arguments. It is much cleaner this way. In the future it would be nice to pass these though to Mysql2::Result.initialize, too.

I don't mind if you rebase / squash some of the commits, as long as I don't lose too much `git blame` glory ;)
