### PR TITLE
Avoid type error when using connect_timeout, read_timeout and write_timeout in a DATABASE_URL env variable

### DIFF
--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -36,7 +36,7 @@ module Mysql2
         when :reconnect, :local_infile, :secure_auth, :automatic_close
           send(:"#{key}=", !!opts[key]) # rubocop:disable Style/DoubleNegation
         when :connect_timeout, :read_timeout, :write_timeout
-          send(:"#{key}=", opts[key]) unless opts[key].nil?
+          send(:"#{key}=", opts[key].to_i) unless opts[key].nil?
         else
           send(:"#{key}=", opts[key])
         end


### PR DESCRIPTION
Why:

* When using a DATABASE_URL env variable with one or more of  these
  params, a type-error is triggered

Example: 

`DATABASE_URL="mysql2://<database>:<password>@<host>:<port>/<db>?encoding=utf8&pool=1&connect_timeout=2&read_timeout=5&write_timeout=5"`

Results in:

```
TypeError: wrong argument type String (expected Fixnum)
/usr/local/bundle/gems/mysql2-0.4.4/lib/mysql2/client.rb:39:in `connect_timeout='
/usr/local/bundle/gems/mysql2-0.4.4/lib/mysql2/client.rb:39:in `block in initialize'
/usr/local/bundle/gems/mysql2-0.4.4/lib/mysql2/client.rb:33:in `each'
/usr/local/bundle/gems/mysql2-0.4.4/lib/mysql2/client.rb:33:in `initialize'
...
```

This fix solves this issue. I have reproduced this in alpine-linux inside a docker container, and as far as I can see it should not break anything. 