### PR TITLE
Fix test that implicitly creates a passwordless user

### DIFF
--- a/spec/configuration.yml.example
+++ b/spec/configuration.yml.example
@@ -7,11 +7,11 @@ root:
 user:
   host: localhost
   username: LOCALUSERNAME
-  password:
+  password: test
   database: mysql2_test
 
 numericuser:
   host: localhost
   username: LOCALUSERNAME
-  password:
+  password: test
   database: 12345

--- a/spec/configuration.yml.example
+++ b/spec/configuration.yml.example
@@ -3,15 +3,3 @@ root:
   username: root
   password:
   database: test
-
-user:
-  host: localhost
-  username: LOCALUSERNAME
-  password: test
-  database: mysql2_test
-
-numericuser:
-  host: localhost
-  username: LOCALUSERNAME
-  password: test
-  database: 12345

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -211,13 +211,13 @@ RSpec.describe Mysql2::Client do
   end
 
   it "should be able to connect to database with numeric-only name" do
-    creds = DatabaseCredentials['numericuser']
-    @client.query "CREATE DATABASE IF NOT EXISTS `#{creds['database']}`"
-    @client.query "GRANT ALL ON `#{creds['database']}`.* TO #{creds['username']}@`#{creds['host']}` IDENTIFIED BY '#{creds['password']}'"
+    creds = DatabaseCredentials['root']
+    @client.query "CREATE DATABASE IF NOT EXISTS `12345`"
+    @client.query "GRANT ALL ON `12345`.* TO #{creds['username']}@`#{creds['host']}`"
 
     expect { Mysql2::Client.new(creds) }.not_to raise_error
 
-    @client.query "DROP DATABASE IF EXISTS `#{creds['database']}`"
+    @client.query "DROP DATABASE IF EXISTS `12345`"
   end
 
   it "should respond to #close" do

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -213,7 +213,7 @@ RSpec.describe Mysql2::Client do
   it "should be able to connect to database with numeric-only name" do
     creds = DatabaseCredentials['numericuser']
     @client.query "CREATE DATABASE IF NOT EXISTS `#{creds['database']}`"
-    @client.query "GRANT ALL ON `#{creds['database']}`.* TO #{creds['username']}@`#{creds['host']}`"
+    @client.query "GRANT ALL ON `#{creds['database']}`.* TO #{creds['username']}@`#{creds['host']}` IDENTIFIED BY '#{creds['password']}'"
 
     expect { Mysql2::Client.new(creds) }.not_to raise_error
 


### PR DESCRIPTION
When the MySQL server has `NO_AUTO_CREATE_USER`, a GRANT can't implicitly
create a user unless a password is specified. To fix, just provide a
dummy password in the example db config and update the GRANT.