### PR TITLE
Fix segv when num of rows is zero

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -913,7 +913,7 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
     app_timezone = Qnil;
   }
 
-  if (wrapper->lastRowProcessed == 0 && !wrapper->is_streaming) {
+  if (wrapper->rows == Qnil && !wrapper->is_streaming) {
     wrapper->numberOfRows = wrapper->stmt_wrapper ? mysql_stmt_num_rows(wrapper->stmt_wrapper->stmt) : mysql_num_rows(wrapper->result);
     if (wrapper->numberOfRows == 0) {
       rb_mysql_result_free_result(wrapper);

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -346,14 +346,14 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
   conn_enc = rb_to_encoding(wrapper->encoding);
 #endif
 
+  if (wrapper->fields == Qnil) {
+    wrapper->numberOfFields = mysql_num_fields(wrapper->result);
+    wrapper->fields = rb_ary_new2(wrapper->numberOfFields);
+  }
   if (args->asArray) {
     rowVal = rb_ary_new2(wrapper->numberOfFields);
   } else {
     rowVal = rb_hash_new();
-  }
-  if (wrapper->fields == Qnil) {
-    wrapper->numberOfFields = mysql_num_fields(wrapper->result);
-    wrapper->fields = rb_ary_new2(wrapper->numberOfFields);
   }
 
   if (wrapper->result_buffers == NULL) {
@@ -541,16 +541,16 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
     return Qnil;
   }
 
+  if (wrapper->fields == Qnil) {
+    wrapper->numberOfFields = mysql_num_fields(wrapper->result);
+    wrapper->fields = rb_ary_new2(wrapper->numberOfFields);
+  }
   if (args->asArray) {
     rowVal = rb_ary_new2(wrapper->numberOfFields);
   } else {
     rowVal = rb_hash_new();
   }
   fieldLengths = mysql_fetch_lengths(wrapper->result);
-  if (wrapper->fields == Qnil) {
-    wrapper->numberOfFields = mysql_num_fields(wrapper->result);
-    wrapper->fields = rb_ary_new2(wrapper->numberOfFields);
-  }
 
   for (i = 0; i < wrapper->numberOfFields; i++) {
     VALUE field = rb_mysql_result_fetch_field(self, i, args->symbolizeKeys);
@@ -915,11 +915,6 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
 
   if (wrapper->rows == Qnil && !wrapper->is_streaming) {
     wrapper->numberOfRows = wrapper->stmt_wrapper ? mysql_stmt_num_rows(wrapper->stmt_wrapper->stmt) : mysql_num_rows(wrapper->result);
-    if (wrapper->numberOfRows == 0) {
-      rb_mysql_result_free_result(wrapper);
-      wrapper->rows = rb_ary_new();
-      return wrapper->rows;
-    }
     wrapper->rows = rb_ary_new2(wrapper->numberOfRows);
   }
 


### PR DESCRIPTION
Fixes #736, #738.

Sorry for my wrong commit. It caused by 5189cfe when num of rows is zero.

Current code has 2 problems.

First one, `numberOfRows ==  0` and `lastRowProcessed == 0` are valid result when result rows is zero.
We should use the condition `wrapper->rows == Qnil` instead.

Second one, we should initialize `fields` before `rb_mysql_result_free_result` even if result rows is zero.
Otherwise the following code causes segv:

```ruby
require 'mysql2'

client = Mysql2::Client.new(
  host: 'localhost',
  username: 'root',
  database: 'mysql',
)

5000.times do |n|
  puts n
  result = client.query('SELECT * FROM user WHERE 1=0 LIMIT 0')
  result.to_a
  result.fields
end
```