### PR TITLE
Tests for streaming and stored procedures with multiple result sets

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -595,13 +595,16 @@ static VALUE rb_mysql_result_count(VALUE self) {
 
   GetMysql2Result(self, wrapper);
   if (wrapper->is_streaming) {
-    return LONG2NUM(wrapper->numberOfRows);
+    /* This is an unsigned long per result.h */
+    return ULONG2NUM(wrapper->numberOfRows);
   }
 
   if (wrapper->resultFreed) {
+    /* Ruby arrays have platform signed long length */
     return LONG2NUM(RARRAY_LEN(wrapper->rows));
   } else {
-    return INT2FIX(mysql_num_rows(wrapper->result));
+    /* MySQL returns an unsigned 64-bit long here */
+    return ULL2NUM(mysql_num_rows(wrapper->result));
   }
 }
 

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -446,7 +446,7 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
   mysql2_result_wrapper * wrapper;
   unsigned long i;
   const char * errstr;
-  int symbolizeKeys = 0, asArray = 0, castBool = 0, cacheRows = 1, cast = 1;
+  int symbolizeKeys, asArray, castBool, cacheRows, cast;
   MYSQL_FIELD * fields = NULL;
 
   GetMysql2Result(self, wrapper);
@@ -459,25 +459,11 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
     opts = defaults;
   }
 
-  if (rb_hash_aref(opts, sym_symbolize_keys) == Qtrue) {
-    symbolizeKeys = 1;
-  }
-
-  if (rb_hash_aref(opts, sym_as) == sym_array) {
-    asArray = 1;
-  }
-
-  if (rb_hash_aref(opts, sym_cast_booleans) == Qtrue) {
-    castBool = 1;
-  }
-
-  if (rb_hash_aref(opts, sym_cache_rows) == Qfalse) {
-    cacheRows = 0;
-  }
-
-  if (rb_hash_aref(opts, sym_cast) == Qfalse) {
-    cast = 0;
-  }
+  symbolizeKeys = RTEST(rb_hash_aref(opts, sym_symbolize_keys));
+  asArray       = rb_hash_aref(opts, sym_as) == sym_array;
+  castBool      = RTEST(rb_hash_aref(opts, sym_cast_booleans));
+  cacheRows     = RTEST(rb_hash_aref(opts, sym_cache_rows));
+  cast          = RTEST(rb_hash_aref(opts, sym_cast));
 
   if (wrapper->is_streaming && cacheRows) {
     rb_warn("cacheRows is ignored if streaming is true");

--- a/ext/mysql2/result.h
+++ b/ext/mysql2/result.h
@@ -12,6 +12,7 @@ typedef struct {
   unsigned int numberOfFields;
   unsigned long numberOfRows;
   unsigned long lastRowProcessed;
+  char is_streaming;
   char streamingComplete;
   char resultFreed;
   MYSQL_RES *result;

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -614,6 +614,21 @@ describe Mysql2::Client do
 
         @multi_client.more_results?.should be_false
       end
+
+      it "#more_results? should work with stored procedures" do
+        @multi_client.query("DROP PROCEDURE IF EXISTS test_proc")
+        @multi_client.query("CREATE PROCEDURE test_proc() BEGIN SELECT 1 AS 'set_1'; SELECT 2 AS 'set_2'; END")
+        @multi_client.query("CALL test_proc()").first.should eql({ 'set_1' => 1 })
+        @multi_client.more_results?.should be_true
+
+        @multi_client.next_result
+        @multi_client.store_result.first.should eql({ 'set_2' => 2 })
+
+        @multi_client.next_result
+        @multi_client.store_result.should be_nil # this is the result from CALL itself
+
+        @multi_client.more_results?.should be_false
+      end
     end
   end
 

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -107,18 +107,19 @@ describe Mysql2::Result do
 
   context "streaming" do
     it "should maintain a count while streaming" do
-      result = @client.query('SELECT 1')
-
-      result.count.should eql(1)
+      result = @client.query('SELECT 1', :stream => true, :cache_rows => false)
+      result.count.should eql(0)
       result.each.to_a
       result.count.should eql(1)
     end
 
-    it "should set the actual count of rows after streaming" do
-      result = @client.query("SELECT * FROM mysql2_test", :stream => true, :cache_rows => false)
+    it "should retain the count when mixing first and each" do
+      result = @client.query("SELECT 1 UNION SELECT 2", :stream => true, :cache_rows => false)
       result.count.should eql(0)
-      result.each {|r|  }
+      result.first
       result.count.should eql(1)
+      result.each.to_a
+      result.count.should eql(2)
     end
 
     it "should not yield nil at the end of streaming" do


### PR DESCRIPTION
Specs for #406. Generally the behavior there is correct and I do not think the OP's issue stands, however there is a weird thing I'd like to understand better:

``` ruby
        @multi_client = Mysql2::Client.new(DatabaseCredentials['root'].merge(:flags => Mysql2::Client::MULTI_STATEMENTS))
        result = @multi_client.query("SELECT 1 AS 'set_1'; SELECT 2 AS 'set_2'", :stream => true, :cache_rows => false)
        result.first.should eql({ 'set_1' => 1 })
        @multi_client.more_results?.should be_true

        result.count.should == 1
        result.each { |r| } # consume the end-of-results packet
        result.count.should == 1
```

Fails with (writing this as part of a new unit test) (it's the second result.count that's now 0)
```
  1) Mysql2::Client#query Multiple results sets should stream multiple result sets
     Failure/Error: result.count.should == 1
       expected: 1
            got: 0 (using ==)
     # ./spec/mysql2/client_spec.rb:640:in `block (4 levels) in <top (required)>'

```