### PR TITLE
Replace `Timeout::ExitException` with `Timeout::Error`

### DIFF
--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -83,7 +83,7 @@ module Mysql2
       require 'timeout'
 
       def query(sql, options = {})
-        Thread.handle_interrupt(::Timeout::ExitException => :never) do
+        Thread.handle_interrupt(::Timeout::Error => :never) do
           _query(sql, @query_options.merge(options))
         end
       end


### PR DESCRIPTION
ruby 2.3.0 will not support `Timeout::ExitException`,
so replace it.

https://github.com/ruby/ruby/commit/0f663b244944c5eb2b6c7d0862c15c377747df05