### PR TITLE
Fix warning again

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -680,7 +680,7 @@ static VALUE rb_mysql_client_real_escape(VALUE self, VALUE str) {
 
 static VALUE _mysql_client_options(VALUE self, int opt, VALUE value) {
   int result;
-  void *retval = NULL;
+  const void *retval = NULL;
   unsigned int intval = 0;
   const char * charval = NULL;
   my_bool boolval;


### PR DESCRIPTION
Though my request #415 was merged (thank you cool guys!), my compiler GCC4.7 still blames me.
It seems that I missed some warnings or dark matters attacked on my machine...

I'll send PR again to wipe them out them.

I believe these changes are too small to break compatibility or logical correctness.
