### PR TITLE
Refactor extconf.rb

### DIFF
--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -36,10 +36,11 @@ class Platform
   end
 
   def detect_headers
-    headers = %w{ mysql.h errmsg.h mysqld_error.h }
+    headers = %w{ errmsg.h mysqld_error.h }
     prefix = ['', 'mysql/'].find do |prefix|
       have_header("#{prefix}mysql.h")
     end
+    asplode('mysql.h') unless prefix
 
     headers.each do |header|
       header = "#{prefix}#{header}"

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -42,7 +42,7 @@ class Platform
     end
 
     headers.each do |header|
-      header = [prefix, h].compact.join '/'
+      header = "#{prefix}#{header}"
       asplode(header) unless have_header(header)
     end
   end
@@ -119,7 +119,7 @@ class Platform
   end
 
   def asplode(library)
-    complain("#{library} is missing. #{asplode_suggestion}")
+    error("#{library} is missing. #{asplode_suggestion}")
   end
 
   def asplode_suggestion

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -1,15 +1,159 @@
 # encoding: UTF-8
 require 'mkmf'
-require 'English'
 
-def asplode(lib)
-  if RUBY_PLATFORM =~ /mingw|mswin/
-    abort "-----\n#{lib} is missing. Check your installation of MySQL or Connector/C, and try again.\n-----"
-  elsif RUBY_PLATFORM =~ /darwin/
-    abort "-----\n#{lib} is missing. You may need to 'brew install mysql' or 'port install mysql', and try again.\n-----"
-  else
-    abort "-----\n#{lib} is missing. You may need to 'apt-get install libmysqlclient-dev' or 'yum install mysql-devel', and try again.\n-----"
+class Platform
+  # Gets the proper platform object for the current platform.
+  def self.current
+    case RUBY_PLATFORM
+      when /mswin|mingw/
+        Windows.new
+      when /darwin/
+        MacOS.new
+      else
+        Linux.new
+    end
   end
+
+  # @return [(String, String)|nil] The include and library paths.
+  def detect_paths
+    detect_by_explicit_path || detect_by_mysql_config
+  end
+
+  protected
+
+  def detect_by_explicit_path
+    # If the user has provided a --with-mysql-dir argument, we must respect it or fail.
+    inc, lib = dir_config('mysql')
+    if inc && lib
+      # Ruby versions not incorporating the mkmf fix at
+      # https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/39717
+      # do not properly search for lib directories, and must be corrected
+      unless lib && lib[-3, 3] == 'lib'
+        @libdir_basename = 'lib'
+        inc, lib = dir_config('mysql')
+      end
+
+      error "Cannot find include dir(s) #{inc}" unless inc && inc.split(File::PATH_SEPARATOR).any?{|dir| File.directory?(dir)}
+      error "Cannot find library dir(s) #{lib}" unless lib && lib.split(File::PATH_SEPARATOR).any?{|dir| File.directory?(dir)}
+      warn  "Using --with-mysql-dir=#{File.dirname(inc)}"
+      [inc, lib]
+    else
+      nil
+    end
+  end
+
+  def detect_by_mysql_config
+    if with_config('mysql-config') && !mysql_config_path
+      error 'Cannot find mysql_config'
+    end
+    warn  "Using mysql_config at #{mysql_config_path}"
+
+    ver = `#{mysql_config_path} --version`.chomp.to_f
+    includes = `#{mysql_config_path} --include`.chomp
+    exit 1 if $? != 0
+    libs = `#{mysql_config_path} --libs_r`.chomp
+
+    # MySQL 5.5 and above already have re-entrant code in libmysqlclient (no _r).
+    if ver >= 5.5 || libs.empty?
+      libs = `#{mysql_config_path} --libs`.chomp
+    end
+    exit 1 if $? != 0
+
+    $INCFLAGS += ' ' + includes
+    $libs = "#{libs} #{$libs}"
+    [includes, libs]
+  end
+
+  def error(message)
+    abort("-----\n#{message}\n-----")
+  end
+
+  def warn(message)
+    super("-----\n#{message}\n-----")
+  end
+
+  def asplode(library)
+    complain("#{library} is missing. #{asplode_suggestion}")
+  end
+
+  def asplode_suggestion
+    'Please check your installation of MySQL and try again.'
+  end
+
+  def mysql_config_path
+    nil
+  end
+end
+
+class Unix < Platform
+  # borrowed from mysqlplus
+  # http://github.com/oldmoe/mysqlplus/blob/master/ext/extconf.rb
+  DEFAULT_MYSQL_CONFIG_SEARCH_PATHS = %w[
+    /opt
+    /opt/local
+    /opt/local/mysql
+    /opt/local/lib/mysql5*
+    /usr
+    /usr/mysql
+    /usr/local
+    /usr/local/mysql
+    /usr/local/mysql-*
+    /usr/local/lib/mysql5*
+  ].freeze
+
+  def detect_paths
+    super || detect_by_known_paths
+  end
+
+  protected
+
+  def detect_by_known_paths
+    inc, lib = dir_config('mysql', '/usr/local')
+    libs = ['m', 'z', 'socket', 'nsl', 'mygcc']
+    found = false
+    until find_library('mysqlclient', 'mysql_query', lib, "#{lib}/mysql") do
+      break if libs.empty?
+      found ||= have_library(libs.shift)
+    end
+
+    asplode('mysql client') unless found
+
+    [inc, lib]
+  end
+
+  def default_mysql_config_search_path
+    ENV['PATH'].split(File::PATH_SEPARATOR) +
+      DEFAULT_MYSQL_CONFIG_SEARCH_PATHS.map{|dir| "#{dir}/bin" }
+  end
+
+  def mysql_config_glob
+    "{#{default_mysql_config_search_path.join(',')}}/{mysql_config,mysql_config5}"
+  end
+
+  def mysql_config_path
+    @mysql_config_path ||= Dir[mysql_config_glob].first
+  end
+end
+
+class Linux < Unix
+  protected
+
+  def asplode_suggestion
+    'Try `apt-get install libmysqlclient-dev` or `yum install mysql-devel`, '\
+    'check your installation of MySQL and try again.'
+  end
+end
+
+class MacOS < Unix
+  protected
+
+  def asplode_suggestion
+    'Try `brew install mysql`, check your installation of MySQL and try again.'
+  end
+end
+
+class Windows < Platform
+
 end
 
 # 2.0-only
@@ -21,63 +165,7 @@ have_func('rb_wait_for_single_fd')
 have_func('rb_hash_dup')
 have_func('rb_intern3')
 
-# borrowed from mysqlplus
-# http://github.com/oldmoe/mysqlplus/blob/master/ext/extconf.rb
-dirs = ENV.fetch('PATH').split(File::PATH_SEPARATOR) + %w(
-  /opt
-  /opt/local
-  /opt/local/mysql
-  /opt/local/lib/mysql5*
-  /usr
-  /usr/mysql
-  /usr/local
-  /usr/local/mysql
-  /usr/local/mysql-*
-  /usr/local/lib/mysql5*
-  /usr/local/opt/mysql5*
-).map { |dir| dir << '/bin' }
-
-GLOB = "{#{dirs.join(',')}}/{mysql_config,mysql_config5,mariadb_config}"
-
-# If the user has provided a --with-mysql-dir argument, we must respect it or fail.
-inc, lib = dir_config('mysql')
-if inc && lib
-  # TODO: Remove when 2.0.0 is the minimum supported version
-  # Ruby versions not incorporating the mkmf fix at
-  # https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/39717
-  # do not properly search for lib directories, and must be corrected
-  unless lib && lib[-3, 3] == 'lib'
-    @libdir_basename = 'lib'
-    inc, lib = dir_config('mysql')
-  end
-  abort "-----\nCannot find include dir(s) #{inc}\n-----" unless inc && inc.split(File::PATH_SEPARATOR).any? { |dir| File.directory?(dir) }
-  abort "-----\nCannot find library dir(s) #{lib}\n-----" unless lib && lib.split(File::PATH_SEPARATOR).any? { |dir| File.directory?(dir) }
-  warn "-----\nUsing --with-mysql-dir=#{File.dirname inc}\n-----"
-  rpath_dir = lib
-elsif (mc = (with_config('mysql-config') || Dir[GLOB].first))
-  # If the user has provided a --with-mysql-config argument, we must respect it or fail.
-  # If the user gave --with-mysql-config with no argument means we should try to find it.
-  mc = Dir[GLOB].first if mc == true
-  abort "-----\nCannot find mysql_config at #{mc}\n-----" unless mc && File.exist?(mc)
-  abort "-----\nCannot execute mysql_config at #{mc}\n-----" unless File.executable?(mc)
-  warn "-----\nUsing mysql_config at #{mc}\n-----"
-  ver = `#{mc} --version`.chomp.to_f
-  includes = `#{mc} --include`.chomp
-  abort unless $CHILD_STATUS.success?
-  libs = `#{mc} --libs_r`.chomp
-  # MySQL 5.5 and above already have re-entrant code in libmysqlclient (no _r).
-  libs = `#{mc} --libs`.chomp if ver >= 5.5 || libs.empty?
-  abort unless $CHILD_STATUS.success?
-  $INCFLAGS += ' ' + includes
-  $libs = libs + " " + $libs
-  rpath_dir = libs
-else
-  _, usr_local_lib = dir_config('mysql', '/usr/local')
-
-  asplode("mysql client") unless find_library('mysqlclient', 'mysql_query', usr_local_lib, "#{usr_local_lib}/mysql")
-
-  rpath_dir = usr_local_lib
-end
+_, rpath_dir = Platform.current.detect_paths
 
 if have_header('mysql.h')
   prefix = nil
@@ -87,111 +175,92 @@ else
   asplode 'mysql.h'
 end
 
-%w(errmsg.h mysqld_error.h).each do |h|
-  header = [prefix, h].compact.join '/'
-  asplode h unless have_header header
-end
+  %w{ errmsg.h mysqld_error.h }.each do |h|
+    header = [prefix, h].compact.join '/'
+    asplode h unless have_header h
+  end
 
-# This is our wishlist. We use whichever flags work on the host.
-# -Wall and -Wextra are included by default.
-wishlist = [
-  '-Weverything',
-  '-Wno-bad-function-cast', # rb_thread_call_without_gvl returns void * that we cast to VALUE
-  '-Wno-conditional-uninitialized', # false positive in client.c
-  '-Wno-covered-switch-default', # result.c -- enum_field_types (when fully covered, e.g. mysql 5.5)
-  '-Wno-declaration-after-statement', # GET_CLIENT followed by GET_STATEMENT in statement.c
-  '-Wno-disabled-macro-expansion', # rubby :(
-  '-Wno-documentation-unknown-command', # rubby :(
-  '-Wno-missing-field-initializers', # gperf generates bad code
-  '-Wno-missing-variable-declarations', # missing symbols due to ruby native ext initialization
-  '-Wno-padded', # mysql :(
-  '-Wno-sign-conversion', # gperf generates bad code
-  '-Wno-static-in-inline', # gperf generates bad code
-  '-Wno-switch-enum', # result.c -- enum_field_types (when not fully covered, e.g. mysql 5.6+)
-  '-Wno-undef', # rubinius :(
-  '-Wno-used-but-marked-unused', # rubby :(
-]
-
-if ENV['CI']
-  wishlist += [
-    '-Werror',
-    '-fsanitize=address',
-    '-fsanitize=cfi',
-    '-fsanitize=integer',
-    '-fsanitize=memory',
-    '-fsanitize=thread',
-    '-fsanitize=undefined',
-  ]
-end
-
-usable_flags = wishlist.select do |flag|
-  try_link('int main() {return 0;}', flag)
-end
-
-$CFLAGS << ' ' << usable_flags.join(' ')
-
-if RUBY_PLATFORM =~ /mswin|mingw/
-  # Build libmysql.a interface link library
-  require 'rake'
-
-  # Build libmysql.a interface link library
-  # Use rake to rebuild only if these files change
-  deffile = File.expand_path('../../../support/libmysql.def', __FILE__)
-  libfile = File.expand_path(File.join(rpath_dir, 'libmysql.lib'))
-  file 'libmysql.a' => [deffile, libfile] do
-    when_writing 'building libmysql.a' do
-      # Ruby kindly shows us where dllwrap is, but that tool does more than we want.
-      # Maybe in the future Ruby could provide RbConfig::CONFIG['DLLTOOL'] directly.
-      dlltool = RbConfig::CONFIG['DLLWRAP'].gsub('dllwrap', 'dlltool')
-      sh dlltool, '--kill-at',
-         '--dllname', 'libmysql.dll',
-         '--output-lib', 'libmysql.a',
-         '--input-def', deffile, libfile
+  # This is our wishlist. We use whichever flags work on the host.
+  # -Wall and -Wextra are included by default.
+  # TODO: fix statement.c and remove -Wno-error=declaration-after-statement
+  %w(
+    -Werror
+    -Weverything
+    -fsanitize=address
+    -fsanitize=integer
+    -fsanitize=thread
+    -fsanitize=memory
+    -fsanitize=undefined
+    -fsanitize=cfi
+    -Wno-error=declaration-after-statement
+  ).each do |flag|
+    if try_link('int main() {return 0;}', flag)
+      $CFLAGS << ' ' << flag
     end
   end
 
-  Rake::Task['libmysql.a'].invoke
-  $LOCAL_LIBS << ' ' << 'libmysql.a'
+  if RUBY_PLATFORM =~ /mswin|mingw/
+    # Build libmysql.a interface link library
+    require 'rake'
 
-  # Make sure the generated interface library works (if cross-compiling, trust without verifying)
-  unless RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
-    abort "-----\nCannot find libmysql.a\n----" unless have_library('libmysql')
-    abort "-----\nCannot link to libmysql.a (my_init)\n----" unless have_func('my_init')
-  end
-
-  # Vendor libmysql.dll
-  vendordir = File.expand_path('../../../vendor/', __FILE__)
-  directory vendordir
-
-  vendordll = File.join(vendordir, 'libmysql.dll')
-  dllfile = File.expand_path(File.join(rpath_dir, 'libmysql.dll'))
-  file vendordll => [dllfile, vendordir] do
-    when_writing 'copying libmysql.dll' do
-      cp dllfile, vendordll
+    # Build libmysql.a interface link library
+    # Use rake to rebuild only if these files change
+    deffile = File.expand_path('../../../support/libmysql.def', __FILE__)
+    libfile = File.expand_path(File.join(rpath_dir, 'libmysql.lib'))
+    file 'libmysql.a' => [deffile, libfile] do |t|
+      when_writing 'building libmysql.a' do
+        # Ruby kindly shows us where dllwrap is, but that tool does more than we want.
+        # Maybe in the future Ruby could provide RbConfig::CONFIG['DLLTOOL'] directly.
+        dlltool = RbConfig::CONFIG['DLLWRAP'].gsub('dllwrap', 'dlltool')
+        sh dlltool, '--kill-at',
+          '--dllname', 'libmysql.dll',
+          '--output-lib', 'libmysql.a',
+          '--input-def', deffile, libfile
+      end
     end
-  end
 
-  # Copy libmysql.dll to the local vendor directory by default
-  if arg_config('--no-vendor-libmysql')
-    # Fine, don't.
-    puts "--no-vendor-libmysql"
-  else # Default: arg_config('--vendor-libmysql')
-    # Let's do it!
-    Rake::Task[vendordll].invoke
-  end
-else
-  case explicit_rpath = with_config('mysql-rpath')
-  when true
-    abort "-----\nOption --with-mysql-rpath must have an argument\n-----"
-  when false
-    warn "-----\nOption --with-mysql-rpath has been disabled at your request\n-----"
-  when String
-    # The user gave us a value so use it
-    rpath_flags = " -Wl,-rpath,#{explicit_rpath}"
-    warn "-----\nSetting mysql rpath to #{explicit_rpath}\n-----"
-    $LDFLAGS << rpath_flags
+    Rake::Task['libmysql.a'].invoke
+    $LOCAL_LIBS << ' ' << 'libmysql.a'
+
+    # Make sure the generated interface library works (if cross-compiling, trust without verifying)
+    unless RbConfig::CONFIG['host_os'] =~ /mswin|mingw/
+      abort "-----\nCannot find libmysql.a\n----" unless have_library('libmysql')
+      abort "-----\nCannot link to libmysql.a (my_init)\n----" unless have_func('my_init')
+    end
+
+    # Vendor libmysql.dll
+    vendordir = File.expand_path('../../../vendor/', __FILE__)
+    directory vendordir
+
+    vendordll = File.join(vendordir, 'libmysql.dll')
+    dllfile = File.expand_path(File.join(rpath_dir, 'libmysql.dll'))
+    file vendordll => [dllfile, vendordir] do |t|
+      when_writing 'copying libmysql.dll' do
+        cp dllfile, vendordll
+      end
+    end
+
+    # Copy libmysql.dll to the local vendor directory by default
+    if arg_config('--no-vendor-libmysql')
+      # Fine, don't.
+      puts "--no-vendor-libmysql"
+    else # Default: arg_config('--vendor-libmysql')
+      # Let's do it!
+      Rake::Task[vendordll].invoke
+    end
   else
-    if (libdir = rpath_dir[%r{(-L)?(/[^ ]+)}, 2])
+    case explicit_rpath = with_config('mysql-rpath')
+    when true
+      abort "-----\nOption --with-mysql-rpath must have an argument\n-----"
+    when false
+      warn "-----\nOption --with-mysql-rpath has been disabled at your request\n-----"
+    when String
+      # The user gave us a value so use it
+      rpath_flags = " -Wl,-rpath,#{explicit_rpath}"
+      warn "-----\nSetting mysql rpath to #{explicit_rpath}\n-----"
+      $LDFLAGS << rpath_flags
+    else
+      if libdir = rpath_dir[%r{(-L)?(/[^ ]+)}, 2]
       rpath_flags = " -Wl,-rpath,#{libdir}"
       if RbConfig::CONFIG["RPATHFLAG"].to_s.empty? && try_link('int main() {return 0;}', rpath_flags)
         # Usually Ruby sets RPATHFLAG the right way for each system, but not on OS X.

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -135,7 +135,7 @@ class Platform
   end
 
   def mysql_config_path
-    nil
+    @mysql_config_path ||= with_config('mysql-config')
   end
 end
 
@@ -219,6 +219,7 @@ class Unix < Platform
   end
 
   def mysql_config_path
+    super
     @mysql_config_path ||= Dir[mysql_config_glob].first
   end
 end

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -162,6 +162,7 @@ class Unix < Platform
     /usr/local/mysql
     /usr/local/mysql-*
     /usr/local/lib/mysql5*
+    /usr/local/opt/mysql5*
   ].freeze
 
   def configure

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -65,11 +65,20 @@ class Platform
   end
 
   def configure_compiler
-    # These gcc style flags are also supported by clang and xcode compilers,
-    # so we'll use a does-it-work test instead of an is-it-gcc test.
-    gcc_flags = ' -Wall -funroll-loops'
-    if try_link('int main() {return 0;}', gcc_flags)
-      $CFLAGS << gcc_flags
+    # This is our wishlist. We use whichever flags work on the host.
+    # TODO: fix statement.c and remove -Wno-declaration-after-statement
+    # TODO: fix gperf mysql_enc_name_to_ruby.h and remove -Wno-missing-field-initializers
+    %w(
+      -Wall
+      -Wextra
+      -Werror
+      -Wno-unused-function
+      -Wno-declaration-after-statement
+      -Wno-missing-field-initializers
+    ).select do |flag|
+      try_link('int main() {return 0;}', flag)
+    end.each do |flag|
+      $CFLAGS << ' ' << flag
     end
   end
 

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -224,7 +224,7 @@ class Unix < Platform
   end
 
   def mysql_config_glob
-    "{#{default_mysql_config_search_path.join(',')}}/{mysql_config,mysql_config5}"
+    "{#{default_mysql_config_search_path.join(',')}}/{mysql_config,mysql_config5,mariadb_config}"
   end
 
   def mysql_config_path

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -207,14 +207,7 @@ class Unix < Platform
 
   def detect_by_known_paths
     inc, lib = dir_config('mysql', '/usr/local')
-    libs = ['m', 'z', 'socket', 'nsl', 'mygcc']
-    found = false
-    until find_library('mysqlclient', 'mysql_query', lib, "#{lib}/mysql") do
-      break if libs.empty?
-      found ||= have_library(libs.shift)
-    end
-
-    asplode('mysql client') unless found
+    asplode('mysql client') unless has_mysql_client?(lib)
 
     [inc, lib]
   end
@@ -231,6 +224,12 @@ class Unix < Platform
   def mysql_config_path
     super
     @mysql_config_path ||= Dir[mysql_config_glob].first
+  end
+
+  private
+
+  def has_mysql_client?(lib)
+    find_library('mysqlclient', 'mysql_query', lib, "#{lib}/mysql")
   end
 end
 


### PR DESCRIPTION
Hello there.

I've made a pretty major rewrite for extconf.rb. It was generating bad makefiles for Windows (since it is not commonly tested) and while trying to fix that I felt that the flow of logic could be much better.

I've split the path detection logic into the `detect_*` functions, and the configuration logic to `configure_*` functions. These are different depending on the platform.

I've tried to be as faithful to the original implementation as possible, however I have not tested this on platforms other than Windows. Comments much appreciated.
