### PR TITLE
Fix some tests for non-default creds

### DIFF
--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -382,24 +382,24 @@ RSpec.describe Mysql2::Client do
 
   it "should expect connect_timeout to be a positive integer" do
     expect {
-      Mysql2::Client.new(:connect_timeout => -1)
+      Mysql2::Client.new(DatabaseCredentials['root'].merge(:connect_timeout => -1))
     }.to raise_error(Mysql2::Error)
   end
 
   it "should expect read_timeout to be a positive integer" do
     expect {
-      Mysql2::Client.new(:read_timeout => -1)
+      Mysql2::Client.new(DatabaseCredentials['root'].merge(:read_timeout => -1))
     }.to raise_error(Mysql2::Error)
   end
 
   it "should expect write_timeout to be a positive integer" do
     expect {
-      Mysql2::Client.new(:write_timeout => -1)
+      Mysql2::Client.new(DatabaseCredentials['root'].merge(:write_timeout => -1))
     }.to raise_error(Mysql2::Error)
   end
 
   it "should allow nil read_timeout" do
-    client = Mysql2::Client.new(:read_timeout => nil)
+    client = Mysql2::Client.new(DatabaseCredentials['root'].merge(:read_timeout => nil))
 
     expect(client.read_timeout).to be_nil
   end


### PR DESCRIPTION
In these cases the database credentials from `spec/configuration.yml` was not being used, so if the credentials differed from the default credentials, there would be a connection error. The first three wouldn't cause a failing test though, because a connection error throws a `Mysql2::Error`.

This is how it (currently) looks before being fixed:
```
  1) Mysql2::Client should allow nil read_timeout
     Failure/Error: connect user, pass, host, port, database, socket, flags
     
     Mysql2::Error:
       Access denied for user 'vagrant'@'localhost' (using password: NO)
     # ./lib/mysql2/client.rb:87:in `connect'
     # ./lib/mysql2/client.rb:87:in `initialize'
     # ./spec/mysql2/client_spec.rb:402:in `new'
     # ./spec/mysql2/client_spec.rb:402:in `block (2 levels) in <top (required)>'
```
(vagrant is the user running the test, but not the user specified in `spec/configuration.yml` for the mysql database)