### PR TITLE
Separate out connect options from query options

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -639,8 +639,8 @@ static VALUE rb_mysql_client_abandon_results(VALUE self) {
 /* call-seq:
  *    client.query(sql, options = {})
  *
- * Query the database with +sql+, with optional +options+.  For the possible
- * options, see @@default_query_options on the Mysql2::Client class.
+ * Query the database with +sql+, with optional +options+.
+ * For available options, see VALID_QUERY_KEYS in the Mysql2::Client class.
  */
 static VALUE rb_query(VALUE self, VALUE sql, VALUE current) {
 #ifndef _WIN32

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -3,29 +3,13 @@ module Mysql2
     attr_reader :connect_options, :query_options, :read_timeout
 
     VALID_CONNECT_KEYS = [:connect_flags, :connect_timeout, :encoding, :default_file, :default_group, :read_timeout, :write_timeout, :secure_auth, :init_command, :reconnect, :local_infile]
-    @@default_connect_options = {
-      :connect_flags   => REMEMBER_OPTIONS | LONG_PASSWORD | LONG_FLAG | TRANSACTIONS | PROTOCOL_41 | SECURE_CONNECTION,
-      :connect_timeout => 120,        # Set default connect_timeout to avoid unlimited retries from signal interruption
-      :encoding        => 'utf8'
-    }
-
     VALID_QUERY_KEYS = [:as, :async, :cast_booleans, :symbolize_keys, :database_timezone, :application_timezone, :cache_rows, :cast]
-    @@default_query_options = {
-      :as                   => :hash,  # the type of object you want each row back as; also supports :array (an array of values)
-      :async                => false,  # don't wait for a result after sending the query, you'll have to monitor the socket yourself then eventually call Mysql2::Client#async_result
-      :cast_booleans        => false,  # cast tinyint(1) fields as true/false in ruby
-      :symbolize_keys       => false,  # return field names as symbols instead of strings
-      :database_timezone    => :local, # timezone Mysql2 will assume datetime objects are stored in
-      :application_timezone => nil,    # timezone Mysql2 will convert to before handing the object back to the caller
-      :cache_rows           => true,   # tells Mysql2 to use it's internal row cache for results
-      :cast                 => true    # cast result fields to corresponding Ruby data types
-    }
 
     def initialize(opts = {})
       opts = Mysql2::Util.key_hash_as_symbols(opts)
       @read_timeout = nil # by default don't timeout on read
-      @connect_options = @@default_connect_options.merge Hash[ opts.select { |k, v| VALID_CONNECT_KEYS.include? k } ]
-      @query_options = @@default_query_options.merge Hash[ opts.select { |k, v| VALID_QUERY_KEYS.include? k } ]
+      @connect_options = self.class.default_connect_options.merge Hash[ opts.select { |k, v| VALID_CONNECT_KEYS.include? k } ]
+      @query_options = self.class.default_query_options.merge Hash[ opts.select { |k, v| VALID_QUERY_KEYS.include? k } ]
 
       initialize_ext
 
@@ -68,11 +52,24 @@ DEPR
     end
 
     def self.default_connect_options
-      @@default_connect_options
+      @default_connect_options ||= {
+        :connect_flags   => REMEMBER_OPTIONS | LONG_PASSWORD | LONG_FLAG | TRANSACTIONS | PROTOCOL_41 | SECURE_CONNECTION,
+        :connect_timeout => 120,         # Set default connect_timeout to avoid unlimited retries from signal interruption
+        :encoding        => 'utf8',
+      }
     end
 
     def self.default_query_options
-      @@default_query_options
+      @default_query_options ||= {
+        :as                   => :hash,  # the type of object you want each row back as; also supports :array (an array of values)
+        :async                => false,  # don't wait for a result after sending the query, you'll have to monitor the socket yourself then eventually call Mysql2::Client#async_result
+        :cast_booleans        => false,  # cast tinyint(1) fields as true/false in ruby
+        :symbolize_keys       => false,  # return field names as symbols instead of strings
+        :database_timezone    => :local, # timezone Mysql2 will assume datetime objects are stored in
+        :application_timezone => nil,    # timezone Mysql2 will convert to before handing the object back to the caller
+        :cache_rows           => true,   # tells Mysql2 to use it's internal row cache for results
+        :cast                 => true,   # cast result fields to corresponding Ruby data types
+      }
     end
 
     if Thread.respond_to?(:handle_interrupt)


### PR DESCRIPTION
An idea to resolve the confusing situation seen in #493 and a few previous tickets.

First pass code has the bad effect of overriding the user's settings with defaults if the user changes the class hash values in `@@default_query_options` before connecting, but has not updated to know about `@@default_connect_options` introduced here.

Retains the bad situation of having both sets of options in the `@query_options` hash from there on out.

Needs some more thinking, putting this out for comment and ideas.
