### PR TITLE
Close connection during garbage collection

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1112,7 +1112,7 @@ static VALUE set_automatic_close(VALUE self, VALUE value) {
 #ifndef _WIN32
     wrapper->automatic_close = 0;
 #else
-    rb_raise(cMysql2Error, "Connections are always closed by garbage collector on Windows");
+    rb_warn("Connections are always closed by garbage collector on Windows");
 #endif
   }
   return value;

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -233,7 +233,7 @@ void decr_mysql2_client(mysql_client_wrapper *wrapper)
 
   if (wrapper->refcount == 0) {
 #ifndef _WIN32
-    if (wrapper->connected) {
+    if (wrapper->connected && !wrapper->automatic_close) {
       /* The client is being garbage collected while connected. Prevent
        * mysql_close() from sending a mysql-QUIT or from calling shutdown() on
        * the socket by invalidating it. invalidate_fd() will drop this
@@ -260,6 +260,11 @@ static VALUE allocate(VALUE klass) {
   obj = Data_Make_Struct(klass, mysql_client_wrapper, rb_mysql_client_mark, rb_mysql_client_free, wrapper);
   wrapper->encoding = Qnil;
   MARK_CONN_INACTIVE(self);
+#ifndef _WIN32
+  wrapper->automatic_close = 0;
+#else
+  wrapper->automatic_close = 1;
+#endif
   wrapper->server_version = 0;
   wrapper->reconnect_enabled = 0;
   wrapper->connect_timeout = 0;
@@ -382,12 +387,9 @@ static VALUE rb_connect(VALUE self, VALUE user, VALUE pass, VALUE host, VALUE po
 
 /*
  * Terminate the connection; call this when the connection is no longer needed.
- * The garbage collector can close the connection, but doing so emits an
- * "Aborted connection" error on the server and increments the Aborted_clients
- * status variable.
+ * To have the garbage collector close the connection, enable +automatic_close+.
  *
- * @see http://dev.mysql.com/doc/en/communication-errors.html
- * @return [void]
+ * @return [nil]
  */
 static VALUE rb_mysql_client_close(VALUE self) {
   GET_CLIENT(self);
@@ -1086,6 +1088,35 @@ static VALUE rb_mysql_client_encoding(VALUE self) {
 #endif
 
 /* call-seq:
+ *    client.automatic_close?
+ *
+ * @return [Boolean]
+ */
+static VALUE get_automatic_close(VALUE self) {
+  GET_CLIENT(self);
+  return wrapper->automatic_close ? Qtrue : Qfalse;
+}
+
+/* call-seq:
+ *    client.automatic_close = true
+ *
+ * Set this to +true+ to let the garbage collector close this connection.
+ */
+static VALUE set_automatic_close(VALUE self, VALUE value) {
+  GET_CLIENT(self);
+  if (RTEST(value)) {
+    wrapper->automatic_close = 1;
+  } else {
+#ifndef _WIN32
+    wrapper->automatic_close = 0;
+#else
+    rb_raise(cMysql2Error, "Connections are always closed by garbage collector on Windows");
+#endif
+  }
+  return value;
+}
+
+/* call-seq:
  *    client.reconnect = true
  *
  * Enable or disable the automatic reconnect behavior of libmysql.
@@ -1268,6 +1299,8 @@ void init_mysql2_client() {
   rb_define_method(cMysql2Client, "more_results?", rb_mysql_client_more_results, 0);
   rb_define_method(cMysql2Client, "next_result", rb_mysql_client_next_result, 0);
   rb_define_method(cMysql2Client, "store_result", rb_mysql_client_store_result, 0);
+  rb_define_method(cMysql2Client, "automatic_close?", get_automatic_close, 0);
+  rb_define_method(cMysql2Client, "automatic_close=", set_automatic_close, 1);
   rb_define_method(cMysql2Client, "reconnect=", set_reconnect, 1);
   rb_define_method(cMysql2Client, "warning_count", rb_mysql_client_warning_count, 0);
   rb_define_method(cMysql2Client, "query_info_string", rb_mysql_info, 0);

--- a/ext/mysql2/client.h
+++ b/ext/mysql2/client.h
@@ -43,6 +43,7 @@ typedef struct {
   int reconnect_enabled;
   unsigned int connect_timeout;
   int active;
+  int automatic_close;
   int connected;
   int initialized;
   int refcount;

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -30,10 +30,10 @@ module Mysql2
       opts[:connect_timeout] = 120 unless opts.key?(:connect_timeout)
 
       # TODO: stricter validation rather than silent massaging
-      [:reconnect, :connect_timeout, :local_infile, :read_timeout, :write_timeout, :default_file, :default_group, :secure_auth, :init_command].each do |key|
+      [:reconnect, :connect_timeout, :local_infile, :read_timeout, :write_timeout, :default_file, :default_group, :secure_auth, :init_command, :automatic_close].each do |key|
         next unless opts.key?(key)
         case key
-        when :reconnect, :local_infile, :secure_auth
+        when :reconnect, :local_infile, :secure_auth, :automatic_close
           send(:"#{key}=", !!opts[key]) # rubocop:disable Style/DoubleNegation
         when :connect_timeout, :read_timeout, :write_timeout
           send(:"#{key}=", opts[key].to_i)

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,6 +90,5 @@ RSpec.configure do |config|
         "test", "test", 'val1', 'val1,val2'
       )
     ]
-    client.close
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,5 +90,6 @@ RSpec.configure do |config|
         "test", "test", 'val1', 'val1,val2'
       )
     ]
+    client.close
   end
 end


### PR DESCRIPTION
Restores the behavior of v0.3.15 which sends `QUIT` during garbage collection. Keep the behavior in #463 behind a new connection option, `automatic_close`.

Relates to #606.