### PR TITLE
Test on ruby-head, allow failures

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -16,6 +16,7 @@ rvm:
   - 2.2
   - ree
   - rbx-2
+  - ruby-head
 matrix:
   include:
     - rvm: 2.0.0
@@ -30,3 +31,5 @@ matrix:
     - rvm: 2.0.0
       env: DB=mysql55
       os: osx
+  allow_failures:
+    - rvm: ruby-head


### PR DESCRIPTION
@tamird @cbandy The query timeout workaround is failing on the uninitialized constant Timeout::ExitException in ruby-head. I wonder if they renamed this upstream!? I'll be sorting through https://github.com/ruby/ruby/blob/trunk/lib/timeout.rb soon...

https://travis-ci.org/sodabrew/mysql2/jobs/79014190