### PR TITLE
fix spec task: ensure to be normal task

### DIFF
--- a/tasks/compile.rake
+++ b/tasks/compile.rake
@@ -54,6 +54,7 @@ Rake::ExtensionTask.new("mysql2", gemspec) do |ext|
   # clean compiled extension
   CLEAN.include "#{ext.lib_dir}/*.#{RbConfig::CONFIG['DLEXT']}"
 end
+task :spec unless Rake::Task.task_defined?(:spec)
 Rake::Task[:spec].prerequisites << :compile
 
 file 'lib/mysql2/mysql2.rb' do |t|


### PR DESCRIPTION
When comlipe.rake is loaded before rspec.rake is loaded, spec task is define as file_task. On some situation 'rake spec' do not execute spec task (ex: spec dir is newer than spec/configuration.yml). Initialize spec task if comlipe.rake is loaded before.
