### PR TITLE
Fix missing 'end' and hidden failing specs

### DIFF
--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -83,6 +83,7 @@ RSpec.describe Mysql2::Statement do
       result = statement.execute
       expect(result.to_a.length).to eq(1)
     end
+  end
 
   it "should handle comparisons and likes" do
     @client.query 'USE test'
@@ -90,11 +91,11 @@ RSpec.describe Mysql2::Statement do
     @client.query 'INSERT INTO mysql2_stmt_q (a, b) VALUES (1, "Hello"), (2, "World")'
     statement = @client.prepare 'SELECT * FROM mysql2_stmt_q WHERE a < ?'
     results = statement.execute(2)
-    results.first.should == {"a" => 1, "b" => "Hello"}
+    expect(results.first).to eq("a" => 1, "b" => "Hello")
 
     statement = @client.prepare 'SELECT * FROM mysql2_stmt_q WHERE b LIKE ?'
     results = statement.execute('%orld')
-    results.first.should == {"a" => 2, "b" => "World"}
+    expect(results.first).to eq("a" => 2, "b" => "World")
 
     @client.query 'DROP TABLE IF EXISTS mysql2_stmt_q'
   end


### PR DESCRIPTION
Not sure how this worked before. Perhaps masked by rspec runner?

Also fixes the failing spec it exposed.