### PR TITLE
RuntimeError "invalid binding to detach" in EM::Client::close

### DIFF
--- a/lib/mysql2/em.rb
+++ b/lib/mysql2/em.rb
@@ -30,7 +30,7 @@ module Mysql2
 
       def close(*args)
         if @watch
-          @watch.detach
+          @watch.detach rescue RuntimeError
         end
         super(*args)
       end


### PR DESCRIPTION
Error happens when you close EM::Client with no query running.

```
RuntimeError invalid binding to detach
.../ruby-2.0.0-p353/gems/eventmachine-1.0.3/lib/em/connection.rb:272:in `detach_fd'
.../ruby-2.0.0-p353/gems/eventmachine-1.0.3/lib/em/connection.rb:272:in `detach'
.../ruby-2.0.0-p353/gems/mysql2-0.3.14/lib/mysql2/em.rb:29:in `close'
```
