### PR TITLE
change sql_state to attr_reader to avoid ruby warning

### DIFF
--- a/lib/mysql2/error.rb
+++ b/lib/mysql2/error.rb
@@ -5,7 +5,8 @@ module Mysql2
     REPLACEMENT_CHAR = '?'
     ENCODE_OPTS      = {:undef => :replace, :invalid => :replace, :replace => REPLACEMENT_CHAR}
 
-    attr_accessor :error_number, :sql_state
+    attr_accessor :error_number
+    attr_reader   :sql_state
     attr_writer   :server_version
 
     # Mysql gem compatibility
@@ -18,10 +19,8 @@ module Mysql2
       super(clean_message(msg))
     end
 
-    if "".respond_to? :encode
-      def sql_state=(state)
-        @sql_state = state.encode(ENCODE_OPTS)
-      end
+    def sql_state=(state)
+      @sql_state = ''.respond_to?(:encode) ? state.encode(ENCODE_OPTS) : state
     end
 
     private


### PR DESCRIPTION
this patch will remove this warning 

```
mysql2-0.3.16/lib/mysql2/error.rb:22: warning: method redefined; discarding old sql_state=
```
