### PR TITLE
Mysql2::Statement#last_id and #affected_rows

### DIFF
--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -430,6 +430,33 @@ static VALUE fields(VALUE self) {
   return field_list;
 }
 
+/* call-seq:
+ *    stmt.last_id
+ *
+ * Returns the AUTO_INCREMENT value from the executed INSERT or UPDATE.
+ */
+static VALUE rb_mysql_stmt_last_id(VALUE self) {
+  GET_STATEMENT(self);
+  return ULL2NUM(mysql_stmt_insert_id(stmt_wrapper->stmt));
+}
+
+/* call-seq:
+ *    stmt.affected_rows
+ *
+ * Returns the number of rows changed, deleted, or inserted.
+ */
+static VALUE rb_mysql_stmt_affected_rows(VALUE self) {
+  my_ulonglong affected;
+  GET_STATEMENT(self);
+
+  affected = mysql_stmt_affected_rows(stmt_wrapper->stmt);
+  if (affected == (my_ulonglong)-1) {
+    rb_raise_mysql2_stmt_error(self);
+  }
+
+  return ULL2NUM(affected);
+}
+
 void init_mysql2_statement() {
   cMysql2Statement = rb_define_class_under(mMysql2, "Statement", rb_cObject);
 
@@ -437,6 +464,8 @@ void init_mysql2_statement() {
   rb_define_method(cMysql2Statement, "field_count", field_count, 0);
   rb_define_method(cMysql2Statement, "execute", execute, -1);
   rb_define_method(cMysql2Statement, "fields", fields, 0);
+  rb_define_method(cMysql2Statement, "last_id", rb_mysql_stmt_last_id, 0);
+  rb_define_method(cMysql2Statement, "affected_rows", rb_mysql_stmt_affected_rows, 0);
 
   sym_stream = ID2SYM(rb_intern("stream"));
 

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -595,4 +595,62 @@ RSpec.describe Mysql2::Statement do
       end
     end
   end
+
+  context 'last_id' do
+    before(:each) do
+      @client.query "USE test"
+      @client.query "CREATE TABLE IF NOT EXISTS lastIdTest (`id` BIGINT NOT NULL AUTO_INCREMENT, blah INT(11), PRIMARY KEY (`id`))"
+    end
+
+    after(:each) do
+      @client.query "DROP TABLE lastIdTest"
+    end
+
+    it 'should return last insert id' do
+      stmt = @client.prepare 'INSERT INTO lastIdTest (blah) VALUES (?)'
+      expect(stmt.last_id).to eq 0
+      stmt.execute 1
+      expect(stmt.last_id).to eq 1
+    end
+
+    it 'should handle bigint ids' do
+      stmt = @client.prepare 'INSERT INTO lastIdTest (id, blah) VALUES (?, ?)'
+      stmt.execute 5000000000, 5000
+      expect(stmt.last_id).to eql(5000000000)
+
+      stmt = @client.prepare 'INSERT INTO lastIdTest (blah) VALUES (?)'
+      stmt.execute 5001
+      expect(stmt.last_id).to eql(5000000001)
+    end
+  end
+
+  context 'affected_rows' do
+    before :each do
+      @client.query 'DELETE FROM mysql2_test'
+      @client.query 'INSERT INTO mysql2_test (bool_cast_test) VALUES (1)'
+    end
+
+    after :each do
+      @client.query 'DELETE FROM mysql2_test'
+    end
+
+    it 'should return number of rows affected by an insert' do
+      stmt = @client.prepare 'INSERT INTO mysql2_test (bool_cast_test) VALUES (?)'
+      expect(stmt.affected_rows).to eq 0
+      stmt.execute 1
+      expect(stmt.affected_rows).to eq 1
+    end
+
+    it 'should return number of rows affected by an update' do
+      stmt = @client.prepare 'UPDATE mysql2_test SET bool_cast_test=? WHERE bool_cast_test=?'
+      stmt.execute 0, 1
+      expect(stmt.affected_rows).to eq 1
+    end
+
+    it 'should return number of rows affected by a delete' do
+      stmt = @client.prepare 'DELETE FROM mysql2_test WHERE bool_cast_test=?'
+      stmt.execute 1
+      expect(stmt.affected_rows).to eq 1
+    end
+  end
 end


### PR DESCRIPTION
* `Mysql2::Statement#last_id` for prepared inserts:
```ruby
insert = client.prepare('insert into t (foo) values (?)')
ids = values.map { insert.execute(1); insert.last_id }
```
* `Mysql2::Statement#affected_rows` for prepared inserts, updates, and deletes:
```ruby
update = client.prepare('update t set foo=? where id=?')
update.execute 1, 1234
update.affected_rows == 1
```