### PR TITLE
Reimplement #509, add self-explaining specs

### DIFF
--- a/lib/mysql2/em.rb
+++ b/lib/mysql2/em.rb
@@ -10,6 +10,7 @@ module Mysql2
         def initialize(client, deferable)
           @client = client
           @deferable = deferable
+          @is_watching = true
         end
 
         def notify_readable
@@ -22,11 +23,19 @@ module Mysql2
             @deferable.succeed(result)
           end
         end
+
+        def watching?
+          @is_watching
+        end
+
+        def unbind
+          @is_watching = false
+        end
       end
 
       def close(*args)
         if @watch
-          @watch.detach
+          @watch.detach if @watch.watching?
         end
         super(*args)
       end

--- a/spec/em/em_spec.rb
+++ b/spec/em/em_spec.rb
@@ -108,6 +108,27 @@ begin
         callbacks_run.should == [:errback]
       end
     end
+
+    it "should not raise error when closing client with no query running" do
+      callbacks_run = []
+      EM.run do
+        client = Mysql2::EM::Client.new DatabaseCredentials['root']
+        defer = client.query("select sleep(0.025)")
+        defer.callback do |result|
+          callbacks_run << :callback
+        end
+        defer.errback do |err|
+          callbacks_run << :errback
+        end
+        EM.add_timer(0.1) do
+          lambda {
+            client.close
+          }.should_not raise_error(/invalid binding to detach/)
+          EM.stop_event_loop
+        end
+      end
+      callbacks_run.should == [:callback]
+    end
   end
 rescue LoadError
   puts "EventMachine not installed, skipping the specs that use it"

--- a/spec/em/em_spec.rb
+++ b/spec/em/em_spec.rb
@@ -121,13 +121,13 @@ begin
           callbacks_run << :errback
         end
         EM.add_timer(0.1) do
+          callbacks_run.should == [:callback]
           lambda {
             client.close
           }.should_not raise_error(/invalid binding to detach/)
           EM.stop_event_loop
         end
       end
-      callbacks_run.should == [:callback]
     end
   end
 rescue LoadError


### PR DESCRIPTION
Related  to #489 and #509 

I reproduced the problem and added specs. It reproduces when trying to close a connection *outside* of deferred callbacks.

I also found similar workaround in ruby-em-pg-client: https://github.com/royaltm/ruby-em-pg-client/blob/v0.3.4/lib/pg/em.rb#L500 - It also detaches a watch only if it can.