### PR TITLE
Support connect attributes and set the script name to `program_name` attribute if it is not specified.

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ Mysql2::Client.new(
   :read_timeout = seconds,
   :write_timeout = seconds,
   :connect_timeout = seconds,
+  :connect_attrs = {:program_name => $0, ...},
   :reconnect = true/false,
   :local_infile = true/false,
   :secure_auth = true/false,

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -352,7 +352,22 @@ static VALUE rb_mysql_get_ssl_cipher(VALUE self)
   return rb_str;
 }
 
-static VALUE rb_connect(VALUE self, VALUE user, VALUE pass, VALUE host, VALUE port, VALUE database, VALUE socket, VALUE flags) {
+#if HAVE_MYSQL_OPTIONS4
+static int opt_connect_attr_add_i(VALUE key, VALUE value, VALUE arg)
+{
+  mysql_client_wrapper *wrapper = (mysql_client_wrapper *)arg;
+#ifdef HAVE_RUBY_ENCODING_H
+  rb_encoding *enc = rb_to_encoding(wrapper->encoding);
+  key = rb_str_export_to_enc(key, enc);
+  value = rb_str_export_to_enc(value, enc);
+#endif
+
+  mysql_options4(wrapper->client, MYSQL_OPT_CONNECT_ATTR_ADD, StringValueCStr(key), StringValueCStr(value));
+  return ST_CONTINUE;
+}
+#endif
+
+static VALUE rb_connect(VALUE self, VALUE user, VALUE pass, VALUE host, VALUE port, VALUE database, VALUE socket, VALUE flags, VALUE conn_attrs) {
   struct nogvl_connect_args args;
   time_t start_time, end_time, elapsed_time, connect_timeout;
   VALUE rv;
@@ -366,6 +381,11 @@ static VALUE rb_connect(VALUE self, VALUE user, VALUE pass, VALUE host, VALUE po
   args.db          = NIL_P(database) ? NULL : StringValueCStr(database);
   args.mysql       = wrapper->client;
   args.client_flag = NUM2ULONG(flags);
+
+#if HAVE_MYSQL_OPTIONS4
+  mysql_options(wrapper->client, MYSQL_OPT_CONNECT_ATTR_RESET, 0);
+  rb_hash_foreach(conn_attrs, opt_connect_attr_add_i, (VALUE)wrapper);
+#endif
 
   if (wrapper->connect_timeout)
     time(&start_time);
@@ -1338,7 +1358,7 @@ void init_mysql2_client() {
   rb_define_private_method(cMysql2Client, "init_command=", set_init_command, 1);
   rb_define_private_method(cMysql2Client, "ssl_set", set_ssl_options, 5);
   rb_define_private_method(cMysql2Client, "initialize_ext", initialize_ext, 0);
-  rb_define_private_method(cMysql2Client, "connect", rb_connect, 7);
+  rb_define_private_method(cMysql2Client, "connect", rb_connect, 8);
   rb_define_private_method(cMysql2Client, "_query", rb_query, 2);
 
   sym_id              = ID2SYM(rb_intern("id"));

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -92,6 +92,8 @@ end
   asplode h unless have_header header
 end
 
+have_func('mysql_options4')
+
 # This is our wishlist. We use whichever flags work on the host.
 # -Wall and -Wextra are included by default.
 wishlist = [

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -404,6 +404,26 @@ RSpec.describe Mysql2::Client do
     expect(client.read_timeout).to be_nil
   end
 
+  it "should set default program_name in connect_attrs" do
+    client = Mysql2::Client.new
+    if Mysql2::Client.info[:version] < '5.6' or client.info[:version] < '5.6'
+      pending('Both client and server versions must be MySQL 5.6 or later.')
+    end
+    result = client.query("SELECT attr_value FROM performance_schema.session_account_connect_attrs where processlist_id = connection_id() and attr_name = 'program_name'")
+    expect(result.first['attr_value']).to eq($0)
+  end
+
+  it "should set custom connect_attrs" do
+    client = Mysql2::Client.new(:connect_attrs => {:program_name => 'my_program_name', :foo => 'fooval', :bar => 'barval'})
+    if Mysql2::Client.info[:version] < '5.6' or client.info[:version] < '5.6'
+      pending('Both client and server versions must be MySQL 5.6 or later.')
+    end
+    results = Hash[client.query("SELECT * FROM performance_schema.session_account_connect_attrs where processlist_id = connection_id()").map { |x| x.values_at('ATTR_NAME', 'ATTR_VALUE') }]
+    expect(results['program_name']).to eq('my_program_name')
+    expect(results['foo']).to eq('fooval')
+    expect(results['bar']).to eq('barval')
+  end
+
   context "#query" do
     it "should let you query again if iterating is finished when streaming" do
       @client.query("SELECT 1 UNION SELECT 2", :stream => true, :cache_rows => false).each.to_a


### PR DESCRIPTION
This is same feature with Perl DBD-MySQL `mysql_conn_attrs` option.
http://search.cpan.org/~capttofu/DBD-mysql-4.033/lib/DBD/mysql.pm#mysql_conn_attrs
