### PR TITLE
Fix SEGV when `wrapper->result` is used after it is freed.

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -920,6 +920,9 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
     wrapper->numberOfRows = wrapper->stmt_wrapper ? mysql_stmt_num_rows(wrapper->stmt_wrapper->stmt) : mysql_num_rows(wrapper->result);
     wrapper->rows = rb_ary_new2(wrapper->numberOfRows);
   } else if (wrapper->rows && !cacheRows) {
+    if (wrapper->resultFreed) {
+      rb_raise(cMysql2Error, "Result set has already been freed");
+    }
     mysql_data_seek(wrapper->result, 0);
     wrapper->lastRowProcessed = 0;
     wrapper->rows = rb_ary_new2(wrapper->numberOfRows);


### PR DESCRIPTION
I got SEGV when I ran rspec.
I found that the `wrapper->result` was used after it was freed.
I'm not sure whether this fix is correct but it works fine for me.
