### PR TITLE
Revert "make sure write_timeout and local_infile ivars are setup to avoid warnings.

### DIFF
--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -1,6 +1,6 @@
 module Mysql2
   class Client
-    attr_reader :query_options, :read_timeout, :write_timeout, :local_infile
+    attr_reader :query_options, :read_timeout
     @@default_query_options = {
       :as => :hash,                   # the type of object you want each row back as; also supports :array (an array of values)
       :async => false,                # don't wait for a result after sending the query, you'll have to monitor the socket yourself then eventually call Mysql2::Client#async_result
@@ -16,8 +16,6 @@ module Mysql2
     def initialize(opts = {})
       opts = Mysql2::Util.key_hash_as_symbols( opts )
       @read_timeout = nil
-      @write_timeout = nil
-      @local_infile = nil
       @query_options = @@default_query_options.dup
       @query_options.merge! opts
 


### PR DESCRIPTION
This reverts commit e7e43411c5fd3191605b0dfb4d0dfb97c1466561.

I added initializing for `read_timeout` because it is used [here](https://github.com/brianmario/mysql2/blob/41f8b327a4029c9dce507eda24d5401891ac5cec/ext/mysql2/client.c#L466). There was case, when that instance variable wasn't initialized and it caused warning, because it was read uninitialized from C Ruby API via `rb_iv_get`.

I think we don't need to initialize another variables. I was looking for another instance variables, but I found only `query_options` (already initialized) and `current_query_options` which is already initialized in C extension. There is no case where `write_timeout` or `local_infile` is set into instance variable. There are just writers to set it into mysql via C extension for `write_timeout` and `local_infile`.
