### PR TITLE
Close MySQL connection on result GC

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -199,9 +199,7 @@ static void rb_mysql_client_free(void *ptr) {
 
   wrapper->refcount--;
   if (wrapper->refcount == 0) {
-    nogvl_close(wrapper);
-    xfree(wrapper->client);
-    xfree(wrapper);
+    close_connection_and_free_mysql2_client(wrapper);
   }
 }
 
@@ -1311,3 +1309,12 @@ void init_mysql2_client() {
       LONG2NUM(CLIENT_BASIC_FLAGS));
 #endif
 }
+
+void close_connection_and_free_mysql2_client(void *ptr) {
+  mysql_client_wrapper *wrapper = (mysql_client_wrapper *)ptr;
+
+  nogvl_close(wrapper);
+  xfree(wrapper->client);
+  xfree(wrapper);
+}
+

--- a/ext/mysql2/client.h
+++ b/ext/mysql2/client.h
@@ -37,6 +37,7 @@ rb_thread_call_without_gvl(
 #endif /* ! HAVE_RB_THREAD_CALL_WITHOUT_GVL */
 
 void init_mysql2_client();
+void close_connection_and_free_mysql2_client(void *);
 
 typedef struct {
   VALUE encoding;

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1,6 +1,7 @@
 #include <mysql2_ext.h>
 #include <stdint.h>
 
+#include "client.h"
 #include "mysql_enc_to_ruby.h"
 
 #ifdef HAVE_RUBY_ENCODING_H
@@ -86,8 +87,7 @@ static void rb_mysql_result_free(void *ptr) {
   if (wrapper->client != Qnil) {
     wrapper->client_wrapper->refcount--;
     if (wrapper->client_wrapper->refcount == 0) {
-      xfree(wrapper->client_wrapper->client);
-      xfree(wrapper->client_wrapper);
+      close_connection_and_free_mysql2_client(wrapper->client_wrapper);
     }
   }
 


### PR DESCRIPTION
Since upgrading to 0.3.13/0.2.20, we have experienced MySQL connections that are left open after Ruby is done using them and has garbage collected the object.  This change fixes this issue for us.

It appears that when the GC triggers `xfree()` on the client_wrapper in `rb_mysql_result_free()` in `result.c` it was not properly closing the MySQL connection like it does in `rb_mysql_client_free()` in `client.c` (see https://github.com/brianmario/mysql2/commit/ec9b61cbe32f53f59fe581823b7a34f34020a49a#diff-3b04aa8aa3de9a18e251b4a95981f3dfR190).

This refactor allows both garbage collection operations to call a shared method that closes and then frees the client.
