### PR TITLE
Update benchmarks.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,7 +4,7 @@ gemspec
 
 # benchmarks
 group :benchmarks do
-  gem 'activerecord'
+  gem 'activerecord', '>= 3.0'
   gem 'mysql'
   gem 'do_mysql'
   gem 'sequel'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ PLATFORMS
   ruby
 
 DEPENDENCIES
-  activerecord
+  activerecord (>= 3.0)
   do_mysql
   eventmachine
   faker

--- a/benchmark/active_record.rb
+++ b/benchmark/active_record.rb
@@ -19,18 +19,18 @@ mysql_opts = {
 }
 
 class Mysql2Model < ActiveRecord::Base
-  set_table_name :mysql2_test
+  self.table_name = "mysql2_test"
 end
 
 class MysqlModel < ActiveRecord::Base
-  set_table_name :mysql2_test
+  self.table_name = "mysql2_test"
 end
 
 Benchmark.bmbm do |x|
   x.report "Mysql2" do
     Mysql2Model.establish_connection(mysql2_opts)
     number_of.times do
-      Mysql2Model.all(:limit => 1000).each{ |r|
+      Mysql2Model.limit(1000).to_a.each{ |r|
         r.attributes.keys.each{ |k|
           r.send(k.to_sym)
         }
@@ -41,7 +41,7 @@ Benchmark.bmbm do |x|
   x.report "Mysql" do
     MysqlModel.establish_connection(mysql_opts)
     number_of.times do
-      MysqlModel.all(:limit => 1000).each{ |r|
+      MysqlModel.limit(1000).to_a.each{ |r|
         r.attributes.keys.each{ |k|
           r.send(k.to_sym)
         }

--- a/benchmark/allocations.rb
+++ b/benchmark/allocations.rb
@@ -1,17 +1,17 @@
 # encoding: UTF-8
 $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
 
-raise Mysql2::Mysql2Error.new("GC allocation benchmarks only supported on Ruby 1.9!") unless RUBY_VERSION =~ /1\.9/
-
 require 'rubygems'
 require 'benchmark'
 require 'active_record'
+
+raise Mysql2::Error.new("GC allocation benchmarks only supported on Ruby 1.9!") unless RUBY_VERSION > '1.9'
 
 ActiveRecord::Base.default_timezone = :local
 ActiveRecord::Base.time_zone_aware_attributes = true
 
 class Mysql2Model < ActiveRecord::Base
-  set_table_name :mysql2_test
+  self.table_name = "mysql2_test"
 end
 
 def bench_allocations(feature, iterations = 10, &blk)
@@ -25,7 +25,7 @@ def bench_allocations(feature, iterations = 10, &blk)
 end
 
 bench_allocations('coercion') do
-  Mysql2Model.all(:limit => 1000).each{ |r|
+  Mysql2Model.limit(1000).to_a.each{ |r|
     r.attributes.keys.each{ |k|
       r.send(k.to_sym)
     }

--- a/benchmark/sequel.rb
+++ b/benchmark/sequel.rb
@@ -8,9 +8,9 @@ require 'sequel'
 require 'sequel/adapters/do'
 
 number_of = 10
-mysql2_opts = "mysql2://localhost/test"
-mysql_opts = "mysql://localhost/test"
-do_mysql_opts = "do:mysql://localhost/test"
+mysql2_opts = "mysql2://root@localhost/test"
+mysql_opts = "mysql://root@localhost/test"
+do_mysql_opts = "do:mysql://root@localhost/test"
 
 class Mysql2Model < Sequel::Model(Sequel.connect(mysql2_opts)[:mysql2_test]); end
 class MysqlModel < Sequel::Model(Sequel.connect(mysql_opts)[:mysql2_test]); end

--- a/benchmark/setup_db.rb
+++ b/benchmark/setup_db.rb
@@ -107,8 +107,8 @@ num.times do |n|
     :medium_text_test => twenty5_paragraphs,
     :long_blob_test => twenty5_paragraphs,
     :long_text_test => twenty5_paragraphs,
-    :enum_test => ['val1', 'val2'].rand,
-    :set_test => ['val1', 'val2', 'val1,val2'].rand
+    :enum_test => ['val1', 'val2'][rand(2)],
+    :set_test => ['val1', 'val2', 'val1,val2'][rand(3)]
   )
   if n % 100 == 0
     $stdout.putc '.'


### PR DESCRIPTION
- Upgraded to new ActiveRecord API (table_name, limit, to_a).
- Locked to ActiveRecord >= 3.0. ^
- Used Mysql2::Error instead of undefined Mysql2::Mysql2Error.
- Specify root user to sequel benchmark. Other benchmarks are using password less
  root account.
- Fixed picking random array value in benchmark/setup_db.rb (1.8 and 1.9
  compat).
