### PR TITLE
Move error_number and sql_state into Mysql2::Error initializer

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -124,9 +124,11 @@ static VALUE rb_raise_mysql2_error(mysql_client_wrapper *wrapper) {
   rb_enc_associate(rb_sql_state, rb_usascii_encoding());
 #endif
 
-  e = rb_funcall(cMysql2Error, intern_new, 2, rb_error_msg, LONG2FIX(wrapper->server_version));
-  rb_funcall(e, intern_error_number_eql, 1, UINT2NUM(mysql_errno(wrapper->client)));
-  rb_funcall(e, intern_sql_state_eql, 1, rb_sql_state);
+  e = rb_funcall(cMysql2Error, intern_new, 4,
+                 rb_error_msg,
+                 LONG2FIX(wrapper->server_version),
+                 UINT2NUM(mysql_errno(wrapper->client)),
+                 rb_sql_state);
   rb_exc_raise(e);
   return Qnil;
 }

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -17,8 +17,7 @@
 VALUE cMysql2Client;
 extern VALUE mMysql2, cMysql2Error;
 static VALUE sym_id, sym_version, sym_header_version, sym_async, sym_symbolize_keys, sym_as, sym_array, sym_stream;
-static ID intern_merge, intern_merge_bang, intern_error_number_eql, intern_sql_state_eql;
-static ID intern_brackets, intern_new;
+static ID intern_brackets, intern_new, intern_merge, intern_merge_bang, intern_new_with_args;
 
 #ifndef HAVE_RB_HASH_DUP
 VALUE rb_hash_dup(VALUE other) {
@@ -124,7 +123,7 @@ static VALUE rb_raise_mysql2_error(mysql_client_wrapper *wrapper) {
   rb_enc_associate(rb_sql_state, rb_usascii_encoding());
 #endif
 
-  e = rb_funcall(cMysql2Error, intern_new, 4,
+  e = rb_funcall(cMysql2Error, intern_new_with_args, 4,
                  rb_error_msg,
                  LONG2FIX(wrapper->server_version),
                  UINT2NUM(mysql_errno(wrapper->client)),
@@ -1303,8 +1302,7 @@ void init_mysql2_client() {
   intern_new = rb_intern("new");
   intern_merge = rb_intern("merge");
   intern_merge_bang = rb_intern("merge!");
-  intern_error_number_eql = rb_intern("error_number=");
-  intern_sql_state_eql = rb_intern("sql_state=");
+  intern_new_with_args = rb_intern("new_with_args");
 
 #ifdef CLIENT_LONG_PASSWORD
   rb_const_set(cMysql2Client, rb_intern("LONG_PASSWORD"),

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -357,11 +357,7 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
   }
 
   if (mysql_stmt_bind_result(wrapper->stmt_wrapper->stmt, wrapper->result_buffers)) {
-    rb_raise_mysql2_stmt_error2(wrapper->stmt_wrapper->stmt
-#ifdef HAVE_RUBY_ENCODING_H
-      , conn_enc
-#endif
-      );
+    rb_raise_mysql2_stmt_error(wrapper->stmt_wrapper);
   }
 
   {
@@ -372,11 +368,7 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
 
       case 1:
         /* error */
-        rb_raise_mysql2_stmt_error2(wrapper->stmt_wrapper->stmt
-#ifdef HAVE_RUBY_ENCODING_H
-          , conn_enc
-#endif
-          );
+        rb_raise_mysql2_stmt_error(wrapper->stmt_wrapper);
 
       case MYSQL_NO_DATA:
         /* no more row */

--- a/ext/mysql2/statement.h
+++ b/ext/mysql2/statement.h
@@ -13,10 +13,6 @@ void init_mysql2_statement();
 void decr_mysql2_stmt(mysql_stmt_wrapper *stmt_wrapper);
 
 VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql);
-VALUE rb_raise_mysql2_stmt_error2(MYSQL_STMT *stmt
-#ifdef HAVE_RUBY_ENCODING_H
-  , rb_encoding* conn_enc
-#endif
-  );
+void rb_raise_mysql2_stmt_error(mysql_stmt_wrapper *stmt_wrapper);
 
 #endif

--- a/lib/mysql2/error.rb
+++ b/lib/mysql2/error.rb
@@ -9,18 +9,24 @@ module Mysql2
     }.freeze
 
     attr_reader :error_number, :sql_state
-    attr_writer :server_version
 
     # Mysql gem compatibility
     alias_method :errno, :error_number
     alias_method :error, :message
 
-    def initialize(msg, server_version=nil, error_number=nil, sql_state=nil)
-      self.server_version = server_version
-      self.error_number = error_number
-      self.sql_state = sql_state.respond_to?(:encode) ? sql_state.encode(ENCODE_OPTS) : sql_state
+    def initialize(msg)
+      @server_version ||= nil
 
       super(clean_message(msg))
+    end
+
+    def self.new_with_args(msg, server_version, error_number, sql_state)
+      err = allocate
+      err.instance_variable_set('@server_version', server_version)
+      err.instance_variable_set('@error_number', error_number)
+      err.instance_variable_set('@sql_state', sql_state.respond_to?(:encode) ? sql_state.encode(ENCODE_OPTS) : sql_state)
+      err.send(:initialize, msg)
+      err
     end
 
     private

--- a/lib/mysql2/error.rb
+++ b/lib/mysql2/error.rb
@@ -8,22 +8,19 @@ module Mysql2
       :replace => '?'.freeze,
     }.freeze
 
-    attr_accessor :error_number
-    attr_reader :sql_state
+    attr_reader :error_number, :sql_state
     attr_writer :server_version
 
     # Mysql gem compatibility
     alias_method :errno, :error_number
     alias_method :error, :message
 
-    def initialize(msg, server_version = nil)
+    def initialize(msg, server_version=nil, error_number=nil, sql_state=nil)
       self.server_version = server_version
+      self.error_number = error_number
+      self.sql_state = sql_state.respond_to?(:encode) ? sql_state.encode(ENCODE_OPTS) : sql_state
 
       super(clean_message(msg))
-    end
-
-    def sql_state=(state)
-      @sql_state = state.respond_to?(:encode) ? state.encode(ENCODE_OPTS) : state
     end
 
     private


### PR DESCRIPTION
An alternative to #544, make all of the needed parameters into the initialize method.