### PR TITLE
Convert specs from "should" to "assert" syntax

### DIFF
--- a/spec/em/em_spec.rb
+++ b/spec/em/em_spec.rb
@@ -24,8 +24,8 @@ begin
         end
       end
 
-      assert_include results[0].keys, "second_query"
-      assert_include results[1].keys, "first_query"
+      assert_includes results[0].keys, "second_query"
+      assert_includes results[1].keys, "first_query"
     end
 
     test "supports queries in callbacks" do
@@ -44,8 +44,8 @@ begin
         end
       end
 
-      assert_include results[0].keys, "first_query"
-      assert_include results[1].keys, "second_query"
+      assert_includes results[0].keys, "first_query"
+      assert_includes results[1].keys, "second_query"
     end
 
     test "doesn't swallow exceptions raised in callbacks" do

--- a/spec/em/em_spec.rb
+++ b/spec/em/em_spec.rb
@@ -24,8 +24,8 @@ begin
         end
       end
 
-      assert_includes results[0].keys, "second_query"
-      assert_includes results[1].keys, "first_query"
+      assert_include results[0].keys, "second_query"
+      assert_include results[1].keys, "first_query"
     end
 
     test "supports queries in callbacks" do
@@ -44,8 +44,8 @@ begin
         end
       end
 
-      assert_includes results[0].keys, "first_query"
-      assert_includes results[1].keys, "second_query"
+      assert_include results[0].keys, "first_query"
+      assert_include results[1].keys, "second_query"
     end
 
     test "doesn't swallow exceptions raised in callbacks" do

--- a/spec/em/em_spec.rb
+++ b/spec/em/em_spec.rb
@@ -5,7 +5,7 @@ begin
   require 'mysql2/em'
 
   describe Mysql2::EM::Client do
-    it "should support async queries" do
+    test "supports async queries" do
       results = []
       EM.run do
         client1 = Mysql2::EM::Client.new DatabaseCredentials['root']
@@ -24,11 +24,11 @@ begin
         end
       end
 
-      results[0].keys.should include("second_query")
-      results[1].keys.should include("first_query")
+      assert_include results[0].keys, "second_query"
+      assert_include results[1].keys, "first_query"
     end
 
-    it "should support queries in callbacks" do
+    test "supports queries in callbacks" do
       results = []
       EM.run do
         client = Mysql2::EM::Client.new DatabaseCredentials['root']
@@ -44,18 +44,18 @@ begin
         end
       end
 
-      results[0].keys.should include("first_query")
-      results[1].keys.should include("second_query")
+      assert_include results[0].keys, "first_query"
+      assert_include results[1].keys, "second_query"
     end
 
-    it "should not swallow exceptions raised in callbacks" do
-      lambda {
+    test "doesn't swallow exceptions raised in callbacks" do
+      assert_raises RuntimeError do
         EM.run do
           client = Mysql2::EM::Client.new DatabaseCredentials['root']
           defer = client.query "SELECT sleep(0.1) as first_query"
           defer.callback do |result|
             client.close
-            raise 'some error'
+            raise RuntimeError, 'some error'
           end
           defer.errback do |err|
             # This _shouldn't_ be run, but it needed to prevent the specs from
@@ -63,7 +63,7 @@ begin
             EM.stop_event_loop
           end
         end
-      }.should raise_error
+      end
     end
 
     context 'when an exception is raised by the client' do
@@ -71,8 +71,9 @@ begin
       let(:error) { StandardError.new('some error') }
       before { client.stub(:async_result).and_raise(error) }
 
-      it "should swallow exceptions raised in by the client" do
+      test "swallows exceptions raised in by the client" do
         errors = []
+
         EM.run do
           defer = client.query "SELECT sleep(0.1) as first_query"
           defer.callback do |result|
@@ -85,10 +86,11 @@ begin
             EM.stop_event_loop
           end
         end
-        errors.should == [error]
+
+        assert_equal [error], errors
       end
 
-      it "should fail the deferrable" do
+      test "fails the deferrable" do
         callbacks_run = []
         EM.run do
           defer = client.query "SELECT sleep(0.025) as first_query"
@@ -105,7 +107,7 @@ begin
             end
           end
         end
-        callbacks_run.should == [:errback]
+        assert_equal [:errback], callbacks_run
       end
     end
   end

--- a/spec/mysql2/error_spec.rb
+++ b/spec/mysql2/error_spec.rb
@@ -22,51 +22,51 @@ describe Mysql2::Error do
     end
   end
 
-  it "should respond to #error_number" do
-    @error.should respond_to(:error_number)
+  test "responds to #error_number" do
+    assert @error.respond_to?(:error_number)
   end
 
-  it "should respond to #sql_state" do
-    @error.should respond_to(:sql_state)
+  test "responds to #sql_state" do
+    assert @error.respond_to?(:sql_state)
   end
 
   # Mysql gem compatibility
-  it "should alias #error_number to #errno" do
-    @error.should respond_to(:errno)
+  test "aliases #error_number to #errno" do
+    assert @error.respond_to?(:errno)
   end
 
-  it "should alias #message to #error" do
-    @error.should respond_to(:error)
+  test "aliases #message to #error" do
+    assert @error.respond_to?(:error)
   end
 
   unless RUBY_VERSION =~ /1.8/
-    it "#message encoding should match the connection's encoding, or Encoding.default_internal if set" do
+    test "#message encoding matches the connection's encoding, or Encoding.default_internal if set" do
       if Encoding.default_internal.nil?
-        @error.message.encoding.should eql(@err_client.encoding)
-        @error2.message.encoding.should eql(@err_client2.encoding)
+        assert_equal @err_client.encoding, @error.message.encoding
+        assert_equal @err_client2.encoding, @error2.message.encoding
       else
-        @error.message.encoding.should eql(Encoding.default_internal)
-        @error2.message.encoding.should eql(Encoding.default_internal)
+        assert_equal Encoding.default_internal, @error.message.encoding
+        assert_equal Encoding.default_internal, @error2.message.encoding
       end
     end
 
-    it "#error encoding should match the connection's encoding, or Encoding.default_internal if set" do
+    test "#error encoding matches the connection's encoding, or Encoding.default_internal if set" do
       if Encoding.default_internal.nil?
-        @error.error.encoding.should eql(@err_client.encoding)
-        @error2.error.encoding.should eql(@err_client2.encoding)
+        assert_equal @err_client.encoding, @error.error.encoding
+        assert_equal @err_client2.encoding, @error2.error.encoding
       else
-        @error.error.encoding.should eql(Encoding.default_internal)
-        @error2.error.encoding.should eql(Encoding.default_internal)
+        assert_equal Encoding.default_internal, @error.error.encoding
+        assert_equal Encoding.default_internal, @error2.error.encoding
       end
     end
 
-    it "#sql_state encoding should match the connection's encoding, or Encoding.default_internal if set" do
+    test "#sql_state encoding matches the connection's encoding, or Encoding.default_internal if set" do
       if Encoding.default_internal.nil?
-        @error.sql_state.encoding.should eql(@err_client.encoding)
-        @error2.sql_state.encoding.should eql(@err_client2.encoding)
+        assert_equal @err_client.encoding, @error.sql_state.encoding
+        assert_equal @err_client2.encoding, @error2.sql_state.encoding
       else
-        @error.sql_state.encoding.should eql(Encoding.default_internal)
-        @error2.sql_state.encoding.should eql(Encoding.default_internal)
+        assert_equal Encoding.default_internal, @error.sql_state.encoding
+        assert_equal Encoding.default_internal, @error2.sql_state.encoding
       end
     end
   end

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -167,7 +167,7 @@ describe Mysql2::Result do
     end
 
     test "returns Fixnum for a TINYINT value" do
-      assert_includes [Fixnum, Bignum], @test_result['tiny_int_test'].class
+      assert_include [Fixnum, Bignum], @test_result['tiny_int_test'].class
       assert_equal 1, @test_result['tiny_int_test']
     end
 
@@ -204,27 +204,27 @@ describe Mysql2::Result do
     end
 
     test "returns Fixnum for a SMALLINT value" do
-      assert_includes [Fixnum, Bignum], @test_result['small_int_test'].class
+      assert_include [Fixnum, Bignum], @test_result['small_int_test'].class
       assert_equal 10, @test_result['small_int_test']
     end
 
     test "returns Fixnum for a MEDIUMINT value" do
-      assert_includes [Fixnum, Bignum], @test_result['medium_int_test'].class
+      assert_include [Fixnum, Bignum], @test_result['medium_int_test'].class
       assert_equal 10, @test_result['medium_int_test']
     end
 
     test "returns Fixnum for an INT value" do
-      assert_includes [Fixnum, Bignum], @test_result['int_test'].class
+      assert_include [Fixnum, Bignum], @test_result['int_test'].class
       assert_equal 10, @test_result['int_test']
     end
 
     test "returns Fixnum for a BIGINT value" do
-      assert_includes [Fixnum, Bignum], @test_result['big_int_test'].class
+      assert_include [Fixnum, Bignum], @test_result['big_int_test'].class
       assert_equal 10, @test_result['big_int_test']
     end
 
     test "returns Fixnum for a YEAR value" do
-      assert_includes [Fixnum, Bignum], @test_result['year_test'].class
+      assert_include [Fixnum, Bignum], @test_result['year_test'].class
       assert_equal 2009, @test_result['year_test']
     end
 

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -6,116 +6,116 @@ describe Mysql2::Result do
     @result = @client.query "SELECT 1"
   end
 
-  it "should maintain a count while streaming" do
+  test "maintains a count while streaming" do
     result = @client.query('SELECT 1')
 
-    result.count.should eql(1)
+    assert_equal 1, result.count
     result.each.to_a
-    result.count.should eql(1)
+    assert_equal 1, result.count
   end
 
-  it "should set the actual count of rows after streaming" do
+  test "sets the actual count of rows after streaming" do
       @client.query "USE test"
       result = @client.query("SELECT * FROM mysql2_test", :stream => true, :cache_rows => false)
-      result.count.should eql(0)
+      assert_equal 0, result.count
       result.each {|r|  }
-      result.count.should eql(1)
+      assert_equal 1, result.count
   end
 
-  it "should not yield nil at the end of streaming" do
+  test "doesn't yield nil at the end of streaming" do
     result = @client.query('SELECT * FROM mysql2_test', :stream => true)
-    result.each { |r| r.should_not be_nil}
+    result.each { |r| assert !r.nil?}
   end
 
-  it "#count should be zero for rows after streaming when there were no results " do
+  test "#count is zero for rows after streaming when there were no results " do
       @client.query "USE test"
       result = @client.query("SELECT * FROM mysql2_test WHERE null_test IS NOT NULL", :stream => true, :cache_rows => false)
-      result.count.should eql(0)
+      assert_equal 0, result.count
       result.each.to_a
-      result.count.should eql(0)
+      assert_equal 0, result.count
   end
 
-  it "should have included Enumerable" do
-    Mysql2::Result.ancestors.include?(Enumerable).should be_true
+  test "includes Enumerable" do
+    assert Mysql2::Result.ancestors.include?(Enumerable)
   end
 
-  it "should respond to #each" do
-    @result.should respond_to(:each)
+  test "responds to #each" do
+    assert @result.respond_to?(:each)
   end
 
-  it "should raise a Mysql2::Error exception upon a bad query" do
-    lambda {
+  test "raises a Mysql2::Error exception upon a bad query" do
+    assert_raises Mysql2::Error do
       @client.query "bad sql"
-    }.should raise_error(Mysql2::Error)
+    end
 
-    lambda {
+    assert_not_raised Mysql2::Error do
       @client.query "SELECT 1"
-    }.should_not raise_error(Mysql2::Error)
+    end
   end
 
-  it "should respond to #count, which is aliased as #size" do
+  test "responds to #count, which is aliased as #size" do
     r = @client.query "SELECT 1"
-    r.should respond_to :count
-    r.should respond_to :size
+    assert r.respond_to? :count
+    assert r.respond_to? :size
   end
 
-  it "should be able to return the number of rows in the result set" do
+  test "returns the number of rows in the result set" do
     r = @client.query "SELECT 1"
-    r.count.should eql(1)
-    r.size.should eql(1)
+    assert_equal 1, r.count
+    assert_equal 1, r.size
   end
 
   context "metadata queries" do
-    it "should show tables" do
+    test "shows tables" do
       @result = @client.query "SHOW TABLES"
     end
   end
 
   context "#each" do
-    it "should yield rows as hash's" do
+    test "yields rows as hashes by default" do
       @result.each do |row|
-        row.class.should eql(Hash)
+        assert_equal Hash, row.class
       end
     end
 
-    it "should yield rows as hash's with symbol keys if :symbolize_keys was set to true" do
+    test "yields rows as hashes with symbol keys if :symbolize_keys was set to true" do
       @result.each(:symbolize_keys => true) do |row|
-        row.keys.first.class.should eql(Symbol)
+        assert_equal Symbol, row.keys.first.class
       end
     end
 
-    it "should be able to return results as an array" do
+    test "yields rows as an array if :as => :array is set" do
       @result.each(:as => :array) do |row|
-        row.class.should eql(Array)
+        assert_equal Array, row.class
       end
     end
 
-    it "should cache previously yielded results by default" do
-      @result.first.object_id.should eql(@result.first.object_id)
+    test "caches previously yielded results by default" do
+      assert_equal @result.first.object_id, @result.first.object_id
     end
 
-    it "should not cache previously yielded results if cache_rows is disabled" do
+    test "doesn't cache previously yielded results if cache_rows is disabled" do
       result = @client.query "SELECT 1", :cache_rows => false
-      result.first.object_id.should_not eql(result.first.object_id)
+      assert_not_equal result.first.object_id, result.first.object_id
     end
 
-    it "should yield different value for #first if streaming" do
+    test "yields different value for #first if streaming" do
       result = @client.query "SELECT 1 UNION SELECT 2", :stream => true, :cache_rows => false
-      result.first.should_not eql(result.first)
+      assert_not_equal result.first, result.first
     end
 
-    it "should yield the same value for #first if streaming is disabled" do
+    test "yields the same value for #first if streaming is disabled" do
       result = @client.query "SELECT 1 UNION SELECT 2", :stream => false
-      result.first.should eql(result.first)
+      assert_equal result.first, result.first
     end
 
-    it "should throw an exception if we try to iterate twice when streaming is enabled" do
+    test "raises an exception if we try to iterate twice when streaming is enabled" do
       result = @client.query "SELECT 1 UNION SELECT 2", :stream => true, :cache_rows => false
 
-      expect {
+      assert_raises Mysql2::Error do
         result.each.to_a
         result.each.to_a
-      }.to raise_exception(Mysql2::Error)
+      end
     end
   end
 
@@ -125,13 +125,13 @@ describe Mysql2::Result do
       @test_result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1")
     end
 
-    it "method should exist" do
-      @test_result.should respond_to(:fields)
+    test "method exists" do
+      assert @test_result.respond_to?(:fields)
     end
 
-    it "should return an array of field names in proper order" do
+    test "returns an array of field names in proper order" do
       result = @client.query "SELECT 'a', 'b', 'c'"
-      result.fields.should eql(['a', 'b', 'c'])
+      assert_equal ['a', 'b', 'c'], result.fields
     end
   end
 
@@ -141,37 +141,37 @@ describe Mysql2::Result do
       @test_result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
     end
 
-    it "should return nil values for NULL and strings for everything else when :cast is false" do
+    test "returns nil values for NULL and strings for everything else when :cast is false" do
       result = @client.query('SELECT null_test, tiny_int_test, bool_cast_test, int_test, date_test, enum_test FROM mysql2_test WHERE bool_cast_test = 1 LIMIT 1', :cast => false).first
-      result["null_test"].should be_nil
-      result["tiny_int_test"].should  eql("1")
-      result["bool_cast_test"].should eql("1")
-      result["int_test"].should       eql("10")
-      result["date_test"].should      eql("2010-04-04")
-      result["enum_test"].should      eql("val1")
+      assert_nil result["null_test"]
+      assert_equal "1", result["tiny_int_test"]
+      assert_equal "1", result["bool_cast_test"]
+      assert_equal "10", result["int_test"]
+      assert_equal "2010-04-04", result["date_test"]
+      assert_equal "val1", result["enum_test"]
     end
 
-    it "should return nil for a NULL value" do
-      @test_result['null_test'].class.should eql(NilClass)
-      @test_result['null_test'].should eql(nil)
+    test "returns nil for a NULL value" do
+      assert_equal NilClass, @test_result['null_test'].class
+      assert_nil @test_result['null_test']
     end
 
-    it "should return String for a BIT(64) value" do
-      @test_result['bit_test'].class.should eql(String)
-      @test_result['bit_test'].should eql("\000\000\000\000\000\000\000\005")
+    test "returns String for a BIT(64) value" do
+      assert_equal String, @test_result['bit_test'].class
+      assert_equal "\000\000\000\000\000\000\000\005", @test_result['bit_test']
     end
 
-    it "should return String for a BIT(1) value" do
-      @test_result['single_bit_test'].class.should eql(String)
-      @test_result['single_bit_test'].should eql("\001")
+    test "returns String for a BIT(1) value" do
+      assert_equal String, @test_result['single_bit_test'].class
+      assert_equal "\001", @test_result['single_bit_test']
     end
 
-    it "should return Fixnum for a TINYINT value" do
-      [Fixnum, Bignum].should include(@test_result['tiny_int_test'].class)
-      @test_result['tiny_int_test'].should eql(1)
+    test "returns Fixnum for a TINYINT value" do
+      assert_includes [Fixnum, Bignum], @test_result['tiny_int_test'].class
+      assert_equal 1, @test_result['tiny_int_test']
     end
 
-    it "should return TrueClass or FalseClass for a TINYINT value if :cast_booleans is enabled" do
+    test "returns TrueClass or FalseClass for a TINYINT value if :cast_booleans is enabled" do
       @client.query 'INSERT INTO mysql2_test (bool_cast_test) VALUES (1)'
       id1 = @client.last_id
       @client.query 'INSERT INTO mysql2_test (bool_cast_test) VALUES (0)'
@@ -182,14 +182,14 @@ describe Mysql2::Result do
       result1 = @client.query 'SELECT bool_cast_test FROM mysql2_test WHERE bool_cast_test = 1 LIMIT 1', :cast_booleans => true
       result2 = @client.query 'SELECT bool_cast_test FROM mysql2_test WHERE bool_cast_test = 0 LIMIT 1', :cast_booleans => true
       result3 = @client.query 'SELECT bool_cast_test FROM mysql2_test WHERE bool_cast_test = -1 LIMIT 1', :cast_booleans => true
-      result1.first['bool_cast_test'].should be_true
-      result2.first['bool_cast_test'].should be_false
-      result3.first['bool_cast_test'].should be_true
+      assert result1.first['bool_cast_test'] == true
+      assert result2.first['bool_cast_test'] == false
+      assert result3.first['bool_cast_test'] == true
 
       @client.query "DELETE from mysql2_test WHERE id IN(#{id1},#{id2},#{id3})"
     end
 
-    it "should return TrueClass or FalseClass for a BIT(1) value if :cast_booleans is enabled" do
+    test "returns TrueClass or FalseClass for a BIT(1) value if :cast_booleans is enabled" do
       @client.query 'INSERT INTO mysql2_test (single_bit_test) VALUES (1)'
       id1 = @client.last_id
       @client.query 'INSERT INTO mysql2_test (single_bit_test) VALUES (0)'
@@ -197,55 +197,55 @@ describe Mysql2::Result do
 
       result1 = @client.query "SELECT single_bit_test FROM mysql2_test WHERE id = #{id1}", :cast_booleans => true
       result2 = @client.query "SELECT single_bit_test FROM mysql2_test WHERE id = #{id2}", :cast_booleans => true
-      result1.first['single_bit_test'].should be_true
-      result2.first['single_bit_test'].should be_false
+      assert result1.first['single_bit_test'] == true
+      assert result2.first['single_bit_test'] == false
 
       @client.query "DELETE from mysql2_test WHERE id IN(#{id1},#{id2})"
     end
 
-    it "should return Fixnum for a SMALLINT value" do
-      [Fixnum, Bignum].should include(@test_result['small_int_test'].class)
-      @test_result['small_int_test'].should eql(10)
+    test "returns Fixnum for a SMALLINT value" do
+      assert_includes [Fixnum, Bignum], @test_result['small_int_test'].class
+      assert_equal 10, @test_result['small_int_test']
     end
 
-    it "should return Fixnum for a MEDIUMINT value" do
-      [Fixnum, Bignum].should include(@test_result['medium_int_test'].class)
-      @test_result['medium_int_test'].should eql(10)
+    test "returns Fixnum for a MEDIUMINT value" do
+      assert_includes [Fixnum, Bignum], @test_result['medium_int_test'].class
+      assert_equal 10, @test_result['medium_int_test']
     end
 
-    it "should return Fixnum for an INT value" do
-      [Fixnum, Bignum].should include(@test_result['int_test'].class)
-      @test_result['int_test'].should eql(10)
+    test "returns Fixnum for an INT value" do
+      assert_includes [Fixnum, Bignum], @test_result['int_test'].class
+      assert_equal 10, @test_result['int_test']
     end
 
-    it "should return Fixnum for a BIGINT value" do
-      [Fixnum, Bignum].should include(@test_result['big_int_test'].class)
-      @test_result['big_int_test'].should eql(10)
+    test "returns Fixnum for a BIGINT value" do
+      assert_includes [Fixnum, Bignum], @test_result['big_int_test'].class
+      assert_equal 10, @test_result['big_int_test']
     end
 
-    it "should return Fixnum for a YEAR value" do
-      [Fixnum, Bignum].should include(@test_result['year_test'].class)
-      @test_result['year_test'].should eql(2009)
+    test "returns Fixnum for a YEAR value" do
+      assert_includes [Fixnum, Bignum], @test_result['year_test'].class
+      assert_equal 2009, @test_result['year_test']
     end
 
-    it "should return BigDecimal for a DECIMAL value" do
-      @test_result['decimal_test'].class.should eql(BigDecimal)
-      @test_result['decimal_test'].should eql(10.3)
+    test "returns BigDecimal for a DECIMAL value" do
+      assert_equal BigDecimal, @test_result['decimal_test'].class
+      assert_equal 10.3, @test_result['decimal_test']
     end
 
-    it "should return Float for a FLOAT value" do
-      @test_result['float_test'].class.should eql(Float)
-      @test_result['float_test'].should eql(10.3)
+    test "returns Float for a FLOAT value" do
+      assert_equal Float, @test_result['float_test'].class
+      assert_equal 10.3, @test_result['float_test']
     end
 
-    it "should return Float for a DOUBLE value" do
-      @test_result['double_test'].class.should eql(Float)
-      @test_result['double_test'].should eql(10.3)
+    test "returns Float for a DOUBLE value" do
+      assert_equal Float, @test_result['double_test'].class
+      assert_equal 10.3,@test_result['double_test']
     end
 
-    it "should return Time for a DATETIME value when within the supported range" do
-      @test_result['date_time_test'].class.should eql(Time)
-      @test_result['date_time_test'].strftime("%Y-%m-%d %H:%M:%S").should eql('2010-04-04 11:44:00')
+    test "returns Time for a DATETIME value when within the supported range" do
+      assert_equal Time, @test_result['date_time_test'].class
+      assert_equal '2010-04-04 11:44:00', @test_result['date_time_test'].strftime("%Y-%m-%d %H:%M:%S")
     end
 
     if 1.size == 4 # 32bit
@@ -255,141 +255,141 @@ describe Mysql2::Result do
         klass = DateTime
       end
 
-      it "should return DateTime when timestamp is < 1901-12-13 20:45:52" do
+      test "returns DateTime when timestamp is < 1901-12-13 20:45:52" do
                                       # 1901-12-13T20:45:52 is the min for 32bit Ruby 1.8
         r = @client.query("SELECT CAST('1901-12-13 20:45:51' AS DATETIME) as test")
-        r.first['test'].class.should eql(klass)
+        assert_equal klass, r.first['test'].class
       end
 
-      it "should return DateTime when timestamp is > 2038-01-19T03:14:07" do
+      test "returns DateTime when timestamp is > 2038-01-19T03:14:07" do
                                       # 2038-01-19T03:14:07 is the max for 32bit Ruby 1.8
         r = @client.query("SELECT CAST('2038-01-19 03:14:08' AS DATETIME) as test")
-        r.first['test'].class.should eql(klass)
+        assert_equal klass, r.first['test'].class
       end
     elsif 1.size == 8 # 64bit
       unless RUBY_VERSION =~ /1.8/
-        it "should return Time when timestamp is < 1901-12-13 20:45:52" do
+        test "returns Time when timestamp is < 1901-12-13 20:45:52" do
           r = @client.query("SELECT CAST('1901-12-13 20:45:51' AS DATETIME) as test")
-          r.first['test'].class.should eql(Time)
+          assert_equal Time, r.first['test'].class
         end
 
-        it "should return Time when timestamp is > 2038-01-19T03:14:07" do
+        test "returns Time when timestamp is > 2038-01-19T03:14:07" do
           r = @client.query("SELECT CAST('2038-01-19 03:14:08' AS DATETIME) as test")
-          r.first['test'].class.should eql(Time)
+          assert_equal Time, r.first['test'].class
         end
       else
-        it "should return Time when timestamp is > 0138-12-31 11:59:59" do
+        test "returns Time when timestamp is > 0138-12-31 11:59:59" do
           r = @client.query("SELECT CAST('0139-1-1 00:00:00' AS DATETIME) as test")
-          r.first['test'].class.should eql(Time)
+          assert_equal Time, r.first['test'].class
         end
 
-        it "should return DateTime when timestamp is < 0139-1-1T00:00:00" do
+        test "returns DateTime when timestamp is < 0139-1-1T00:00:00" do
           r = @client.query("SELECT CAST('0138-12-31 11:59:59' AS DATETIME) as test")
-          r.first['test'].class.should eql(DateTime)
+          assert_equal DateTime, r.first['test'].class
         end
 
-        it "should return Time when timestamp is > 2038-01-19T03:14:07" do
+        test "returns Time when timestamp is > 2038-01-19T03:14:07" do
           r = @client.query("SELECT CAST('2038-01-19 03:14:08' AS DATETIME) as test")
-          r.first['test'].class.should eql(Time)
+          assert_equal Time, r.first['test'].class
         end
       end
     end
 
-    it "should return Time for a TIMESTAMP value when within the supported range" do
-      @test_result['timestamp_test'].class.should eql(Time)
-      @test_result['timestamp_test'].strftime("%Y-%m-%d %H:%M:%S").should eql('2010-04-04 11:44:00')
+    test "returns Time for a TIMESTAMP value when within the supported range" do
+      assert_equal Time, @test_result['timestamp_test'].class
+      assert_equal '2010-04-04 11:44:00', @test_result['timestamp_test'].strftime("%Y-%m-%d %H:%M:%S")
     end
 
-    it "should return Time for a TIME value" do
-      @test_result['time_test'].class.should eql(Time)
-      @test_result['time_test'].strftime("%Y-%m-%d %H:%M:%S").should eql('2000-01-01 11:44:00')
+    test "returns Time for a TIME value" do
+      assert_equal Time, @test_result['time_test'].class
+      assert_equal '2000-01-01 11:44:00', @test_result['time_test'].strftime("%Y-%m-%d %H:%M:%S")
     end
 
-    it "should return Date for a DATE value" do
-      @test_result['date_test'].class.should eql(Date)
-      @test_result['date_test'].strftime("%Y-%m-%d").should eql('2010-04-04')
+    test "returns Date for a DATE value" do
+      assert_equal Date, @test_result['date_test'].class
+      assert_equal '2010-04-04', @test_result['date_test'].strftime("%Y-%m-%d")
     end
 
-    it "should return String for an ENUM value" do
-      @test_result['enum_test'].class.should eql(String)
-      @test_result['enum_test'].should eql('val1')
+    test "returns String for an ENUM value" do
+      assert_equal String, @test_result['enum_test'].class
+      assert_equal 'val1', @test_result['enum_test']
     end
 
     if defined? Encoding
       context "string encoding for ENUM values" do
-        it "should default to the connection's encoding if Encoding.default_internal is nil" do
+        test "defaults to the connection's encoding if Encoding.default_internal is nil" do
           Encoding.default_internal = nil
           result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
-          result['enum_test'].encoding.should eql(Encoding.find('utf-8'))
+          assert_equal Encoding.find('utf-8'), result['enum_test'].encoding
 
           client2 = Mysql2::Client.new(DatabaseCredentials['root'].merge(:encoding => 'ascii'))
           client2.query "USE test"
           result = client2.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
-          result['enum_test'].encoding.should eql(Encoding.find('us-ascii'))
+          assert_equal Encoding.find('us-ascii'), result['enum_test'].encoding
           client2.close
         end
 
-        it "should use Encoding.default_internal" do
+        test "uses Encoding.default_internal" do
           Encoding.default_internal = Encoding.find('utf-8')
           result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
-          result['enum_test'].encoding.should eql(Encoding.default_internal)
+          assert_equal Encoding.default_internal, result['enum_test'].encoding
           Encoding.default_internal = Encoding.find('us-ascii')
           result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
-          result['enum_test'].encoding.should eql(Encoding.default_internal)
+          assert_equal Encoding.default_internal, result['enum_test'].encoding
         end
       end
     end
 
-    it "should return String for a SET value" do
-      @test_result['set_test'].class.should eql(String)
-      @test_result['set_test'].should eql('val1,val2')
+    test "returns String for a SET value" do
+      assert_equal String, @test_result['set_test'].class
+      assert_equal 'val1,val2', @test_result['set_test']
     end
 
     if defined? Encoding
       context "string encoding for SET values" do
-        it "should default to the connection's encoding if Encoding.default_internal is nil" do
+        test "defaults to the connection's encoding if Encoding.default_internal is nil" do
           Encoding.default_internal = nil
           result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
-          result['set_test'].encoding.should eql(Encoding.find('utf-8'))
+          assert_equal Encoding.find('utf-8'), result['set_test'].encoding
 
           client2 = Mysql2::Client.new(DatabaseCredentials['root'].merge(:encoding => 'ascii'))
           client2.query "USE test"
           result = client2.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
-          result['set_test'].encoding.should eql(Encoding.find('us-ascii'))
+          assert_equal Encoding.find('us-ascii'), result['set_test'].encoding
           client2.close
         end
 
-        it "should use Encoding.default_internal" do
+        test "uses Encoding.default_internal" do
           Encoding.default_internal = Encoding.find('utf-8')
           result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
-          result['set_test'].encoding.should eql(Encoding.default_internal)
+          assert_equal Encoding.default_internal, result['set_test'].encoding
           Encoding.default_internal = Encoding.find('us-ascii')
           result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
-          result['set_test'].encoding.should eql(Encoding.default_internal)
+          assert_equal Encoding.default_internal, result['set_test'].encoding
         end
       end
     end
 
-    it "should return String for a BINARY value" do
-      @test_result['binary_test'].class.should eql(String)
-      @test_result['binary_test'].should eql("test#{"\000"*6}")
+    test "returns String for a BINARY value" do
+      assert_equal String, @test_result['binary_test'].class
+      assert_equal "test#{"\000"*6}", @test_result['binary_test']
     end
 
     if defined? Encoding
       context "string encoding for BINARY values" do
-        it "should default to binary if Encoding.default_internal is nil" do
+        test "defaults to binary if Encoding.default_internal is nil" do
           Encoding.default_internal = nil
           result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
-          result['binary_test'].encoding.should eql(Encoding.find('binary'))
+          assert_equal Encoding.find('binary'), result['binary_test'].encoding
         end
 
-        it "should not use Encoding.default_internal" do
+        test "doesn't use Encoding.default_internal" do
           Encoding.default_internal = Encoding.find('utf-8')
           result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
-          result['binary_test'].encoding.should eql(Encoding.find('binary'))
+          assert_equal Encoding.find('binary'), result['binary_test'].encoding
           Encoding.default_internal = Encoding.find('us-ascii')
           result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
-          result['binary_test'].encoding.should eql(Encoding.find('binary'))
+          assert_equal Encoding.find('binary'), result['binary_test'].encoding
         end
       end
     end
@@ -407,48 +407,48 @@ describe Mysql2::Result do
       'long_blob_test' => 'LONGBLOB',
       'long_text_test' => 'LONGTEXT'
     }.each do |field, type|
-      it "should return a String for #{type}" do
-        @test_result[field].class.should eql(String)
-        @test_result[field].should eql("test")
+      test "returns a String for #{type}" do
+        assert_equal String, @test_result[field].class
+        assert_equal "test", @test_result[field]
       end
 
       if defined? Encoding
         context "string encoding for #{type} values" do
           if ['VARBINARY', 'TINYBLOB', 'BLOB', 'MEDIUMBLOB', 'LONGBLOB'].include?(type)
-            it "should default to binary if Encoding.default_internal is nil" do
+            test "defaults to binary if Encoding.default_internal is nil" do
               Encoding.default_internal = nil
               result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
-              result['binary_test'].encoding.should eql(Encoding.find('binary'))
+              assert_equal Encoding.find('binary'), result['binary_test'].encoding
             end
 
-            it "should not use Encoding.default_internal" do
+            test "doesn't use Encoding.default_internal" do
               Encoding.default_internal = Encoding.find('utf-8')
               result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
-              result['binary_test'].encoding.should eql(Encoding.find('binary'))
+              assert_equal Encoding.find('binary'), result['binary_test'].encoding
               Encoding.default_internal = Encoding.find('us-ascii')
               result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
-              result['binary_test'].encoding.should eql(Encoding.find('binary'))
+              assert_equal Encoding.find('binary'), result['binary_test'].encoding
             end
           else
-            it "should default to utf-8 if Encoding.default_internal is nil" do
+            test "defaults to utf-8 if Encoding.default_internal is nil" do
               Encoding.default_internal = nil
               result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
-              result[field].encoding.should eql(Encoding.find('utf-8'))
+              assert_equal Encoding.find('utf-8'), result[field].encoding
 
               client2 = Mysql2::Client.new(DatabaseCredentials['root'].merge(:encoding => 'ascii'))
               client2.query "USE test"
               result = client2.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
-              result[field].encoding.should eql(Encoding.find('us-ascii'))
+              assert_equal Encoding.find('us-ascii'), result[field].encoding
               client2.close
             end
 
-            it "should use Encoding.default_internal" do
+            test "uses Encoding.default_internal" do
               Encoding.default_internal = Encoding.find('utf-8')
               result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
-              result[field].encoding.should eql(Encoding.default_internal)
+              assert_equal Encoding.default_internal, result[field].encoding
               Encoding.default_internal = Encoding.find('us-ascii')
               result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
-              result[field].encoding.should eql(Encoding.default_internal)
+              assert_equal Encoding.default_internal, result[field].encoding
             end
           end
         end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -15,6 +15,10 @@ RSpec.configure do |config|
     end
   end
 
+  def assert_include(collection, value)
+    assert collection.include?(value), "#{value} not found in [#{collection.join(', ')}]"
+  end
+
   # makes it so we can use `test` instead of `it` when defining test cases
   config.alias_example_to :test
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,13 @@ require 'yaml'
 DatabaseCredentials = YAML.load_file('spec/configuration.yml')
 
 RSpec.configure do |config|
+  # makes it so we can use `test` instead of `it` when defining test cases
+  config.alias_example_to :test
+
+  # we're only going to use Test::Unit assertions
+  # this will also prevent the use of the rspec stuff
+  config.expect_with :stdlib
+
   config.before :each do
     @client = Mysql2::Client.new DatabaseCredentials['root']
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -7,6 +7,14 @@ require 'yaml'
 DatabaseCredentials = YAML.load_file('spec/configuration.yml')
 
 RSpec.configure do |config|
+  def assert_not_raised(err_klass)
+    begin
+      yield
+    rescue err_klass => e
+      fail_with "Expected to not raise #{err_klass}, but one was caught"
+    end
+  end
+
   # makes it so we can use `test` instead of `it` when defining test cases
   config.alias_example_to :test
 


### PR DESCRIPTION
This may seem like a useless waste of time, but the "should" syntax is deprecated anyway and I personally prefer using the assert syntax anyway. This also means it'll be a lot easier to move to minitest in the future if we want to.

Don't worry, I still love rspec's runner WAY more so we'll be sticking with it for at least a little while longer ;)

No huge rush on merging this, but it will get harder and harder to do if this branch and master get diverged too much. Especially if tests are being updated often in master.