### PR TITLE
Allow read connection defaults from custom default file and group.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,3 +12,4 @@ tmp
 vendor
 lib/mysql2/mysql2.rb
 spec/configuration.yml
+spec/my.cnf

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -284,9 +284,9 @@ static VALUE rb_connect(VALUE self, VALUE user, VALUE pass, VALUE host, VALUE po
   VALUE rv;
   GET_CLIENT(self);
 
-  args.host = NIL_P(host) ? "localhost" : StringValuePtr(host);
+  args.host = NIL_P(host) ? NULL : StringValuePtr(host);
   args.unix_socket = NIL_P(socket) ? NULL : StringValuePtr(socket);
-  args.port = NIL_P(port) ? 3306 : NUM2INT(port);
+  args.port = NIL_P(port) ? NULL : NUM2INT(port);
   args.user = NIL_P(user) ? NULL : StringValuePtr(user);
   args.passwd = NIL_P(pass) ? NULL : StringValuePtr(pass);
   args.db = NIL_P(database) ? NULL : StringValuePtr(database);
@@ -682,6 +682,7 @@ static VALUE _mysql_client_options(VALUE self, int opt, VALUE value) {
   int result;
   void *retval = NULL;
   unsigned int intval = 0;
+  const char * charval = NULL;
   my_bool boolval;
 
   GET_CLIENT(self);
@@ -720,6 +721,16 @@ static VALUE _mysql_client_options(VALUE self, int opt, VALUE value) {
     case MYSQL_SECURE_AUTH:
       boolval = (value == Qfalse ? 0 : 1);
       retval = &boolval;
+      break;
+
+    case MYSQL_READ_DEFAULT_FILE:
+      charval = (const char *)StringValuePtr(value);
+      retval  = charval;
+      break;
+
+    case MYSQL_READ_DEFAULT_GROUP:
+      charval = (const char *)StringValuePtr(value);
+      retval  = charval;
       break;
 
     default:
@@ -1098,6 +1109,14 @@ static VALUE set_secure_auth(VALUE self, VALUE value) {
   return _mysql_client_options(self, MYSQL_SECURE_AUTH, value);
 }
 
+static VALUE set_read_default_file(VALUE self, VALUE value) {
+  return _mysql_client_options(self, MYSQL_READ_DEFAULT_FILE, value);
+}
+
+static VALUE set_read_default_group(VALUE self, VALUE value) {
+  return _mysql_client_options(self, MYSQL_READ_DEFAULT_GROUP, value);
+}
+
 static VALUE initialize_ext(VALUE self) {
   GET_CLIENT(self);
 
@@ -1167,6 +1186,8 @@ void init_mysql2_client() {
   rb_define_private_method(cMysql2Client, "local_infile=", set_local_infile, 1);
   rb_define_private_method(cMysql2Client, "charset_name=", set_charset_name, 1);
   rb_define_private_method(cMysql2Client, "secure_auth=", set_secure_auth, 1);
+  rb_define_private_method(cMysql2Client, "default_file=", set_read_default_file, 1);
+  rb_define_private_method(cMysql2Client, "default_group=", set_read_default_group, 1);
   rb_define_private_method(cMysql2Client, "ssl_set", set_ssl_options, 5);
   rb_define_private_method(cMysql2Client, "initialize_ext", initialize_ext, 0);
   rb_define_private_method(cMysql2Client, "connect", rb_connect, 7);

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -10,7 +10,9 @@ module Mysql2
       :application_timezone => nil,   # timezone Mysql2 will convert to before handing the object back to the caller
       :cache_rows => true,            # tells Mysql2 to use it's internal row cache for results
       :connect_flags => REMEMBER_OPTIONS | LONG_PASSWORD | LONG_FLAG | TRANSACTIONS | PROTOCOL_41 | SECURE_CONNECTION,
-      :cast => true
+      :cast => true,
+      :default_file => nil,
+      :default_group => nil
     }
 
     def initialize(opts = {})
@@ -21,8 +23,7 @@ module Mysql2
 
       initialize_ext
 
-      # Set MySQL connection options (each one is a call to mysql_options())
-      [:reconnect, :connect_timeout, :local_infile, :read_timeout, :write_timeout, :secure_auth].each do |key|
+      [:reconnect, :connect_timeout, :local_infile, :read_timeout, :write_timeout, :default_file, :default_group, :secure_auth].each do |key|
         next unless opts.key?(key)
         case key
         when :reconnect, :local_infile, :secure_auth
@@ -49,8 +50,8 @@ module Mysql2
 
       user     = opts[:username] || opts[:user]
       pass     = opts[:password] || opts[:pass]
-      host     = opts[:host] || opts[:hostname] || 'localhost'
-      port     = opts[:port] || 3306
+      host     = opts[:host] || opts[:hostname]
+      port     = opts[:port]
       database = opts[:database] || opts[:dbname] || opts[:db]
       socket   = opts[:socket] || opts[:sock]
       flags    = opts[:flags] ? opts[:flags] | @query_options[:connect_flags] : @query_options[:connect_flags]

--- a/spec/my.cnf.example
+++ b/spec/my.cnf.example
@@ -1,0 +1,9 @@
+[root]
+host=localhost
+user=LOCALUSERNAME
+password=
+
+[client]
+host=localhost
+user=LOCALUSERNAME
+password=

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -2,6 +2,22 @@
 require 'spec_helper'
 
 describe Mysql2::Client do
+  context "using defaults file" do
+    let(:cnf_file) { File.expand_path('../../my.cnf', __FILE__) }
+
+    it "should not raise an exception for valid defaults group" do
+      lambda {
+        @client = Mysql2::Client.new(:default_file => cnf_file, :default_group => "test")
+      }.should_not raise_error(Mysql2::Error)
+    end
+
+    it "should not raise an exception without default group" do
+      lambda {
+        @client = Mysql2::Client.new(:default_file => cnf_file)
+      }.should_not raise_error(Mysql2::Error)
+    end
+  end
+
   it "should raise an exception upon connection failure" do
     lambda {
       # The odd local host IP address forces the mysql client library to

--- a/tasks/rspec.rake
+++ b/tasks/rspec.rake
@@ -40,4 +40,13 @@ file 'spec/configuration.yml' => 'spec/configuration.yml.example' do |task|
   sh "sed -i 's/LOCALUSERNAME/#{ENV['USER']}/' #{dst_path}"
 end
 
+file 'spec/my.cnf' => 'spec/my.cnf.example' do |task|
+  CLEAN.exclude task.name
+  src_path = File.expand_path("../../#{task.prerequisites.first}", __FILE__)
+  dst_path = File.expand_path("../../#{task.name}", __FILE__)
+  cp src_path, dst_path
+  sh "sed -i 's/LOCALUSERNAME/#{ENV['USER']}/' #{dst_path}"
+end
+
 Rake::Task[:spec].prerequisites << :'spec/configuration.yml'
+Rake::Task[:spec].prerequisites << :'spec/my.cnf'


### PR DESCRIPTION
For example:

``` ruby
@client = Mysql2::Client.new(:default_file => "/user/.my.cnf", :default_group => "client")
```
## CHANGES
- I removed defaults for hostname and port. According to [docs](http://dev.mysql.com/doc/refman/5.0/en/connecting.html), they are defaults in MySQL also.
## TODO
- better test suite

Originally requested in #262.
