### PR TITLE
Statement GC fixes

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -490,7 +490,7 @@ static VALUE rb_mysql_client_async_result(VALUE self) {
   current = rb_hash_dup(rb_iv_get(self, "@current_query_options"));
   (void)RB_GC_GUARD(current);
   Check_Type(current, T_HASH);
-  resultObj = rb_mysql_result_to_obj(self, wrapper->encoding, current, result, NULL);
+  resultObj = rb_mysql_result_to_obj(self, wrapper->encoding, current, result, Qnil);
 
   return resultObj;
 }
@@ -1050,7 +1050,7 @@ static VALUE rb_mysql_client_store_result(VALUE self)
   current = rb_hash_dup(rb_iv_get(self, "@current_query_options"));
   (void)RB_GC_GUARD(current);
   Check_Type(current, T_HASH);
-  resultObj = rb_mysql_result_to_obj(self, wrapper->encoding, current, result, NULL);
+  resultObj = rb_mysql_result_to_obj(self, wrapper->encoding, current, result, Qnil);
 
   return resultObj;
 }

--- a/ext/mysql2/mysql2_ext.h
+++ b/ext/mysql2/mysql2_ext.h
@@ -39,8 +39,8 @@ typedef unsigned int    uint;
 #endif
 
 #include <client.h>
-#include <result.h>
 #include <statement.h>
+#include <result.h>
 #include <infile.h>
 
 #endif

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -107,6 +107,8 @@ static void rb_mysql_result_free_result(mysql2_result_wrapper * wrapper) {
         xfree(wrapper->error);
         xfree(wrapper->length);
       }
+      /* Clue that the next statement execute will need to allocate a new result buffer. */
+      wrapper->result_buffers = NULL;
     }
     /* FIXME: this may call flush_use_result, which can hit the socket */
     /* For prepared statements, wrapper->result is the result metadata */

--- a/ext/mysql2/result.h
+++ b/ext/mysql2/result.h
@@ -2,13 +2,14 @@
 #define MYSQL2_RESULT_H
 
 void init_mysql2_result();
-VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_RES *r, MYSQL_STMT * s);
+VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_RES *r, VALUE statement);
 
 typedef struct {
   VALUE fields;
   VALUE rows;
   VALUE client;
   VALUE encoding;
+  VALUE statement;
   unsigned int numberOfFields;
   unsigned long numberOfRows;
   unsigned long lastRowProcessed;

--- a/ext/mysql2/result.h
+++ b/ext/mysql2/result.h
@@ -17,7 +17,7 @@ typedef struct {
   char streamingComplete;
   char resultFreed;
   MYSQL_RES *result;
-  MYSQL_STMT *stmt;
+  mysql_stmt_wrapper *stmt_wrapper;
   mysql_client_wrapper *client_wrapper;
   /* statement result bind buffers */
   MYSQL_BIND *result_buffers;

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -109,7 +109,7 @@ VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql) {
   rb_stmt = Data_Make_Struct(cMysql2Statement, mysql_stmt_wrapper, rb_mysql_stmt_mark, rb_mysql_stmt_free, stmt_wrapper);
   {
     stmt_wrapper->client = rb_client;
-    stmt_wrapper->refcount = 0;
+    stmt_wrapper->refcount = 1;
     stmt_wrapper->stmt = NULL;
   }
 

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -12,7 +12,7 @@ static VALUE intern_usec, intern_sec, intern_min, intern_hour, intern_day, inter
 
 static void rb_mysql_stmt_mark(void * ptr) {
   mysql_stmt_wrapper* stmt_wrapper = (mysql_stmt_wrapper *)ptr;
-  if(! stmt_wrapper) return;
+  if (!stmt_wrapper) return;
 
   rb_gc_mark(stmt_wrapper->client);
 }
@@ -176,7 +176,7 @@ static VALUE field_count(VALUE self) {
 static void *nogvl_execute(void *ptr) {
   MYSQL_STMT *stmt = ptr;
 
-  if(mysql_stmt_execute(stmt)) {
+  if (mysql_stmt_execute(stmt)) {
     return (void*)Qfalse;
   } else {
     return (void*)Qtrue;
@@ -186,7 +186,7 @@ static void *nogvl_execute(void *ptr) {
 static void *nogvl_stmt_store_result(void *ptr) {
   MYSQL_STMT *stmt = ptr;
 
-  if(mysql_stmt_store_result(stmt)) {
+  if (mysql_stmt_store_result(stmt)) {
     return (void *)Qfalse;
   } else {
     return (void *)Qtrue;
@@ -347,8 +347,8 @@ static VALUE execute(int argc, VALUE *argv, VALUE self) {
   FREE_BINDS;
 
   metadata = mysql_stmt_result_metadata(stmt);
-  if(metadata == NULL) {
-    if(mysql_stmt_errno(stmt) != 0) {
+  if (metadata == NULL) {
+    if (mysql_stmt_errno(stmt) != 0) {
       // either CR_OUT_OF_MEMORY or CR_UNKNOWN_ERROR. both fatal.
 
       MARK_CONN_INACTIVE(stmt_wrapper->client);

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -359,12 +359,13 @@ static VALUE execute(int argc, VALUE *argv, VALUE self) {
   if (!is_streaming) {
     // recieve the whole result set from the server
     if (rb_thread_call_without_gvl(nogvl_stmt_store_result, stmt, RUBY_UBF_IO, 0) == Qfalse) {
+      mysql_free_result(metadata);
       rb_raise_mysql2_stmt_error(self);
     }
     MARK_CONN_INACTIVE(stmt_wrapper->client);
   }
 
-  resultObj = rb_mysql_result_to_obj(stmt_wrapper->client, wrapper->encoding, current, metadata, stmt);
+  resultObj = rb_mysql_result_to_obj(stmt_wrapper->client, wrapper->encoding, current, metadata, self);
 
   if (!is_streaming) {
     // cache all result

--- a/ext/mysql2/statement.h
+++ b/ext/mysql2/statement.h
@@ -3,13 +3,14 @@
 
 extern VALUE cMysql2Statement;
 
-void init_mysql2_statement();
-
 typedef struct {
   VALUE client;
   MYSQL_STMT *stmt;
   int refcount;
 } mysql_stmt_wrapper;
+
+void init_mysql2_statement();
+void decr_mysql2_stmt(mysql_stmt_wrapper *stmt_wrapper);
 
 VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql);
 VALUE rb_raise_mysql2_stmt_error2(MYSQL_STMT *stmt

--- a/ext/mysql2/statement.h
+++ b/ext/mysql2/statement.h
@@ -8,6 +8,7 @@ void init_mysql2_statement();
 typedef struct {
   VALUE client;
   MYSQL_STMT *stmt;
+  int refcount;
 } mysql_stmt_wrapper;
 
 VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql);

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -70,6 +70,14 @@ RSpec.describe Mysql2::Statement do
     @client.query 'DROP TABLE IF EXISTS mysql2_stmt_q'
   end
 
+  it "should be reusable 1000 times" do
+    statement = @client.prepare 'SELECT 1'
+    1000.times do
+      result = statement.execute
+      expect(result.to_a.length).to eq(1)
+    end
+  end
+
   it "should be reusable 10000 times" do
     statement = @client.prepare 'SELECT 1'
     10000.times do

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -70,6 +70,14 @@ RSpec.describe Mysql2::Statement do
     @client.query 'DROP TABLE IF EXISTS mysql2_stmt_q'
   end
 
+  it "should be reusable 10000 times" do
+    statement = @client.prepare 'SELECT 1'
+    10000.times do
+      result = statement.execute
+      expect(result.to_a.length).to eq(1)
+    end
+  end
+
   it "should select dates" do
     statement = @client.prepare 'SELECT NOW()'
     result = statement.execute


### PR DESCRIPTION
Resolves #631 - In a reprise of #378, the Result object needs to keep a reference to the Statement that produced it in order to prevent a GC of the Statement from calling `mysql_stmt_close` ahead of the Result GC calling `mysql_stmt_result_free` which would result in use-after-free crash.

There is still a use-after-free I cannot figure out. The valgrind output is:

```
==10247== 1 errors in context 1 of 163:
==10247== Invalid write of size 8
==10247==    at 0xAAEE240: ??? (in /usr/lib/x86_64-linux-gnu/libmysqlclient.so.18.0.0)
==10247==    by 0xAAF223D: mysql_stmt_execute (in /usr/lib/x86_64-linux-gnu/libmysqlclient.so.18.0.0)
==10247==    by 0xA8BAA28: nogvl_execute (statement.c:179)
==10247==    by 0x4F923AF: rb_thread_blocking_region (in /usr/lib/libruby-1.9.1.so.1.9.1)
==10247==    by 0xA8BAC9F: execute (statement.c:342)
==10247==    by 0x4F831D2: vm_call_method (in /usr/lib/libruby-1.9.1.so.1.9.1)
==10247==    by 0x4F7DA94: vm_exec_core (in /usr/lib/libruby-1.9.1.so.1.9.1)
==10247==    by 0x4F80D8D: vm_exec (in /usr/lib/libruby-1.9.1.so.1.9.1)
==10247==    by 0x4F8214B: invoke_block_from_c (in /usr/lib/libruby-1.9.1.so.1.9.1)
==10247==    by 0x4F85D51: yield_under (in /usr/lib/libruby-1.9.1.so.1.9.1)
==10247==    by 0x4F831D2: vm_call_method (in /usr/lib/libruby-1.9.1.so.1.9.1)
==10247==    by 0x4F7DA94: vm_exec_core (in /usr/lib/libruby-1.9.1.so.1.9.1)
==10247==  Address 0xa6d9c10 is 0 bytes inside a block of size 8 free'd
==10247==    at 0x4C2BDEC: free (in /usr/lib/valgrind/vgpreload_memcheck-amd64-linux.so)
==10247==    by 0xA8B7F3D: rb_mysql_result_free_result (result.c:108)
==10247==    by 0xA8B87A1: rb_mysql_result_each (result.c:846)
==10247==    by 0x4F81232: vm_call0 (in /usr/lib/libruby-1.9.1.so.1.9.1)
==10247==    by 0x4F81C87: rb_funcall (in /usr/lib/libruby-1.9.1.so.1.9.1)
==10247==    by 0xA8BB1F6: execute (statement.c:379)
==10247==    by 0x4F831D2: vm_call_method (in /usr/lib/libruby-1.9.1.so.1.9.1)
==10247==    by 0x4F7DA94: vm_exec_core (in /usr/lib/libruby-1.9.1.so.1.9.1)
==10247==    by 0x4F80D8D: vm_exec (in /usr/lib/libruby-1.9.1.so.1.9.1)
==10247==    by 0x4F8214B: invoke_block_from_c (in /usr/lib/libruby-1.9.1.so.1.9.1)
==10247==    by 0x4F85D51: yield_under (in /usr/lib/libruby-1.9.1.so.1.9.1)
==10247==    by 0x4F831D2: vm_call_method (in /usr/lib/libruby-1.9.1.so.1.9.1)
```

If I comment this out:
```
 844       if (wrapper->lastRowProcessed == wrapper->numberOfRows) {
 845         /* we don't need the mysql C dataset around anymore, peace it */
 846         rb_mysql_result_free_result(wrapper);
 847       }
```
Then I get this error executing a statement in a loop: `Attempt to read a row while there is no result set associated with the statement`