### PR TITLE
fix memory leak on connection close

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -213,6 +213,7 @@ static void *nogvl_close(void *ptr) {
 
   if (wrapper->client) {
     mysql_close(wrapper->client);
+    xfree(wrapper->client);
     wrapper->client = NULL;
     wrapper->connected = 0;
     wrapper->active_thread = Qnil;


### PR DESCRIPTION
It looks like when you call `close` on a connection, it closes the
connection but doesn't free the memory allocated for the connection.
Since the pointed gets nulled out, the GC free function doesn't have a
pointer to free.

Fixes #701 

I suspect there is still a possible race condition with the refcount thing, but I can't prove it yet.  However, this seems to plug the hole for #701.