### PR TITLE
configuration.yml and my.cnf are written with sync mode

### DIFF
--- a/tasks/rspec.rake
+++ b/tasks/rspec.rake
@@ -38,6 +38,7 @@ file 'spec/configuration.yml' => 'spec/configuration.yml.example' do |task|
   dst_path = File.expand_path("../../#{task.name}", __FILE__)
 
   dst_file = File.open(dst_path, 'w')
+  dst_file.sync = true
   File.open(src_path) do |f|
     f.each_line do |line|
       dst_file.write line.gsub(/LOCALUSERNAME/, ENV['USER'])
@@ -51,6 +52,7 @@ file 'spec/my.cnf' => 'spec/my.cnf.example' do |task|
   dst_path = File.expand_path("../../#{task.name}", __FILE__)
 
   dst_file = File.open(dst_path, 'w')
+  dst_file.sync = true
   File.open(src_path) do |f|
     f.each_line do |line|
       dst_file.write line.gsub(/LOCALUSERNAME/, ENV['USER'])


### PR DESCRIPTION
File open with non sync mode, sometimes spec task is executed before file tasks (`configuration.yml` and `my.cnf`) are complete. If spec task is executed before, DatabaseCredentials loading `spec/configuration.yml`  to be false. So change with sync mode to ensure configuration.yml`and`my.cnf` are copyed completely.
