### PR TITLE
Refactor branching to assignment

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -431,7 +431,7 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
   mysql2_result_wrapper * wrapper;
   unsigned long i;
   const char * errstr;
-  int symbolizeKeys = 0, asArray = 0, castBool = 0, cacheRows = 1, cast = 1, streaming = 0;
+  int symbolizeKeys, asArray, castBool, cacheRows, cast, streaming;
   MYSQL_FIELD * fields = NULL;
 
   GetMysql2Result(self, wrapper);
@@ -444,29 +444,12 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
     opts = defaults;
   }
 
-  if (rb_hash_aref(opts, sym_symbolize_keys) == Qtrue) {
-    symbolizeKeys = 1;
-  }
-
-  if (rb_hash_aref(opts, sym_as) == sym_array) {
-    asArray = 1;
-  }
-
-  if (rb_hash_aref(opts, sym_cast_booleans) == Qtrue) {
-    castBool = 1;
-  }
-
-  if (rb_hash_aref(opts, sym_cache_rows) == Qfalse) {
-    cacheRows = 0;
-  }
-
-  if (rb_hash_aref(opts, sym_cast) == Qfalse) {
-    cast = 0;
-  }
-
-  if(rb_hash_aref(opts, sym_stream) == Qtrue) {
-    streaming = 1;
-  }
+  symbolizeKeys = RTEST(rb_hash_aref(opts, sym_symbolize_keys));
+  asArray = rb_hash_aref(opts, sym_as) == sym_array;
+  castBool = RTEST(rb_hash_aref(opts, sym_cast_booleans));
+  cacheRows = RTEST(rb_hash_aref(opts, sym_cache_rows));
+  cast = RTEST(rb_hash_aref(opts, sym_cast));
+  streaming = RTEST(rb_hash_aref(opts, sym_stream));
 
   if(streaming && cacheRows) {
     rb_warn("cacheRows is ignored if streaming is true");


### PR DESCRIPTION
Currently, the function `rb_mysql_result_each` in `result.c` sets some default values on C vars and change those values depending on the `options` ruby hash.

This PR removes the default C values and the branching with some simple assignments. This works because:

- The C vars default value are kept in sync with the `@query_options` ruby hash, and that hash is merged with the supplied options, so the merged hash has the same values than the default C ones, unless they are overriden.
- The code doesn't check for the actual values of the variables (1 or 0). It only bothers about their truthiness.

This improves a couple of minor things in my opinion:
- Changing an existing default value will only require changes in the ruby `@@default_query_options` attribute
- It removes N branches(one for each option). While this wont improve performance, it improves the readability a little bit.