### PR TITLE
The argument spec to Win32API.new may be required to be a string in Ruby 2.2

### DIFF
--- a/lib/mysql2.rb
+++ b/lib/mysql2.rb
@@ -20,7 +20,7 @@ if RUBY_PLATFORM =~ /mswin|mingw/
              end
 
   require 'Win32API'
-  LoadLibrary = Win32API.new('Kernel32', 'LoadLibrary', ['P'], 'I')
+  LoadLibrary = Win32API.new('Kernel32', 'LoadLibrary', 'P', 'I')
   if 0 == LoadLibrary.call(dll_path)
     abort "Failed to load libmysql.dll from #{dll_path}"
   end


### PR DESCRIPTION
This may be a fix for #584. AppVeyor results at https://ci.appveyor.com/project/sodabrew/mysql2