### PR TITLE
After closing the MySQL fd, set it to -1 to prevent a race condition

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -177,6 +177,7 @@ static void *nogvl_close(void *ptr) {
      * share this object across a fork().
      */
     close(wrapper->client->net.fd);
+    wrapper->client->net.fd = -1;
 #endif
 
     mysql_close(wrapper->client);


### PR DESCRIPTION
This updates a2bcfd6 / #213 / #463.

The MySQL library also calls close() on the fd, so it is possible for another
thread to have a new use for the same fd value. By setting the fd to -1, the
second close() will return EBADF without the risk of closing the wrong file.
