### PR TITLE
Disallow iterating results multiple times with false :cache_rows

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -815,6 +815,8 @@ static VALUE rb_mysql_result_each_(VALUE self,
       for (i = 0; i < wrapper->numberOfRows; i++) {
         rb_yield(rb_ary_entry(wrapper->rows, i));
       }
+    } else if (!args->cacheRows && wrapper->lastRowProcessed == wrapper->numberOfRows) {
+      rb_raise(cMysql2Error, "You have already fetched all the rows for this query and cache_rows is false. (to reiterate you must requery).");
     } else {
       unsigned long rowsProcessed = 0;
       rowsProcessed = RARRAY_LEN(wrapper->rows);

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -100,6 +100,15 @@ RSpec.describe Mysql2::Result do
         result.each.to_a
       }.to raise_exception(Mysql2::Error)
     end
+
+    it "should throw an exception if we try to iterate twice when cache_rows is disabled" do
+      result = @client.query "SELECT 1 UNION SELECT 2", :cache_rows => false
+
+      expect {
+        result.each.to_a
+        result.each.to_a
+      }.to raise_exception(Mysql2::Error)
+    end
   end
 
   context "#fields" do

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -77,11 +77,6 @@ RSpec.describe Mysql2::Result do
       expect(@result.first.object_id).to eql(@result.first.object_id)
     end
 
-    it "should not cache previously yielded results if cache_rows is disabled" do
-      result = @client.query "SELECT 1", :cache_rows => false
-      expect(result.first.object_id).not_to eql(result.first.object_id)
-    end
-
     it "should yield different value for #first if streaming" do
       result = @client.query "SELECT 1 UNION SELECT 2", :stream => true, :cache_rows => false
       expect(result.first).not_to eql(result.first)


### PR DESCRIPTION
See notes from #742 . Pretty sure this should be backported to 0.3.x as well.

This should fix some cases of segfaulting.

Note: I opted to add the lines in result.c where I did to minimize the numbers of lines with a diff :)