### PR TITLE
Enabled bundler cache.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,6 @@
 sudo: required
 dist: trusty
+cache: bundler
 language: ruby
 bundler_args: --without benchmarks development
 # Temporary workaround for broken Rubygems on Travis


### PR DESCRIPTION
Caching is now available for all Travis' build environments.
It should speed up the build.