### PR TITLE
Avoid crashing when Statement#close is called before a Result is collected

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -133,7 +133,7 @@ static VALUE rb_raise_mysql2_error(mysql_client_wrapper *wrapper) {
 
 static void *nogvl_init(void *ptr) {
   MYSQL *client;
-  mysql_client_wrapper *wrapper = (mysql_client_wrapper *)ptr;
+  mysql_client_wrapper *wrapper = ptr;
 
   /* may initialize embedded server and read /etc/services off disk */
   client = mysql_init(wrapper->client);
@@ -224,7 +224,7 @@ static void *nogvl_close(void *ptr) {
 
 /* this is called during GC */
 static void rb_mysql_client_free(void *ptr) {
-  mysql_client_wrapper *wrapper = (mysql_client_wrapper *)ptr;
+  mysql_client_wrapper *wrapper = ptr;
   decr_mysql2_client(wrapper);
 }
 
@@ -437,10 +437,9 @@ static void *nogvl_read_query_result(void *ptr) {
 }
 
 static void *nogvl_do_result(void *ptr, char use_result) {
-  mysql_client_wrapper *wrapper;
+  mysql_client_wrapper *wrapper = ptr;
   MYSQL_RES *result;
 
-  wrapper = (mysql_client_wrapper *)ptr;
   if (use_result) {
     result = mysql_use_result(wrapper->client);
   } else {
@@ -533,14 +532,13 @@ static VALUE disconnect_and_raise(VALUE self, VALUE error) {
 }
 
 static VALUE do_query(void *args) {
-  struct async_query_args *async_args;
+  struct async_query_args *async_args = args;
   struct timeval tv;
   struct timeval* tvp;
   long int sec;
   int retval;
   VALUE read_timeout;
 
-  async_args = (struct async_query_args *)args;
   read_timeout = rb_iv_get(async_args->self, "@read_timeout");
 
   tvp = NULL;
@@ -578,10 +576,8 @@ static VALUE do_query(void *args) {
 }
 #else
 static VALUE finish_and_mark_inactive(void *args) {
-  VALUE self;
+  VALUE self = args;
   MYSQL_RES *result;
-
-  self = (VALUE)args;
 
   GET_CLIENT(self);
 

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -534,7 +534,7 @@ static VALUE disconnect_and_raise(VALUE self, VALUE error) {
 static VALUE do_query(void *args) {
   struct async_query_args *async_args = args;
   struct timeval tv;
-  struct timeval* tvp;
+  struct timeval *tvp;
   long int sec;
   int retval;
   VALUE read_timeout;

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -13,7 +13,7 @@ static VALUE intern_usec, intern_sec, intern_min, intern_hour, intern_day, inter
 
 
 static void rb_mysql_stmt_mark(void * ptr) {
-  mysql_stmt_wrapper* stmt_wrapper = ptr;
+  mysql_stmt_wrapper *stmt_wrapper = ptr;
   if (!stmt_wrapper) return;
 
   rb_gc_mark(stmt_wrapper->client);
@@ -29,7 +29,7 @@ static void *nogvl_stmt_close(void * ptr) {
 }
 
 static void rb_mysql_stmt_free(void * ptr) {
-  mysql_stmt_wrapper* stmt_wrapper = ptr;
+  mysql_stmt_wrapper *stmt_wrapper = ptr;
   decr_mysql2_stmt(stmt_wrapper);
 }
 
@@ -94,7 +94,7 @@ static void *nogvl_prepare_statement(void *ptr) {
 }
 
 VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql) {
-  mysql_stmt_wrapper* stmt_wrapper;
+  mysql_stmt_wrapper *stmt_wrapper;
   VALUE rb_stmt;
 #ifdef HAVE_RUBY_ENCODING_H
   rb_encoding *conn_enc;

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -13,14 +13,14 @@ static VALUE intern_usec, intern_sec, intern_min, intern_hour, intern_day, inter
 
 
 static void rb_mysql_stmt_mark(void * ptr) {
-  mysql_stmt_wrapper* stmt_wrapper = (mysql_stmt_wrapper *)ptr;
+  mysql_stmt_wrapper* stmt_wrapper = ptr;
   if (!stmt_wrapper) return;
 
   rb_gc_mark(stmt_wrapper->client);
 }
 
 static void *nogvl_stmt_close(void * ptr) {
-  mysql_stmt_wrapper *stmt_wrapper = (mysql_stmt_wrapper *)ptr;
+  mysql_stmt_wrapper *stmt_wrapper = ptr;
   if (stmt_wrapper->stmt) {
     mysql_stmt_close(stmt_wrapper->stmt);
     stmt_wrapper->stmt = NULL;
@@ -29,7 +29,7 @@ static void *nogvl_stmt_close(void * ptr) {
 }
 
 static void rb_mysql_stmt_free(void * ptr) {
-  mysql_stmt_wrapper* stmt_wrapper = (mysql_stmt_wrapper *)ptr;
+  mysql_stmt_wrapper* stmt_wrapper = ptr;
   decr_mysql2_stmt(stmt_wrapper);
 }
 

--- a/ext/mysql2/statement.h
+++ b/ext/mysql2/statement.h
@@ -7,6 +7,7 @@ typedef struct {
   VALUE client;
   MYSQL_STMT *stmt;
   int refcount;
+  int closed;
 } mysql_stmt_wrapper;
 
 void init_mysql2_statement(void);


### PR DESCRIPTION
Alternative to #692 / Resolves #690 

I found that you can call `mysql_stmt_close` first, without calling `mysql_stmt_result_free`, however you must not later call `mysql_stmt_result_free`. 