### PR TITLE
Support prepared_statement.close

### DIFF
--- a/ext/mysql2/statement.h
+++ b/ext/mysql2/statement.h
@@ -6,6 +6,7 @@ extern VALUE cMysql2Statement;
 typedef struct {
   VALUE client;
   MYSQL_STMT *stmt;
+  int closed;
   int refcount;
 } mysql_stmt_wrapper;
 

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -664,4 +664,17 @@ RSpec.describe Mysql2::Statement do
       expect(stmt.affected_rows).to eq 1
     end
   end
+
+  context 'close' do
+    it 'should free server resources' do
+      stmt = @client.prepare 'SELECT 1'
+      expect(stmt.close).to eq nil
+    end
+
+    it 'should raise an error on subsequent execution' do
+      stmt = @client.prepare 'SELECT 1'
+      stmt.close
+      expect { stmt.execute }.to raise_error(Mysql2::Error)
+    end
+  end
 end


### PR DESCRIPTION
Useful when caching prepared statements. Evicted statements can release
server resources immediately rather than waiting for Ruby GC.