### PR TITLE
Fixed a bug when linking against newer 64-bit mysql connectors

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1079,13 +1079,13 @@ void init_mysql2_client() {
   int i;
   int dots = 0;
   const char *lib = mysql_get_client_info();
-  for (i = 0; lib[i] != 0 && MYSQL_SERVER_VERSION[i] != 0; i++) {
+  for (i = 0; lib[i] != 0 && LIBMYSQL_VERSION[i] != 0; i++) {
     if (lib[i] == '.') {
       dots++;
               /* we only compare MAJOR and MINOR */
       if (dots == 2) break;
     }
-    if (lib[i] != MYSQL_SERVER_VERSION[i]) {
+    if (lib[i] != LIBMYSQL_VERSION[i]) {
       rb_raise(rb_eRuntimeError, "Incorrect MySQL client library version! This gem was compiled for %s but the client library is %s.", MYSQL_SERVER_VERSION, lib);
       return;
     }


### PR DESCRIPTION
The 6.1.0-winx64 version of the mySQL connector library lacks consistency between MYSQL_SERVER_VERSION and what's returned from mysql_get_client_info(). LIBMYSQL_VERSION seems to return the proper numbers. I'd like to see if this exists in previous versions of the connector for backwards compatibility, but I'm not sure where to get them.

Need to try linking against the 32-bit connector, but I haven't worked a lot with Rubygems, so I'm having trouble creating a local version of the gem.
