### PR TITLE
Initialize read_timeout 

### DIFF
--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -1,6 +1,6 @@
 module Mysql2
   class Client
-    attr_reader :query_options
+    attr_reader :query_options, :read_timeout
     @@default_query_options = {
       :as => :hash,                   # the type of object you want each row back as; also supports :array (an array of values)
       :async => false,                # don't wait for a result after sending the query, you'll have to monitor the socket yourself then eventually call Mysql2::Client#async_result
@@ -15,6 +15,7 @@ module Mysql2
 
     def initialize(opts = {})
       opts = Mysql2::Util.key_hash_as_symbols( opts )
+      @read_timeout = nil
       @query_options = @@default_query_options.dup
       @query_options.merge! opts
 


### PR DESCRIPTION
Initialize `read_timeout` to avoid `warning: instance variable @read_timeout not initialized`.

related: https://github.com/rails/rails/issues/11457
example: https://travis-ci.org/rails/rails/builds/9117770
