### PR TITLE
Avoid buffer overrun

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -157,6 +157,8 @@ static VALUE mysql2_set_field_string_encoding(VALUE val, MYSQL_FIELD field, rb_e
   /* if binary flag is set, respect it's wishes */
   if (field.flags & BINARY_FLAG && field.charsetnr == 63) {
     rb_enc_associate(val, binaryEncoding);
+  } else if (!field.charsetnr) {
+    rb_enc_associate(val, binaryEncoding);
   } else {
     /* lookup the encoding configured on this field */
     const char *enc_name;


### PR DESCRIPTION
I have a very old (4.0.17) server to query and when I do so, the client dies with following situation:

```
Program received signal EXC_BAD_ACCESS, Could not access memory.
Reason: KERN_INVALID_ADDRESS at address: 0x000000090391f7f8
0x000000010391b384 in mysql2_set_field_string_encoding (val=4313498720, field={name = 0x101161b18 "data", org_name = 0x0, table = 0x101161b10 "rr", org_table = 0x101161b10 "rr", db = 0x10395b0c8 "", catalog = 0x10395b0c8 "", def = 0x0, length = 128, max_length = 11, name_length = 4, org_name_length = 0, table_length = 2, org_table_length = 2, db_length = 0, catalog_length = 0, def_length = 0, flags = 16385, decimals = 0, charsetnr = 0, type = MYSQL_TYPE_STRING, extension = 0x0}, default_internal_enc=0x0, conn_enc=0x100402a60) at result.c:165
165         enc_name = mysql2_mysql_enc_to_rb[field.charsetnr-1];
(gdb) bt
#0  0x000000010391b384 in mysql2_set_field_string_encoding (val=4313498720, field={name = 0x101161b18 "data", org_name = 0x0, table = 0x101161b10 "rr", org_table = 0x101161b10 "rr", db = 0x10395b0c8 "", catalog = 0x10395b0c8 "", def = 0x0, length = 128, max_length = 11, name_length = 4, org_name_length = 0, table_length = 2, org_table_length = 2, db_length = 0, catalog_length = 0, def_length = 0, flags = 16385, decimals = 0, charsetnr = 0, type = MYSQL_TYPE_STRING, extension = 0x0}, default_internal_enc=0x0, conn_enc=0x100402a60) at result.c:165
#1  0x000000010391bfbf in rb_mysql_result_fetch_row (self=4313499320, db_timezone=10208, app_timezone=8, symbolizeKeys=0, asArray=0, castBool=0, cast=1, fields=0x101161a10) at result.c:367
#2  0x000000010391c713 in rb_mysql_result_each (argc=0, argv=0x100500070, self=4313499320) at result.c:538
#3  0x0000000100187267 in call_cfunc_m1 ()
#4  0x000000010018801c in vm_call_cfunc_with_frame ()
#5  0x00000001001883a4 in vm_call_cfunc ()
#6  0x00000001001892f4 in vm_call_method ()
#7  0x0000000100189aef in vm_call_general ()
#8  0x000000010018e3cf in vm_exec_core ()
#9  0x000000010019f40e in vm_exec ()
#10 0x00000001001a0417 in rb_iseq_eval_main ()
#11 0x0000000100042ad7 in ruby_exec_internal ()
#12 0x0000000100042bfb in ruby_exec_node ()
#13 0x0000000100042bce in ruby_run_node ()
#14 0x0000000100000a1f in main ()
(gdb) p field
$1 = {
  name = 0x101161b18 "data", 
  org_name = 0x0, 
  table = 0x101161b10 "rr", 
  org_table = 0x101161b10 "rr", 
  db = 0x10395b0c8 "", 
  catalog = 0x10395b0c8 "", 
  def = 0x0, 
  length = 128, 
  max_length = 11, 
  name_length = 4, 
  org_name_length = 0, 
  table_length = 2, 
  org_table_length = 2, 
  db_length = 0, 
  catalog_length = 0, 
  def_length = 0, 
  flags = 16385, 
  decimals = 0, 
  charsetnr = 0, 
  type = MYSQL_TYPE_STRING, 
  extension = 0x0
}
(gdb) 
```

This patch should fix.
