### PR TITLE
Add Ruby 2.2 on Travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -34,10 +34,10 @@ os:
   - linux
 rvm:
   - 1.8.7
-  - 1.9.2
   - 1.9.3
   - 2.0.0
-  - 2.1.4
+  - 2.1
+  - 2.2
   - ree
 matrix:
   allow_failures:


### PR DESCRIPTION
Blocked on an eventmachine 1.0.4 / 1.1.0 release. Support for Ruby 2.2 is already in eventmachine master.
