### PR TITLE
Drop Ruby 1.8.7 and REE support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -24,10 +24,6 @@ rvm:
   - ruby-head
 matrix:
   include:
-    - rvm: 1.8.7
-      dist: precise
-    - rvm: ree
-      dist: precise
     - rvm: rbx-2
       dist: precise
     - rvm: 2.0.0

--- a/mysql2.gemspec
+++ b/mysql2.gemspec
@@ -11,6 +11,7 @@ Mysql2::GEMSPEC = Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.summary = 'A simple, fast Mysql library for Ruby, binding to libmysql'
 
+  gem.required_ruby_version = '>= 1.9.3'
   s.files = `git ls-files README.md CHANGELOG.md LICENSE ext lib support`.split
   s.test_files = `git ls-files spec examples`.split
 end


### PR DESCRIPTION
Their CI statuses are badly broken now: https://travis-ci.org/brianmario/mysql2/builds/124159847
(others are also broken but some of them can be fixed by https://github.com/brianmario/mysql2/pull/765)