### PR TITLE
Result as json option.

### DIFF
--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -61,6 +61,13 @@ describe Mysql2::Result do
       end
     end
 
+    it "should be able to return results as json" do
+      @result.each(:as => :json) do |row|
+        row.class.should eql(String)
+        row.should eql("{\"1\":1}")
+      end
+    end
+
     it "should cache previously yielded results by default" do
       @result.first.object_id.should eql(@result.first.object_id)
     end


### PR DESCRIPTION
Requested in #464.

There's no C api for ruby stdlib, so I call `JSON` via `rb_funcall`.

This is very naive implementation. Any hints how to improve this are welcome!
### Ideas
- merge `asArray` and `asJson` into one option.
