### PR TITLE
Apply the use `Thread.handle_interrupt` to protect `query` fix to the 0.3.x branch

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1259,7 +1259,6 @@ void init_mysql2_client() {
   rb_define_singleton_method(cMysql2Client, "info", rb_mysql_client_info, 0);
 
   rb_define_method(cMysql2Client, "close", rb_mysql_client_close, 0);
-  rb_define_method(cMysql2Client, "query", rb_mysql_client_query, -1);
   rb_define_method(cMysql2Client, "abandon_results!", rb_mysql_client_abandon_results, 0);
   rb_define_method(cMysql2Client, "escape", rb_mysql_client_real_escape, 1);
   rb_define_method(cMysql2Client, "server_info", rb_mysql_client_server_info, 0);
@@ -1280,6 +1279,7 @@ void init_mysql2_client() {
   rb_define_method(cMysql2Client, "encoding", rb_mysql_client_encoding, 0);
 #endif
 
+  rb_define_private_method(cMysql2Client, "_query", rb_mysql_client_query, -1);
   rb_define_private_method(cMysql2Client, "connect_timeout=", set_connect_timeout, 1);
   rb_define_private_method(cMysql2Client, "read_timeout=", set_read_timeout, 1);
   rb_define_private_method(cMysql2Client, "write_timeout=", set_write_timeout, 1);

--- a/lib/mysql2.rb
+++ b/lib/mysql2.rb
@@ -61,4 +61,21 @@ module Mysql2::Util
     Hash[hash.map { |k,v| [k.to_sym, v] }]
   end
 
+  #
+  # In Mysql2::Client#query and Mysql2::Statement#execute,
+  # Thread#handle_interrupt is used to prevent Timeout#timeout
+  # from interrupting query execution.
+  #
+  # Timeout::ExitException was removed in Ruby 2.3.0, 2.2.3, and 2.1.8,
+  # but is present in earlier 2.1.x and 2.2.x, so we provide a shim.
+  #
+  if Thread.respond_to?(:handle_interrupt)
+    require 'timeout'
+    # rubocop:disable Style/ConstantName
+    TimeoutError = if defined?(::Timeout::ExitException)
+      ::Timeout::ExitException
+    else
+      ::Timeout::Error
+    end
+  end
 end

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -74,6 +74,18 @@ module Mysql2
       @@default_query_options
     end
 
+    if Thread.respond_to?(:handle_interrupt)
+      def query(sql, options = {})
+        Thread.handle_interrupt(::Mysql2::Util::TimeoutError => :never) do
+          _query(sql, @query_options.merge(options))
+        end
+      end
+    else
+      def query(sql, options = {})
+        _query(sql, @query_options.merge(options))
+      end
+    end
+
     def query_info
       info = query_info_string
       return {} unless info


### PR DESCRIPTION
This is to back port of @tamird's #592 to the `0.3.x` branch.

I recently came across the issue, `This connection is still waiting for a result, try again once you have the result`. I am running Ruby 2.2.4, Rails 3.2.22, Mysql2 0.3.20, and MySQL 5.6. I came across issues #99 and #566. These led me to PR #592. I saw that the fix was applied to `master` (`0.4.x`), but not to `0.3.x`. This change was able to solve the problem that I was experiencing. I was wondering why the fix was not applied to the `0.3.x` branch?