### PR TITLE
Allow nil for timeouts instead of casting to zero

### DIFF
--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -36,7 +36,7 @@ module Mysql2
         when :reconnect, :local_infile, :secure_auth
           send(:"#{key}=", !!opts[key]) # rubocop:disable Style/DoubleNegation
         when :connect_timeout, :read_timeout, :write_timeout
-          send(:"#{key}=", opts[key].to_i)
+          send(:"#{key}=", opts[key]) unless opts[key].nil?
         else
           send(:"#{key}=", opts[key])
         end

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -352,6 +352,12 @@ RSpec.describe Mysql2::Client do
     }.to raise_error(Mysql2::Error)
   end
 
+  it "should allow nil read_timeout" do
+    client = Mysql2::Client.new(:read_timeout => nil)
+
+    expect(client.read_timeout).to be_nil
+  end
+
   context "#query" do
     it "should let you query again if iterating is finished when streaming" do
       @client.query("SELECT 1 UNION SELECT 2", :stream => true, :cache_rows => false).each.to_a


### PR DESCRIPTION
The only problem I can see is that the default `connect_timeout` would not be used if set to nil in the `opts`.