### PR TITLE
Only do library version check in Windows environment

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1215,6 +1215,7 @@ static VALUE rb_mysql_client_prepare_statement(VALUE self, VALUE sql) {
 }
 
 void init_mysql2_client() {
+#ifdef _WIN32
   /* verify the libmysql we're about to use was the version we were built against
      https://github.com/luislavena/mysql-gem/commit/a600a9c459597da0712f70f43736e24b484f8a99 */
   int i;
@@ -1232,6 +1233,7 @@ void init_mysql2_client() {
       return;
     }
   }
+#endif
 
   /* Initializing mysql library, so different threads could call Client.new */
   /* without race condition in the library */


### PR DESCRIPTION
Unix systems using libtool do not need to do a version check against the
client version string as the libraries themselves are versioned:

libmysqlclient.so.14 = MySQL 4.1
libmysqlclient.so.15 = MySQL 5.0
libmysqlclient.so.16 = MySQL 5.1
libmysqlclient.so.18 = MySQL 5.5/5.6
libmysqlclient.so.20 = MySQL 5.7

The current test causes failures when attempting to use MariaDB with packages that were built against MySQL (libmysqlclient.so.16 and MySQL 5.1, but MariaDB advertises as 5.3 in the same so.16 library).  Same will  happen with MySQL 5.5/5.6 which use the same .so.18 libtool versioned library.

Libtool versioning should prevent the library version failure scenarios that this test is checking for...it appears to have been added specifically for Windows clients where the DLLs are not versioned.  This change limits this version test to the Windows platform.