### PR TITLE
Avoid dynamically-sized stack allocation

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -122,16 +122,12 @@ static VALUE rb_mysql_result_fetch_field(VALUE self, unsigned int idx, short int
 
     field = mysql_fetch_field_direct(wrapper->result, idx);
     if (symbolize_keys) {
-      char buf[field->name_length+1];
-      memcpy(buf, field->name, field->name_length);
-      buf[field->name_length] = 0;
-
 #ifdef HAVE_RB_INTERN3
-      rb_field = rb_intern3(buf, field->name_length, rb_utf8_encoding());
+      rb_field = rb_intern3(field->name, field->name_length, rb_utf8_encoding());
       rb_field = ID2SYM(rb_field);
 #else
       VALUE colStr;
-      colStr = rb_str_new2(buf);
+      colStr = rb_str_new(field->name, field->name_length);
       rb_field = ID2SYM(rb_to_id(colStr));
 #endif
     } else {


### PR DESCRIPTION
Otherwise, long field names have the potential to cause stack overflow and perhaps slow down the MRI GC.  This reduces one extraneous data copy while we're at it, too.

Using the `checkstack.pl` script in the Linux kernel reveals no other dynamically sized stack allcations after this change.

`usage: objdump -d mysql2.so | ~/linux/scripts/checkstack.pl x86_64`

Just got this patch from Eric Wong, opening a pull for visibility across the maintainers. Patch looks good, though I feel sheepish for not noticing and fixing this before :sheep: 
