### PR TITLE
Uninitialized constant Mysql2::Client::Timeout

### DIFF
--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -80,8 +80,10 @@ module Mysql2
     end
 
     if Thread.respond_to?(:handle_interrupt)
+      require 'timeout'
+
       def query(sql, options = {})
-        Thread.handle_interrupt(Timeout::ExitException => :never) do
+        Thread.handle_interrupt(::Timeout::ExitException => :never) do
           _query(sql, @query_options.merge(options))
         end
       end


### PR DESCRIPTION
```
→ ruby -I ./lib -r mysql2 -e 'Mysql2::Client.new(host: "localhost", username: "root").query("")'
/home/cbandy/mysql2/lib/mysql2/client.rb:84:in `query': uninitialized constant Mysql2::Client::Timeout (NameError)
        from -e:1:in `<main>'
```

`Timeout` is part of stdlib and must be loaded before it can be used.