### PR TITLE
Only invoke vendor:mysql while cross-compiling for Windows

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
   - gem --version
   - gem install bundler --quiet --no-ri --no-rdoc
   - bundler --version
-  - bundle install --without benchmarks
+  - bundle install --without benchmarks --path vendor/bundle
 build_script:
   - bundle exec rake compile
 test_script:
@@ -31,13 +31,5 @@ environment:
     - ruby_version: "21-x64"
 cache:
   - vendor
-  - C:\Ruby200\lib\ruby\gems\2.0.0
-  - C:\Ruby200\bin
-  - C:\Ruby200-x64\lib\ruby\gems\2.0.0
-  - C:\Ruby200-x64\bin
-  - C:\Ruby21\lib\ruby\gems\2.1.0
-  - C:\Ruby21\bin
-  - C:\Ruby21-x64\lib\ruby\gems\2.1.0
-  - C:\Ruby21-x64\bin
 services:
   - mysql

--- a/tasks/vendor_mysql.rake
+++ b/tasks/vendor_mysql.rake
@@ -21,6 +21,12 @@ def vendor_mysql_url(*args)
 end
 
 # vendor:mysql
+task "vendor:mysql:cross" do |t|
+  # When cross-compiling, grab both 32 and 64 bit connectors
+  Rake::Task['vendor:mysql'].invoke('x86')
+  Rake::Task['vendor:mysql'].invoke('x64')
+end
+
 task "vendor:mysql", [:platform] do |t, args|
   puts "vendor:mysql for #{vendor_mysql_dir(args[:platform])}"
 


### PR DESCRIPTION
Correct a mistake in #473, `vendor:mysql` is getting called and downloading Connector/C-{win32, -winx64}  on non-Windows platforms.