### PR TITLE
state the name of the field that contains a bad datetime

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -325,7 +325,7 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, ID db_timezone, ID app_timezo
             val = Qnil;
           } else {
             if (month < 1 || day < 1) {
-              rb_raise(cMysql2Error, "Invalid date: %s", row[i]);
+              rb_raise(cMysql2Error, "Invalid date in field '%.*s': %s", fields[i].name_length, fields[i].name, row[i]);
               val = Qnil;
             } else {
               if (seconds < MYSQL2_MIN_TIME || seconds > MYSQL2_MAX_TIME) { /* use DateTime for larger date range, does not support microseconds */
@@ -370,7 +370,7 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, ID db_timezone, ID app_timezo
             val = Qnil;
           } else {
             if (month < 1 || day < 1) {
-              rb_raise(cMysql2Error, "Invalid date: %s", row[i]);
+              rb_raise(cMysql2Error, "Invalid date in field '%.*s': %s", fields[i].name_length, fields[i].name, row[i]);
               val = Qnil;
             } else {
               val = rb_funcall(cDate, intern_new, 3, UINT2NUM(year), UINT2NUM(month), UINT2NUM(day));

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -335,6 +335,16 @@ describe Mysql2::Result do
       @test_result['enum_test'].should eql('val1')
     end
 
+    it "should raise an error given an invalid DATETIME" do
+      begin
+        @client.query("SELECT CAST('1972-00-27 00:00:00' AS DATETIME) as bad_datetime").each
+      rescue Mysql2::Error => e
+        error = e
+      end
+
+      error.message.should eql("Invalid date in field 'bad_datetime': 1972-00-27 00:00:00")
+    end
+
     if defined? Encoding
       context "string encoding for ENUM values" do
         it "should default to the connection's encoding if Encoding.default_internal is nil" do


### PR DESCRIPTION
To make it easier to tell where bad data is coming from.

Is `fields[i].name` null terminated or do we need to do something special to make it correct? I don't remember how C works.

cc @brianmario @tnm @ymendel
