### PR TITLE
Add CHANGELOG.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,1 @@
+Changes are maintained under [Releases](https://github.com/brianmario/mysql2/releases)


### PR DESCRIPTION
addresses #485 

I think it would be helpful to have an explicit pointer to the release notes. I know I check for a CHANGELOG first, and then the README. I went searching for changes from 3.19 and didn't find either a changelog or a reference in README. It took a while before I found this issue.