### PR TITLE
Add failing timeout spec

### DIFF
--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -474,6 +474,20 @@ describe Mysql2::Client do
         }.should_not raise_error(Mysql2::Error)
       end
 
+      it "should handle Timeouts with default exception without leaving the connection hanging if reconnect is true" do
+        client = Mysql2::Client.new(DatabaseCredentials['root'].merge(:reconnect => true))
+        begin
+          Timeout.timeout(1) do
+            client.query("SELECT sleep(2)")
+          end
+        rescue Timeout::Error
+        end
+
+        lambda {
+          client.query("SELECT 1")
+        }.should_not raise_error(Mysql2::Error)
+      end
+
       it "should handle Timeouts without leaving the connection hanging if reconnect is set to true after construction true" do
         client = Mysql2::Client.new(DatabaseCredentials['root'])
         begin


### PR DESCRIPTION
For https://github.com/brianmario/mysql2/issues/532, this reproduces the issue, when the class of the exception to be raised is not passed to Timeout.timeout, then the mysql connection becomes unusable.
