### PR TITLE
Eschew use of `sed`

### DIFF
--- a/tasks/rspec.rake
+++ b/tasks/rspec.rake
@@ -36,16 +36,26 @@ file 'spec/configuration.yml' => 'spec/configuration.yml.example' do |task|
   CLEAN.exclude task.name
   src_path = File.expand_path("../../#{task.prerequisites.first}", __FILE__)
   dst_path = File.expand_path("../../#{task.name}", __FILE__)
-  cp src_path, dst_path
-  sh "sed -i 's/LOCALUSERNAME/#{ENV['USER']}/' #{dst_path}"
+
+  dst_file = File.open(dst_path, 'w')
+  File.open(src_path) do |f|
+    f.each_line do |line|
+      dst_file.write line.gsub(/LOCALUSERNAME/, ENV['USER'])
+    end
+  end
 end
 
 file 'spec/my.cnf' => 'spec/my.cnf.example' do |task|
   CLEAN.exclude task.name
   src_path = File.expand_path("../../#{task.prerequisites.first}", __FILE__)
   dst_path = File.expand_path("../../#{task.name}", __FILE__)
-  cp src_path, dst_path
-  sh "sed -i 's/LOCALUSERNAME/#{ENV['USER']}/' #{dst_path}"
+
+  dst_file = File.open(dst_path, 'w')
+  File.open(src_path) do |f|
+    f.each_line do |line|
+      dst_file.write line.gsub(/LOCALUSERNAME/, ENV['USER'])
+    end
+  end
 end
 
 Rake::Task[:spec].prerequisites << :'spec/configuration.yml'


### PR DESCRIPTION
At least on the Mac, the `sed` command silently fails, not replacing
`LOCALUSERNAME`.
There, a correct invocation is something like:

```
sh "sed -i '' -e 's/LOCALUSERNAME/#{ENV['USER']}/' #{dst_path}"
```

Rather than comprehensively account for differences in `sed` on various
platforms, use Ruby's File class to manipulate the files.
