### PR TITLE
Friendly ext build error <3

### DIFF
--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -2,7 +2,14 @@
 require 'mkmf'
 
 def asplode lib
-  abort "-----\n#{lib} is missing.  please check your installation of mysql and try again.\n-----"
+  if RUBY_PLATFORM =~ /mingw|mswin/
+    abort "-----\n#{lib} is missing. please check your installation of mysql and try again.\n-----"
+  elsif RUBY_PLATFORM =~ /darwin/
+    abort "-----\n#{lib} is missing. Try 'brew install mysql', check your installation of mysql and try again.\n-----"
+  else
+    abort "-----\n#{lib} is missing. Try 'apt-get install libmysqlclient-dev' or
+'yum install mysql-devel', check your installation of mysql and try again.\n-----"
+  end
 end
 
 # 2.0-only
@@ -67,10 +74,14 @@ elsif mc = (with_config('mysql-config') || Dir[GLOB].first)
 else
   inc, lib = dir_config('mysql', '/usr/local')
   libs = ['m', 'z', 'socket', 'nsl', 'mygcc']
+  found = false
   while not find_library('mysqlclient', 'mysql_query', lib, "#{lib}/mysql") do
     exit 1 if libs.empty?
-    have_library(libs.shift)
+    found ||= have_library(libs.shift)
   end
+
+  asplode("mysql client") unless found
+
   rpath_dir = lib
 end
 


### PR DESCRIPTION
I always bundle this gem on my production servers, then it fails and I'm googling which Deian package should I install. After I find out it's `libmysqlclient-dev`, I can finally install it.

I think that suggesting this package right in the output will save few minutes for every Ruby developer.
The same [trick is used in sqlite3-ruby](https://github.com/sparklemotion/sqlite3-ruby/blob/master/ext/sqlite3/extconf.rb#L22)

:heart: 