### PR TITLE
Add MySQL 5.7 test to CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,12 @@ script:
 before_install:
   - gem --version
   - |
+    bash -c " # Install MySQL 5.7 if DB=mysql57
+    if [[ x$DB =~ mysql57 ]]; then
+      bash .travis_mysql57.sh
+    fi
+    "
+  - |
     bash -c " # Install MariaDB if DB=mariadb
     if [[ x$DB =~ xmariadb ]]; then
       sudo bash .travis_mariadb.sh '$DB'
@@ -34,12 +40,15 @@ rvm:
   - ree
 matrix:
   allow_failures:
+    - env: DB=mysql57
     - rvm: rbx-2
   include:
     - rvm: 2.0.0
       env: DB=mariadb55
     - rvm: 2.0.0
       env: DB=mariadb10
+    - rvm: 2.0.0
+      env: DB=mysql57
     - rvm: rbx-2
       env: RBXOPT=-Xgc.honor_start=true
     - rvm: 2.0.0

--- a/.travis_mysql57.sh
+++ b/.travis_mysql57.sh
@@ -1,0 +1,10 @@
+sudo apt-get remove --purge "^mysql.*"
+sudo apt-get autoremove
+sudo apt-get autoclean
+sudo rm -rf /var/lib/mysql
+sudo rm -rf /var/log/mysql
+echo mysql-apt-config mysql-apt-config/enable-repo select mysql-5.7-dmr | sudo debconf-set-selections
+wget http://dev.mysql.com/get/mysql-apt-config_0.2.1-1ubuntu12.04_all.deb
+sudo dpkg --install mysql-apt-config_0.2.1-1ubuntu12.04_all.deb
+sudo apt-get update -q
+sudo apt-get install -q -y -o Dpkg::Options::="--force-confdef" -o Dpkg::Options::="--force-confold" mysql-server ruby libmysqlclient-dev


### PR DESCRIPTION
preview: https://travis-ci.org/zizkovrb/mysql2/builds/38104527
based on: http://unix.stackexchange.com/questions/158052/how-to-configure-the-mysql-apt-repo-on-ubuntu-on-a-non-interactive-shell

related to https://github.com/brianmario/mysql2/issues/548#issuecomment-59258039
