### PR TITLE
Allow query options to be set on each Statement object

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,7 +23,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 125
+  Max: 128
 
 # Offense count: 3
 Metrics/CyclomaticComplexity:

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1341,11 +1341,11 @@ static VALUE initialize_ext(VALUE self) {
  *
  * Create a new prepared statement.
  */
-static VALUE rb_mysql_client_prepare_statement(VALUE self, VALUE sql) {
+static VALUE rb_mysql_prepare_statement(VALUE self, VALUE sql, VALUE options) {
   GET_CLIENT(self);
   REQUIRE_CONNECTED(wrapper);
 
-  return rb_mysql_stmt_new(self, sql);
+  return rb_mysql_stmt_new(self, sql, options);
 }
 
 void init_mysql2_client() {
@@ -1393,7 +1393,6 @@ void init_mysql2_client() {
   rb_define_method(cMysql2Client, "async_result", rb_mysql_client_async_result, 0);
   rb_define_method(cMysql2Client, "last_id", rb_mysql_client_last_id, 0);
   rb_define_method(cMysql2Client, "affected_rows", rb_mysql_client_affected_rows, 0);
-  rb_define_method(cMysql2Client, "prepare", rb_mysql_client_prepare_statement, 1);
   rb_define_method(cMysql2Client, "thread_id", rb_mysql_client_thread_id, 0);
   rb_define_method(cMysql2Client, "ping", rb_mysql_client_ping, 0);
   rb_define_method(cMysql2Client, "select_db", rb_mysql_client_select_db, 1);
@@ -1423,6 +1422,7 @@ void init_mysql2_client() {
   rb_define_private_method(cMysql2Client, "initialize_ext", initialize_ext, 0);
   rb_define_private_method(cMysql2Client, "connect", rb_mysql_connect, 8);
   rb_define_private_method(cMysql2Client, "_query", rb_mysql_query, 2);
+  rb_define_private_method(cMysql2Client, "_prepare", rb_mysql_prepare_statement, 2);
 
   sym_id              = ID2SYM(rb_intern("id"));
   sym_version         = ID2SYM(rb_intern("version"));

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -91,12 +91,13 @@ static void *nogvl_prepare_statement(void *ptr) {
   }
 }
 
-VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql) {
+VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql, VALUE options) {
   mysql_stmt_wrapper *stmt_wrapper;
   VALUE rb_stmt;
   rb_encoding *conn_enc;
 
   Check_Type(sql, T_STRING);
+  Check_Type(options, T_HASH);
 
   rb_stmt = Data_Make_Struct(cMysql2Statement, mysql_stmt_wrapper, rb_mysql_stmt_mark, rb_mysql_stmt_free, stmt_wrapper);
   {
@@ -105,6 +106,9 @@ VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql) {
     stmt_wrapper->closed = 0;
     stmt_wrapper->stmt = NULL;
   }
+
+  rb_obj_call_init(rb_stmt, 0, NULL);
+  rb_iv_set(rb_stmt, "@query_options", options);
 
   // instantiate stmt
   {
@@ -419,7 +423,7 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
     return Qnil;
   }
 
-  current = rb_hash_dup(rb_iv_get(stmt_wrapper->client, "@query_options"));
+  current = rb_iv_get(self, "@query_options");
   (void)RB_GC_GUARD(current);
   Check_Type(current, T_HASH);
 

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -108,7 +108,7 @@ VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql, VALUE options) {
   }
 
   rb_obj_call_init(rb_stmt, 0, NULL);
-  rb_iv_set(rb_stmt, "@query_options", options);
+  rb_iv_set(rb_stmt, "@query_options", rb_hash_dup(options));
 
   // instantiate stmt
   {

--- a/ext/mysql2/statement.h
+++ b/ext/mysql2/statement.h
@@ -13,7 +13,7 @@ typedef struct {
 void init_mysql2_statement(void);
 void decr_mysql2_stmt(mysql_stmt_wrapper *stmt_wrapper);
 
-VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql);
+VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql, VALUE options);
 void rb_raise_mysql2_stmt_error(mysql_stmt_wrapper *stmt_wrapper) RB_MYSQL_NORETURN;
 
 #endif

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -136,6 +136,10 @@ module Mysql2
       end
     end
 
+    def prepare(sql, options = {})
+      _prepare(sql, @query_options.merge(options))
+    end
+
     def query_info
       info = query_info_string
       return {} unless info

--- a/lib/mysql2/statement.rb
+++ b/lib/mysql2/statement.rb
@@ -2,6 +2,7 @@
 
 module Mysql2
   class Statement
+    attr_reader :query_options
     include Enumerable
 
     if Thread.respond_to?(:handle_interrupt)

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -241,7 +241,7 @@ RSpec.describe Mysql2::Statement do
       n = 1
       stmt = @client.prepare("SELECT 1 UNION SELECT 2")
 
-      @client.query_options.merge!(stream: true, cache_rows: false, as: :array)
+      stmt.query_options.merge!(stream: true, cache_rows: false, as: :array)
 
       stmt.execute.each do |r|
         case n

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -239,10 +239,7 @@ RSpec.describe Mysql2::Statement do
   context "streaming result" do
     it "should be able to stream query result" do
       n = 1
-      stmt = @client.prepare("SELECT 1 UNION SELECT 2")
-
-      stmt.query_options.merge!(stream: true, cache_rows: false, as: :array)
-
+      stmt = @client.prepare("SELECT 1 UNION SELECT 2", stream: true, cache_rows: false, as: :array)
       stmt.execute.each do |r|
         case n
         when 1
@@ -262,67 +259,55 @@ RSpec.describe Mysql2::Statement do
     #       The drawback of this is that args of Result#each is ignored...
 
     it "should yield rows as hash's" do
-      @result = @client.prepare("SELECT 1").execute
-      @result.each do |row|
+      result = @client.prepare("SELECT 1").execute
+      result.each do |row|
         expect(row).to be_an_instance_of(Hash)
       end
     end
 
     it "should yield rows as hash's with symbol keys if :symbolize_keys was set to true" do
-      @client.query_options[:symbolize_keys] = true
-      @result = @client.prepare("SELECT 1").execute
-      @result.each do |row|
+      result = @client.prepare("SELECT 1", symbolize_keys: true).execute
+      result.each do |row|
         expect(row.keys.first).to be_an_instance_of(Symbol)
       end
-      @client.query_options[:symbolize_keys] = false
+    end
+
+    it "should be able to return results as a hash" do
+      result = @client.prepare("SELECT 1", as: :hash).execute
+      result.each do |row|
+        expect(row).to be_an_instance_of(Hash)
+      end
     end
 
     it "should be able to return results as an array" do
-      @client.query_options[:as] = :array
-
-      @result = @client.prepare("SELECT 1").execute
-      @result.each do |row|
+      result = @client.prepare("SELECT 1", as: :array).execute
+      result.each do |row|
         expect(row).to be_an_instance_of(Array)
       end
-
-      @client.query_options[:as] = :hash
     end
 
     it "should cache previously yielded results by default" do
-      @result = @client.prepare("SELECT 1").execute
-      expect(@result.first.object_id).to eql(@result.first.object_id)
+      result = @client.prepare("SELECT 1").execute
+      expect(result.first.object_id).to eql(result.first.object_id)
     end
 
     it "should yield different value for #first if streaming" do
-      @client.query_options[:stream] = true
-      @client.query_options[:cache_rows] = false
-
-      result = @client.prepare("SELECT 1 UNION SELECT 2").execute
+      result = @client.prepare("SELECT 1 UNION SELECT 2", stream: true, cache_rows: false).execute
       expect(result.first).not_to eql(result.first)
-
-      @client.query_options[:stream] = false
-      @client.query_options[:cache_rows] = true
     end
 
     it "should yield the same value for #first if streaming is disabled" do
-      @client.query_options[:stream] = false
-      result = @client.prepare("SELECT 1 UNION SELECT 2").execute
+      result = @client.prepare("SELECT 1 UNION SELECT 2", stream: false).execute
       expect(result.first).to eql(result.first)
     end
 
     it "should throw an exception if we try to iterate twice when streaming is enabled" do
-      @client.query_options[:stream] = true
-      @client.query_options[:cache_rows] = false
-
-      result = @client.prepare("SELECT 1 UNION SELECT 2").execute
+      result = @client.prepare("SELECT 1 UNION SELECT 2", stream: true, cache_rows: false).execute
 
       expect do
         result.each {}
         result.each {}
       end.to raise_exception(Mysql2::Error)
-
-      @client.query_options[:stream] = false
-      @client.query_options[:cache_rows] = true
     end
   end
 


### PR DESCRIPTION
The original Prepared Statements API didn't provide a way to pass query options into the prepare or execute phase of a statement. Rather, you'd have to modify the query options on the Client object prior to each Statement#execute.

In this PR, I've added a query options argument to Client#prepare, analogous to Client#query, and save a copy of these options into the Statement object, to be used for each Statement#execute.

I sort of wish the options were on Statement#execute, but I can't think of any way to differentiate between "argument that is supposed to be a ? replacement" and "argument that is the options hash".
