### PR TITLE
Added call to mysql_library_init during initialization of the gem

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1235,6 +1235,13 @@ void init_mysql2_client() {
     }
   }
 
+  /* Initializing mysql library, so different threads could call Client.new */
+  /* without race condition in the library */
+  if (mysql_library_init(0, NULL, NULL) != 0) {
+    rb_raise(rb_eRuntimeError, "Could not initialize MySQL client library");
+    return;
+  }
+
 #if 0
   mMysql2      = rb_define_module("Mysql2"); Teach RDoc about Mysql2 constant.
 #endif


### PR DESCRIPTION
This call must be performed before trying to call mysql_init from multiple threads
Reference: http://dev.mysql.com/doc/refman/5.1/en/mysql-init.html
Minimal reproduction of the problem if mysql_library_init is not called
(username and password omitted)

```
require 'mysql2'

def connect
  Mysql2::Client.new()
end

threads = [0,1].map {
  Thread.new { connect }
}
threads.map(&:join)
puts "OK!"
```

The above code fails on version of the gem with error:
/home/michael/.rvm/gems/ruby-1.9.3-p484/gems/mysql2-0.3.16/lib/mysql2/client.rb:70:in `connect': Lost connection to MySQL server at 'reading initial communication packet', system error: 111 (Mysql2::Error)

After the fix, prints OK.
