### PR TITLE
Fix a BigDecimal value binding

### DIFF
--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -180,7 +180,6 @@ static void *nogvl_execute(void *ptr) {
 static void set_buffer_for_string(MYSQL_BIND* bind_buffer, unsigned long *length_buffer, VALUE string) {
   unsigned long length;
 
-  bind_buffer->buffer_type = MYSQL_TYPE_STRING;
   bind_buffer->buffer = RSTRING_PTR(string);
 
   length = RSTRING_LEN(string);
@@ -275,13 +274,13 @@ static VALUE execute(int argc, VALUE *argv, VALUE self) {
           *(double*)(bind_buffers[i].buffer) = NUM2DBL(argv[i]);
           break;
         case T_STRING:
-          {
-            params_enc[i] = argv[i];
+          bind_buffers[i].buffer_type = MYSQL_TYPE_STRING;
+
+          params_enc[i] = argv[i];
 #ifdef HAVE_RUBY_ENCODING_H
-            params_enc[i] = rb_str_export_to_enc(params_enc[i], conn_enc);
+          params_enc[i] = rb_str_export_to_enc(params_enc[i], conn_enc);
 #endif
-            set_buffer_for_string(&bind_buffers[i], &length_buffers[i], params_enc[i]);
-          }
+          set_buffer_for_string(&bind_buffers[i], &length_buffers[i], params_enc[i]);
           break;
         default:
           // TODO: what Ruby type should support MYSQL_TYPE_TIME

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -117,6 +117,13 @@ RSpec.describe Mysql2::Statement do
     expect(list[1]).to eq('2')
   end
 
+  it "should handle as a decimal binding a BigDecimal" do
+    stmt = @client.prepare('SELECT ? AS decimal_test')
+    test_result = stmt.execute(BigDecimal.new("123.45")).first
+    expect(test_result['decimal_test']).to be_an_instance_of(BigDecimal)
+    expect(test_result['decimal_test']).to eql(123.45)
+  end
+
   it "should update a DECIMAL value passing a BigDecimal" do
     @client.query 'USE test'
     @client.query 'DROP TABLE IF EXISTS mysql2_stmt_decimal_test'


### PR DESCRIPTION
Currently a BigDecimal value is bound as a string because
`set_buffer_for_string` overwrites `buffer_type` to `MYSQL_TYPE_STRING`.

This commit fixes to a BigDecimal value is bound as a decimal.