### PR TITLE
Move Mysql2::Client#info to a class method for easier debugging

### DIFF
--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -82,6 +82,10 @@ module Mysql2
       info_hash
     end
 
+    def info
+      self.class.info
+    end
+
     private
       def self.local_offset
         ::Time.local(2010).utc_offset.to_r / 86400

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -732,23 +732,16 @@ describe Mysql2::Client do
 
   if defined? Encoding
     context "strings returned by #info" do
-      it "should default to the connection's encoding if Encoding.default_internal is nil" do
-        with_internal_encoding nil do
-          @client.info[:version].encoding.should eql(Encoding.find('utf-8'))
-
-          client2 = Mysql2::Client.new(DatabaseCredentials['root'].merge(:encoding => 'ascii'))
-          client2.info[:version].encoding.should eql(Encoding.find('us-ascii'))
-        end
+      it "should be tagged as ascii" do
+        @client.info[:version].encoding.should eql(Encoding::US_ASCII)
+        @client.info[:header_version].encoding.should eql(Encoding::US_ASCII)
       end
+    end
 
-      it "should use Encoding.default_internal" do
-        with_internal_encoding 'utf-8' do
-          @client.info[:version].encoding.should eql(Encoding.default_internal)
-        end
-
-        with_internal_encoding 'us-ascii' do
-          @client.info[:version].encoding.should eql(Encoding.default_internal)
-        end
+    context "strings returned by .info" do
+      it "should be tagged as ascii" do
+        Mysql2::Client.info[:version].encoding.should eql(Encoding::US_ASCII)
+        Mysql2::Client.info[:header_version].encoding.should eql(Encoding::US_ASCII)
       end
     end
   end


### PR DESCRIPTION
Previously a successfully connected `Mysql2::Client` instance needed to be created in order to call it's `info` instance method. When needing to debug connection issues, that can be a pain. The C api calls we're using here don't require a connection to be passed, so there's no reason for us to require a connection. Although we were previously using the connections encoding to transcode the strings returned from the C api into `Encoding.default_internal` - the strings we get back from the C api are almost _always_ going to be fixed ASCII strings, so this changes that behavior to instead just tag the string with Ruby's `us-ascii` encoding and return them as-is without any transcoding.

I came across this while trying to help debug https://github.com/brianmario/mysql2/issues/279 with @naox