### PR TITLE
Add a test console

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -10,3 +10,7 @@ group :benchmarks do
   gem 'sequel'
   gem 'faker'
 end
+
+group :development do
+  gem 'pry'
+end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -25,6 +25,7 @@ GEM
     arel (4.0.0)
     atomic (1.1.10)
     builder (3.1.4)
+    coderay (1.0.9)
     data_objects (0.10.13)
       addressable (~> 2.1)
     diff-lcs (1.1.3)
@@ -34,9 +35,14 @@ GEM
     faker (1.1.2)
       i18n (~> 0.5)
     i18n (0.6.4)
+    method_source (0.8.1)
     minitest (4.7.5)
     multi_json (1.7.7)
     mysql (2.9.1)
+    pry (0.9.12.2)
+      coderay (~> 1.0.5)
+      method_source (~> 0.8)
+      slop (~> 3.4)
     rake (0.9.6)
     rake-compiler (0.8.3)
       rake
@@ -49,6 +55,7 @@ GEM
       diff-lcs (~> 1.1.2)
     rspec-mocks (2.8.0)
     sequel (4.0.0)
+    slop (3.4.5)
     thread_safe (0.1.0)
       atomic
     tzinfo (0.3.37)
@@ -63,6 +70,7 @@ DEPENDENCIES
   faker
   mysql
   mysql2!
+  pry
   rake (~> 0.9.3)
   rake-compiler (~> 0.8.1)
   rspec (~> 2.8.0)

--- a/lib/mysql2/console.rb
+++ b/lib/mysql2/console.rb
@@ -1,0 +1,5 @@
+# Loaded by script/console. Land helpers here.
+
+Pry.config.prompt = lambda do |context, nesting, pry|
+  "[mysql2] #{context}> "
+end

--- a/script/bootstrap
+++ b/script/bootstrap
@@ -1,0 +1,5 @@
+#!/bin/sh
+set -e
+
+cd "$(dirname "$0")/.."
+exec bundle install --binstubs --path vendor/gems "$@"

--- a/script/console
+++ b/script/console
@@ -1,0 +1,7 @@
+#!/bin/sh
+# Run a Ruby REPL.
+
+set -e
+
+cd $(dirname "$0")/..
+exec ruby -S bin/pry -Ilib -r mysql2 -r mysql2/console


### PR DESCRIPTION
This adds a `script/console` binary which will load up a pry session with mysql2 already loaded. This is intended for use in development testing only.

This also adds a `script/bootstrap` binary which will perform local development setup tasks in one command. At the moment it just runs bundler for you, but future setup can happen here.
