### PR TITLE
Add rake-compiler-dock for building Windows binary gems.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,6 +21,7 @@ end
 
 group :development do
   gem 'pry'
+  gem 'rake-compiler-dock', '~> 0.4.2'
 end
 
 platforms :rbx do

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -880,7 +880,7 @@ static VALUE rb_mysql_client_server_info(VALUE self) {
  *
  * Return the file descriptor number for this client.
  */
-static VALUE rb_mysql_client_socket(VALUE self) {
+static VALUE rb_mysql_client_socket(RB_MYSQL_UNUSED VALUE self) {
 #ifndef _WIN32
   GET_CLIENT(self);
   REQUIRE_CONNECTED(wrapper);

--- a/tasks/compile.rake
+++ b/tasks/compile.rake
@@ -86,3 +86,12 @@ else
     Rake::Task['cross'].prerequisites.unshift 'vendor:mysql:cross'
   end
 end
+
+desc "Build the windows binary gems per rake-compiler-dock"
+task 'gem:windows' do
+  require 'rake_compiler_dock'
+  RakeCompilerDock.sh <<-EOT
+    bundle install "--without=test benchmarks development rbx" &&
+    rake cross native gem
+  EOT
+end


### PR DESCRIPTION
[rake-compiler-dock](https://github.com/larskanis/rake-compiler-dock) makes building Windows gems faster and with little to no setup compared to [rake-compiler-dev-box](https://github.com/tjschuck/rake-compiler-dev-box). A simple 'rake gem:windows' is usually enough.

This also removes warning about unused variable in the Windows branch, that otherwise breaks the build.

The build of the mysql2 gem is successfully tested on Linux and Windows. I tested all resulting gems on RubyInstaller versions 2.1.4-x64, 2.2.1-x86 and 2.2.1-x64 on Windows-7.

The cross ruby versions used by gem:windows are not passed to the container, so the rake-compiler-dock's defaults are used, which are [defined here](https://github.com/larskanis/rake-compiler-dock/blob/master/Dockerfile#L113).
