### PR TITLE
Fix encoding if Mysql2#escape was nothing escaped

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -720,6 +720,11 @@ static VALUE rb_mysql_client_real_escape(VALUE self, VALUE str) {
   newLen = mysql_real_escape_string(wrapper->client, (char *)newStr, RSTRING_PTR(str), oldLen);
   if (newLen == oldLen) {
     /* no need to return a new ruby string if nothing changed */
+#ifdef HAVE_RUBY_ENCODING_H
+    if (default_internal_enc) {
+      str = rb_str_export_to_enc(str, default_internal_enc);
+    }
+#endif
     xfree(newStr);
     return str;
   } else {

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -703,6 +703,17 @@ RSpec.describe Mysql2::Client do
         @client.escape ""
       }.to raise_error(Mysql2::Error)
     end
+
+    context 'when mysql encoding is not utf8' do
+      let(:client) { Mysql2::Client.new(DatabaseCredentials['root'].merge(:encoding => "ujis")) }
+
+      it 'should return a internal encoding string if Encoding.default_internal is set' do
+        with_internal_encoding Encoding::UTF_8 do
+          expect(client.escape("\u{30C6}\u{30B9}\u{30C8}")).to eq "\u{30C6}\u{30B9}\u{30C8}"
+          expect(client.escape("\u{30C6}'\u{30B9}\"\u{30C8}")).to eq "\u{30C6}\\'\u{30B9}\\\"\u{30C8}"
+        end
+      end
+    end
   end
 
   it "should respond to #info" do

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -705,6 +705,8 @@ RSpec.describe Mysql2::Client do
     end
 
     context 'when mysql encoding is not utf8' do
+      before { pending('Encoding is undefined') unless defined?(Encoding) }
+
       let(:client) { Mysql2::Client.new(DatabaseCredentials['root'].merge(:encoding => "ujis")) }
 
       it 'should return a internal encoding string if Encoding.default_internal is set' do


### PR DESCRIPTION
If `Encoding.default_internal` and the mysql encoding is different, `Encoding::CompatibilityError` is raised when concatenating a escaped string and a not escaped string. Because of `Mysql2#escape` returns a different encoding according to the string is escaped or not.

This pull request changes this. `Mysql2#escape` returns the same encoding regardless of whether it has been escaped.
