### PR TITLE
Use rb_str_conv_enc_opts to transcode error strings in MySQL < 5.5

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -128,7 +128,7 @@ static VALUE rb_raise_mysql2_error(mysql_client_wrapper *wrapper) {
 #ifdef HAVE_RUBY_ENCODING_H
   rb_encoding *conn_enc = rb_to_encoding(wrapper->encoding);
   rb_encoding *default_internal_enc = rb_default_internal_encoding();
-  rb_encoding *dest_enc = default_internal_enc ? default_internal_enc : rb_utf8_encoding();
+  rb_encoding *dest_enc = default_internal_enc ? default_internal_enc : conn_enc;
 
   rb_enc_associate(rb_error_msg, conn_enc);
   rb_enc_associate(rb_sql_state, conn_enc);

--- a/spec/mysql2/error_spec.rb
+++ b/spec/mysql2/error_spec.rb
@@ -67,6 +67,7 @@ describe Mysql2::Error do
     it_behaves_like "mysql2 error encoding", nil   , nil               , Encoding::UTF_8   , %r/near '\xE9\x80\xA0\xE5\xAD\x97'/n
     it_behaves_like "mysql2 error encoding", 'utf8', Encoding::UTF_8   , Encoding::UTF_8   , %r/near '\xE9\x80\xA0\xE5\xAD\x97'/n
     it_behaves_like "mysql2 error encoding", 'big5', Encoding::Big5    , Encoding::Big5    , %r/near '\xB3\x79\xA6\x72'/n
-    it_behaves_like "mysql2 error encoding", 'big5', Encoding::US_ASCII, Encoding::US_ASCII, %r/near '??'/n
+    # FIXME it_behaves_like "mysql2 error encoding", 'latin1', Encoding::ISO_8859_1, Encoding::ISO_8859_1, %r/near '\?\?'/n
+    it_behaves_like "mysql2 error encoding", 'big5', Encoding::US_ASCII, Encoding::US_ASCII, %r/near '\?\?'/n
   end
 end


### PR DESCRIPTION
This resolves the problem in https://github.com/pwnall/rails5738 but does not pass our own specs on MySQL 5.1, as it appears to be allowing invalid UTF-8 characters through (in the case of our tests, there is a Big5-encoded Chinese character U+9020 which is not valid UTF-8 – I'm using this to test whether the transcoding is thorough).

The transcoding function calls are now:

``` C
   rb_encoding *err_enc = rb_ascii8bit_encoding();
   rb_error_msg = rb_str_conv_enc_opts(rb_error_msg, err_enc, conn_enc, ECONV_UNDEF_REPLACE | ECONV_INVALID_REPLACE, Qnil);
   rb_sql_state = rb_str_conv_enc_opts(rb_sql_state, err_enc, conn_enc, ECONV_UNDEF_REPLACE | ECONV_INVALID_REPLACE, Qnil);
```
