### PR TITLE
Also search for mariadb_config on compile

### DIFF
--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -36,7 +36,7 @@ dirs = ENV['PATH'].split(File::PATH_SEPARATOR) + %w[
   /usr/local/lib/mysql5*
 ].map{|dir| "#{dir}/bin" }
 
-GLOB = "{#{dirs.join(',')}}/{mysql_config,mysql_config5}"
+GLOB = "{#{dirs.join(',')}}/{mysql_config,mysql_config5,mariadb_config}"
 
 # If the user has provided a --with-mysql-dir argument, we must respect it or fail.
 inc, lib = dir_config('mysql')


### PR DESCRIPTION
libmariadb-client-lgpl-dev in newly released Debian stable (jessie)
ships `/usr/bin/mariadb_config` and not `/usr/bin/mysql_config`.