### PR TITLE
workaround for bug in mkmf

### DIFF
--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -29,6 +29,14 @@ GLOB = "{#{dirs.join(',')}}/{mysql_config,mysql_config5}"
 
 if RUBY_PLATFORM =~ /mswin|mingw/
   inc, lib = dir_config('mysql')
+
+  # Ruby versions not incorporating the mkmf fix at
+  # https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/39717
+  # do not properly search for lib directories, and must be corrected
+  unless lib[-3, 3] == 'lib'
+    @libdir_basename = 'lib'
+    inc, lib = dir_config('mysql')
+  end
   exit 1 unless have_library("libmysql")
 elsif mc = (with_config('mysql-config') || Dir[GLOB].first) then
   mc = Dir[GLOB].first if mc == true


### PR DESCRIPTION
This allows Windows users to build the gem more easily. Without this fix, Windows users must either (use both --with-mysql-lib and --with-mysql-include) when compiling, or they must put libmysql.dll into ruby/lib.

This was developed in response to #364

This is a work around for a known bug in mkmf, which was resolved in
https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/39717

Since the current Windows Ruby distribution doesn't include this fix yet,
we work around it by detecting whether mkmf is functioning properly or
not, and fixing it if it's not. This behavior will degrade gracefully if
the user is running a version of mkmf with the fix.
