### PR TITLE
Stop supporting older Rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,14 +21,9 @@ rvm:
   - 2.2
   - 2.1
   - 2.0.0
-  - 1.9.3
   - ruby-head
 matrix:
   include:
-    - rvm: 1.8.7
-      dist: precise
-    - rvm: ree
-      dist: precise
     - rvm: rbx-2
       dist: precise
     - rvm: 2.0.0


### PR DESCRIPTION
I think that once we hit 1.0 we should stop supporting older Rubies since they are no longer maintained.
If it's possible to stop supporting them now it'd be great.