### PR TITLE
Fix 0.3.x segfault for :cache_rows => false

### DIFF
--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -78,6 +78,11 @@ describe Mysql2::Result do
       result.first.object_id.should_not eql(result.first.object_id)
     end
 
+    it "should be able to iterate a second time even if cache_rows is disabled" do
+      result = @client.query "SELECT 1 UNION SELECT 2", :cache_rows => false
+      result.to_a.should eql(result.to_a)
+    end
+
     it "should yield different value for #first if streaming" do
       result = @client.query "SELECT 1 UNION SELECT 2", :stream => true, :cache_rows => false
       result.first.should_not eql(result.first)


### PR DESCRIPTION
This fixes #691.

I managed to reproduce the segfault with the following code (note: the `SELECT` just returns the numbers 1..10000).

```ruby
require 'mysql2'                                                                   
                                                                                   
client = Mysql2::Client.new(:host => "localhost", :username => "vagrant", :database => "test")
                                                                                   
results = client.query("SELECT @row := @row + 1 as row FROM " \                    
"(select 0 union all select 1 union all select 3 union all select 4 union all select 5 union all select 6 union all select 6 union all select 7 union all select 8 union all select 9) t, "\
"(select 0 union all select 1 union all select 3 union all select 4 union all select 5 union all select 6 union all select 6 union all select 7 union all select 8 union all select 9) t2, "\
"(select 0 union all select 1 union all select 3 union all select 4 union all select 5 union all select 6 union all select 6 union all select 7 union all select 8 union all select 9) t3, "\
"(select 0 union all select 1 union all select 3 union all select 4 union all select 5 union all select 6 union all select 6 union all select 7 union all select 8 union all select 9) t4, "\
"(SELECT @row:=0) as f", :cache_rows => false)                                     
                                                                                   
puts results.to_a.length                                                           
puts results.to_a.length                                                           
puts results.to_a.length                                                           
puts results.to_a.length                                                           
puts results.to_a.length                                                           
puts results.to_a.length                                                           
puts results.to_a.length                                                           
puts results.to_a.length                                                           
puts results.to_a.length                                                           
puts results.to_a.length                                                           
puts results.to_a.length  
```

(Yes, the repeated `to_a` and large `SELECT` appear to be necessary, I'm not entirely sure why.)

The segfault is related to `wrapper->lastRowProcessed` not being set back to 0 when we free the mysql result. (Thus causing issues with future calls of `#each`.) I'm not sure what the direct cause is, (and it's very late at night and I can't reason about code very well at the moment). This seems to fix it, and I'll take another look tomorrow.