### PR TITLE
Add ability to set ssl_mode.

### DIFF
--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Mysql2::Client.new(
   :reconnect = true/false,
   :local_infile = true/false,
   :secure_auth = true/false,
-  :ssl_mode = SSL_MODE_DISABLED / SSL_MODE_PREFERRED / REQUIRED / VERIFY_CA / VERIFY_IDENTITY,
+  :ssl_mode = :disabled / :preferred / :required / :verify_ca / :verify_identity,
   :default_file = '/path/to/my.cfg',
   :default_group = 'my.cfg section',
   :init_command => sql

--- a/README.md
+++ b/README.md
@@ -203,6 +203,7 @@ Mysql2::Client.new(
   :reconnect = true/false,
   :local_infile = true/false,
   :secure_auth = true/false,
+  :ssl_mode = "DISABLED" | "PREFERRED" | "REQUIRED" | "VERIFY_CA" | "VERIFY_IDENTITY",
   :default_file = '/path/to/my.cfg',
   :default_group = 'my.cfg section',
   :init_command => sql

--- a/README.md
+++ b/README.md
@@ -203,7 +203,7 @@ Mysql2::Client.new(
   :reconnect = true/false,
   :local_infile = true/false,
   :secure_auth = true/false,
-  :ssl_mode = "DISABLED" | "PREFERRED" | "REQUIRED" | "VERIFY_CA" | "VERIFY_IDENTITY",
+  :ssl_mode = SSL_MODE_DISABLED / SSL_MODE_PREFERRED / REQUIRED / VERIFY_CA / VERIFY_IDENTITY,
   :default_file = '/path/to/my.cfg',
   :default_group = 'my.cfg section',
   :init_command => sql

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -47,7 +47,6 @@ VALUE rb_hash_dup(VALUE other) {
   #define MYSQL_LINK_VERSION MYSQL_SERVER_VERSION
 #endif
 
-
 /*
  * used to pass all arguments to mysql_real_connect while inside
  * rb_thread_call_without_gvl
@@ -83,6 +82,7 @@ struct nogvl_select_db_args {
   MYSQL *mysql;
   char *db;
 };
+
 static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
   unsigned long version = mysql_get_client_version();
 

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -90,13 +90,13 @@ static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
     rb_warn( "Your mysql client library does not support setting ssl_mode; full support comes with 5.7.11." );
     return Qnil;
   }
-  GET_CLIENT(self); 
   Check_Type( setting, T_FIXNUM);
   if( NIL_P( setting ) ) {
     rb_raise(cMysql2Error, "ssl_mode= takes DISABLED, PREFERRED, REQUIRED, VERIFY_CA, VERIFY_IDENTITY, you passed nil" );
   }
-  int val = NUM2INT( setting );
 #ifdef HAVE_CONST_MYSQL_OPT_SSL_ENFORCE
+  GET_CLIENT(self); 
+  int val = NUM2INT( setting );
   if( version >= 50703 && version < 50711 ) {
     if( val == SSL_MODE_DISABLED || val == SSL_MODE_REQUIRED ) {
       bool b = ( val == SSL_MODE_REQUIRED );
@@ -110,6 +110,7 @@ static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
   }
 #endif
 #ifdef FULL_SSL_MODE_SUPPORT
+  GET_CLIENT(self); 
 
   if( val != SSL_MODE_DISABLED && val != SSL_MODE_PREFERRED && val != SSL_MODE_REQUIRED && val != SSL_MODE_VERIFY_CA && val != SSL_MODE_VERIFY_IDENTITY ) {
     rb_raise(cMysql2Error, "ssl_mode= takes DISABLED, PREFERRED, REQUIRED, VERIFY_CA, VERIFY_IDENTITY, you passed: %d", val );

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1337,7 +1337,6 @@ void init_mysql2_client() {
 
   rb_define_singleton_method(cMysql2Client, "escape", rb_mysql_client_escape, 1);
   rb_define_singleton_method(cMysql2Client, "info", rb_mysql_client_info, 0);
-  rb_define_method(cMysql2Client, "ssl_mode=", rb_set_ssl_mode_option, 1);
 
   rb_define_method(cMysql2Client, "close", rb_mysql_client_close, 0);
   rb_define_method(cMysql2Client, "abandon_results!", rb_mysql_client_abandon_results, 0);
@@ -1374,6 +1373,7 @@ void init_mysql2_client() {
   rb_define_private_method(cMysql2Client, "default_group=", set_read_default_group, 1);
   rb_define_private_method(cMysql2Client, "init_command=", set_init_command, 1);
   rb_define_private_method(cMysql2Client, "ssl_set", set_ssl_options, 5);
+  rb_define_private_method(cMysql2Client, "ssl_mode=", rb_set_ssl_mode_option, 1);
   rb_define_private_method(cMysql2Client, "initialize_ext", initialize_ext, 0);
   rb_define_private_method(cMysql2Client, "connect", rb_connect, 7);
   rb_define_private_method(cMysql2Client, "_query", rb_query, 2);

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -82,7 +82,8 @@ struct nogvl_select_db_args {
   MYSQL *mysql;
   char *db;
 };
-static VALUE rb_set_ssl_mode_option(RB_MYSQL_UNUSED VALUE klass, VALUE str) {
+static VALUE rb_set_ssl_mode_option(VALUE self, VALUE str) {
+  GET_CLIENT(self); 
   if( NIL_P( str ) ) {
     rb_raise(cMysql2Error, "ssl_mode= takes DISABLED, PREFERRED, REQUIRED< VERIFY_CA, VERIFY_IDENTITY, you passed nil" );
   }
@@ -97,11 +98,11 @@ static VALUE rb_set_ssl_mode_option(RB_MYSQL_UNUSED VALUE klass, VALUE str) {
   } else if( strncasecmp( val, "VERIFY_CA", 10 ) == 0 ) {
     setting = SSL_MODE_VERIFY_CA;
   } else if( strncasecmp( val, "VERIFY_IDENTIFY", 16 ) == 0 ) {
-    setting = SSL_MODE_VERIFY_IDENTIFY;
+    setting = SSL_MODE_VERIFY_IDENTITY;
   } else {
     rb_raise(cMysql2Error, "ssl_mode= takes DISABLED, PREFERRED, REQUIRED< VERIFY_CA, VERIFY_IDENTITY, you passed: %s", val );
   }
-  result = mysql_options( wrapper->client, MYSQL_OPT_SSL_MODE, &setting );
+  int result = mysql_options( wrapper->client, MYSQL_OPT_SSL_MODE, &setting );
 
   return INT2NUM(result);
 }
@@ -1323,7 +1324,7 @@ void init_mysql2_client() {
 
   rb_define_singleton_method(cMysql2Client, "escape", rb_mysql_client_escape, 1);
   rb_define_singleton_method(cMysql2Client, "info", rb_mysql_client_info, 0);
-  rb_define_singleton_method(cMysql2Client, "ssl_mode=", rb_set_ssl_mode_option, 1);
+  rb_define_method(cMysql2Client, "ssl_mode=", rb_set_ssl_mode_option, 1);
 
   rb_define_method(cMysql2Client, "close", rb_mysql_client_close, 0);
   rb_define_method(cMysql2Client, "abandon_results!", rb_mysql_client_abandon_results, 0);

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -98,7 +98,7 @@ struct nogvl_select_db_args {
   char *db;
 };
 static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
-  int version = mysql_get_client_version()
+  unsigned long version = mysql_get_client_version();
 
   if( version < 50703 ) {
     rb_warn( "Your mysql client library does not support setting ssl_mode" );

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1514,4 +1514,19 @@ void init_mysql2_client() {
   rb_const_set(cMysql2Client, rb_intern("SSL_MODE_DISABLED"),INT2NUM( SSL_MODE_DISABLED ) );
   rb_const_set(cMysql2Client, rb_intern("SSL_MODE_REQUIRED"),INT2NUM( SSL_MODE_REQUIRED ) );
 #endif
+#ifndef HAVE_CONST_SSL_MODE_DISABLED
+  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_DISABLED"),INT2NUM( 0 ) );
+#endif
+#ifndef HAVE_CONST_SSL_MODE_PREFERRED
+  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_PREFERRED"),INT2NUM( 0 ) );
+#endif
+#ifndef HAVE_CONST_SSL_MODE_REQUIRED
+  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_REQUIRED"),INT2NUM( 0 ) );
+#endif
+#ifndef HAVE_CONST_SSL_MODE_VERIFY_CA
+  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_VERIFY_CA"),INT2NUM( 0 ) );
+#endif
+#ifndef HAVE_CONST_SSL_MODE_VERIFY_IDENTITY
+  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_VERIFY_IDENTITY"),INT2NUM( 0 ) );
+#endif
 }

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -96,7 +96,7 @@ static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
     rb_raise(cMysql2Error, "ssl_mode= takes DISABLED, PREFERRED, REQUIRED, VERIFY_CA, VERIFY_IDENTITY, you passed nil" );
   }
   int val = NUM2INT( setting );
-#ifdef SSL_TOGGLE_SUPPORT
+#ifdef HAVE_CONST_MYSQL_OPT_SSL_ENFORCE
   if( version >= 50703 && version < 50711 ) {
     if( val == SSL_MODE_DISABLED || val == SSL_MODE_REQUIRED ) {
       bool b = ( val == SSL_MODE_REQUIRED );
@@ -109,7 +109,7 @@ static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
     }
   }
 #endif
-#ifdef SSL_MODE_SUPPORT
+#ifdef FULL_SSL_MODE_SUPPORT
 
   if( val != SSL_MODE_DISABLED && val != SSL_MODE_PREFERRED && val != SSL_MODE_REQUIRED && val != SSL_MODE_VERIFY_CA && val != SSL_MODE_VERIFY_IDENTITY ) {
     rb_raise(cMysql2Error, "ssl_mode= takes DISABLED, PREFERRED, REQUIRED, VERIFY_CA, VERIFY_IDENTITY, you passed: %d", val );
@@ -1501,14 +1501,14 @@ void init_mysql2_client() {
   rb_const_set(cMysql2Client, rb_intern("BASIC_FLAGS"),
       LONG2NUM(CLIENT_BASIC_FLAGS));
 #endif
-#ifdef SSL_MODE_SUPPORT
+#ifdef FULL_SSL_MODE_SUPPORT
   rb_const_set(cMysql2Client, rb_intern("SSL_MODE_DISABLED"),INT2NUM( SSL_MODE_DISABLED ) );
   rb_const_set(cMysql2Client, rb_intern("SSL_MODE_PREFERRED"),INT2NUM( SSL_MODE_PREFERRED ) );
   rb_const_set(cMysql2Client, rb_intern("SSL_MODE_REQUIRED"),INT2NUM( SSL_MODE_REQUIRED ) );
   rb_const_set(cMysql2Client, rb_intern("SSL_MODE_VERIFY_CA"),INT2NUM( SSL_MODE_VERIFY_CA ) );
   rb_const_set(cMysql2Client, rb_intern("SSL_MODE_VERIFY_IDENTITY"),INT2NUM( SSL_MODE_VERIFY_IDENTITY ) );
 #endif
-#ifdef SSL_TOGGLE_SUPPORT
+#ifdef HAVE_CONST_MYSQL_OPT_SSL_ENFORCE
   #define SSL_MODE_DISABLED 1
   #define SSL_MODE_REQUIRED 3
   rb_const_set(cMysql2Client, rb_intern("SSL_MODE_DISABLED"),INT2NUM( SSL_MODE_DISABLED ) );

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -111,6 +111,7 @@ static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
 #endif
 #ifdef FULL_SSL_MODE_SUPPORT
   GET_CLIENT(self); 
+  int val = NUM2INT( setting );
 
   if( val != SSL_MODE_DISABLED && val != SSL_MODE_PREFERRED && val != SSL_MODE_REQUIRED && val != SSL_MODE_VERIFY_CA && val != SSL_MODE_VERIFY_IDENTITY ) {
     rb_raise(cMysql2Error, "ssl_mode= takes DISABLED, PREFERRED, REQUIRED, VERIFY_CA, VERIFY_IDENTITY, you passed: %d", val );

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1511,6 +1511,9 @@ void init_mysql2_client() {
 #ifdef HAVE_CONST_MYSQL_OPT_SSL_ENFORCE
   #define SSL_MODE_DISABLED 1
   #define SSL_MODE_REQUIRED 3
+  #define HAVE_CONST_SSL_MODE_DISABLED
+  #define HAVE_CONST_SSL_MODE_REQUIRED
+
   rb_const_set(cMysql2Client, rb_intern("SSL_MODE_DISABLED"),INT2NUM( SSL_MODE_DISABLED ) );
   rb_const_set(cMysql2Client, rb_intern("SSL_MODE_REQUIRED"),INT2NUM( SSL_MODE_REQUIRED ) );
 #endif

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -90,10 +90,6 @@ static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
     rb_warn( "Your mysql client library does not support setting ssl_mode; full support comes with 5.7.11." );
     return Qnil;
   }
-  Check_Type( setting, T_FIXNUM);
-  if( NIL_P( setting ) ) {
-    rb_raise(cMysql2Error, "ssl_mode= takes DISABLED, PREFERRED, REQUIRED, VERIFY_CA, VERIFY_IDENTITY, you passed nil" );
-  }
 #ifdef HAVE_CONST_MYSQL_OPT_SSL_ENFORCE
   GET_CLIENT(self); 
   int val = NUM2INT( setting );
@@ -104,7 +100,7 @@ static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
       return INT2NUM(result);
       
     } else {
-      rb_warn( "Mysql client libraries between 5.7.3 and 5.7.10 do not support other values for ssl_mode" );
+      rb_warn( "MySQL client libraries between 5.7.3 and 5.7.10 only support SSL_MODE_DISABLED and SSL_MODE_REQUIRED"" );
       return Qnil;
     }
   }

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -120,6 +120,9 @@ static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
 
   return INT2NUM(result);
 #endif
+#ifdef NO_SSL_MODE_SUPPORT
+  return Qnil;
+#endif
 }
 /*
  * non-blocking mysql_*() functions that we won't be wrapping since

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1503,11 +1503,11 @@ void init_mysql2_client() {
       LONG2NUM(CLIENT_BASIC_FLAGS));
 #endif
 #ifdef FULL_SSL_MODE_SUPPORT
-  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_DISABLED"),INT2NUM( SSL_MODE_DISABLED ) );
-  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_PREFERRED"),INT2NUM( SSL_MODE_PREFERRED ) );
-  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_REQUIRED"),INT2NUM( SSL_MODE_REQUIRED ) );
-  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_VERIFY_CA"),INT2NUM( SSL_MODE_VERIFY_CA ) );
-  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_VERIFY_IDENTITY"),INT2NUM( SSL_MODE_VERIFY_IDENTITY ) );
+  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_DISABLED"), INT2NUM(SSL_MODE_DISABLED));
+  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_PREFERRED"), INT2NUM(SSL_MODE_PREFERRED));
+  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_REQUIRED"), INT2NUM(SSL_MODE_REQUIRED));
+  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_VERIFY_CA"), INT2NUM(SSL_MODE_VERIFY_CA));
+  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_VERIFY_IDENTITY"), INT2NUM(SSL_MODE_VERIFY_IDENTITY));
 #endif
 #ifdef HAVE_CONST_MYSQL_OPT_SSL_ENFORCE
   #define SSL_MODE_DISABLED 1
@@ -1515,22 +1515,22 @@ void init_mysql2_client() {
   #define HAVE_CONST_SSL_MODE_DISABLED
   #define HAVE_CONST_SSL_MODE_REQUIRED
 
-  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_DISABLED"),INT2NUM( SSL_MODE_DISABLED ) );
-  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_REQUIRED"),INT2NUM( SSL_MODE_REQUIRED ) );
+  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_DISABLED"), INT2NUM(SSL_MODE_DISABLED));
+  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_REQUIRED"), INT2NUM(SSL_MODE_REQUIRED));
 #endif
 #ifndef HAVE_CONST_SSL_MODE_DISABLED
-  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_DISABLED"),INT2NUM( 0 ) );
+  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_DISABLED"), INT2NUM(0));
 #endif
 #ifndef HAVE_CONST_SSL_MODE_PREFERRED
-  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_PREFERRED"),INT2NUM( 0 ) );
+  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_PREFERRED"), INT2NUM(0));
 #endif
 #ifndef HAVE_CONST_SSL_MODE_REQUIRED
-  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_REQUIRED"),INT2NUM( 0 ) );
+  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_REQUIRED"), INT2NUM(0));
 #endif
 #ifndef HAVE_CONST_SSL_MODE_VERIFY_CA
-  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_VERIFY_CA"),INT2NUM( 0 ) );
+  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_VERIFY_CA"), INT2NUM(0));
 #endif
 #ifndef HAVE_CONST_SSL_MODE_VERIFY_IDENTITY
-  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_VERIFY_IDENTITY"),INT2NUM( 0 ) );
+  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_VERIFY_IDENTITY"), INT2NUM(0));
 #endif
 }

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -82,7 +82,29 @@ struct nogvl_select_db_args {
   MYSQL *mysql;
   char *db;
 };
+static VALUE rb_set_ssl_mode_option(RB_MYSQL_UNUSED VALUE klass, VALUE str) {
+  if( NIL_P( str ) ) {
+    rb_raise(cMysql2Error, "ssl_mode= takes DISABLED, PREFERRED, REQUIRED< VERIFY_CA, VERIFY_IDENTITY, you passed nil" );
+  }
+  char *val = StringValueCStr( str );
+  unsigned int setting;
+  if( strncasecmp( val, "DISABLED", 9 ) == 0 ) {
+    setting = SSL_MODE_DISABLED;
+  } else if( strncasecmp( val, "PREFERRED", 10 ) == 0 ) {
+    setting = SSL_MODE_PREFERRED;
+  } else if( strncasecmp( val, "REQUIRED", 9 ) == 0 ) {
+    setting = SSL_MODE_REQUIRED;
+  } else if( strncasecmp( val, "VERIFY_CA", 10 ) == 0 ) {
+    setting = SSL_MODE_VERIFY_CA;
+  } else if( strncasecmp( val, "VERIFY_IDENTIFY", 16 ) == 0 ) {
+    setting = SSL_MODE_VERIFY_IDENTIFY;
+  } else {
+    rb_raise(cMysql2Error, "ssl_mode= takes DISABLED, PREFERRED, REQUIRED< VERIFY_CA, VERIFY_IDENTITY, you passed: %s", val );
+  }
+  result = mysql_options( wrapper->client, MYSQL_OPT_SSL_MODE, &setting );
 
+  return INT2NUM(result);
+}
 /*
  * non-blocking mysql_*() functions that we won't be wrapping since
  * they do not appear to hit the network nor issue any interruptible
@@ -1301,6 +1323,7 @@ void init_mysql2_client() {
 
   rb_define_singleton_method(cMysql2Client, "escape", rb_mysql_client_escape, 1);
   rb_define_singleton_method(cMysql2Client, "info", rb_mysql_client_info, 0);
+  rb_define_singleton_method(cMysql2Client, "ssl_mode=", rb_set_ssl_mode_option, 1);
 
   rb_define_method(cMysql2Client, "close", rb_mysql_client_close, 0);
   rb_define_method(cMysql2Client, "abandon_results!", rb_mysql_client_abandon_results, 0);

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -86,21 +86,21 @@ struct nogvl_select_db_args {
 static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
   unsigned long version = mysql_get_client_version();
 
-  if( version < 50703 ) {
+  if (version < 50703) {
     rb_warn( "Your mysql client library does not support setting ssl_mode; full support comes with 5.7.11." );
     return Qnil;
   }
 #ifdef HAVE_CONST_MYSQL_OPT_SSL_ENFORCE
   GET_CLIENT(self); 
   int val = NUM2INT( setting );
-  if( version >= 50703 && version < 50711 ) {
-    if( val == SSL_MODE_DISABLED || val == SSL_MODE_REQUIRED ) {
+  if (version >= 50703 && version < 50711) {
+    if (val == SSL_MODE_DISABLED || val == SSL_MODE_REQUIRED) {
       bool b = ( val == SSL_MODE_REQUIRED );
       int result = mysql_options( wrapper->client, MYSQL_OPT_SSL_ENFORCE, &b );
       return INT2NUM(result);
       
     } else {
-      rb_warn( "MySQL client libraries between 5.7.3 and 5.7.10 only support SSL_MODE_DISABLED and SSL_MODE_REQUIRED"" );
+      rb_warn( "MySQL client libraries between 5.7.3 and 5.7.10 only support SSL_MODE_DISABLED and SSL_MODE_REQUIRED" );
       return Qnil;
     }
   }
@@ -109,7 +109,7 @@ static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
   GET_CLIENT(self); 
   int val = NUM2INT( setting );
 
-  if( val != SSL_MODE_DISABLED && val != SSL_MODE_PREFERRED && val != SSL_MODE_REQUIRED && val != SSL_MODE_VERIFY_CA && val != SSL_MODE_VERIFY_IDENTITY ) {
+  if (val != SSL_MODE_DISABLED && val != SSL_MODE_PREFERRED && val != SSL_MODE_REQUIRED && val != SSL_MODE_VERIFY_CA && val != SSL_MODE_VERIFY_IDENTITY) {
     rb_raise(cMysql2Error, "ssl_mode= takes DISABLED, PREFERRED, REQUIRED, VERIFY_CA, VERIFY_IDENTITY, you passed: %d", val );
   }
   int result = mysql_options( wrapper->client, MYSQL_OPT_SSL_MODE, &val );

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -83,6 +83,11 @@ struct nogvl_select_db_args {
   char *db;
 };
 static VALUE rb_set_ssl_mode_option(VALUE self, VALUE str) {
+  if( mysql_get_client_version() < 50700 ) {
+    rb_warn( "Your mysql client library does not support setting ssl_mode" );
+    return Qnil;
+  }
+
   GET_CLIENT(self); 
   if( NIL_P( str ) ) {
     rb_raise(cMysql2Error, "ssl_mode= takes DISABLED, PREFERRED, REQUIRED< VERIFY_CA, VERIFY_IDENTITY, you passed nil" );

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -83,7 +83,7 @@ struct nogvl_select_db_args {
   char *db;
 };
 static VALUE rb_set_ssl_mode_option(VALUE self, VALUE str) {
-  if( mysql_get_client_version() < 50700 ) {
+  if( mysql_get_client_version() < 50711 ) {
     rb_warn( "Your mysql client library does not support setting ssl_mode" );
     return Qnil;
   }

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -90,7 +90,7 @@ static VALUE rb_set_ssl_mode_option(VALUE self, VALUE str) {
 
   GET_CLIENT(self); 
   if( NIL_P( str ) ) {
-    rb_raise(cMysql2Error, "ssl_mode= takes DISABLED, PREFERRED, REQUIRED< VERIFY_CA, VERIFY_IDENTITY, you passed nil" );
+    rb_raise(cMysql2Error, "ssl_mode= takes DISABLED, PREFERRED, REQUIRED, VERIFY_CA, VERIFY_IDENTITY, you passed nil" );
   }
   char *val = StringValueCStr( str );
   unsigned int setting;
@@ -105,7 +105,7 @@ static VALUE rb_set_ssl_mode_option(VALUE self, VALUE str) {
   } else if( strncasecmp( val, "VERIFY_IDENTIFY", 16 ) == 0 ) {
     setting = SSL_MODE_VERIFY_IDENTITY;
   } else {
-    rb_raise(cMysql2Error, "ssl_mode= takes DISABLED, PREFERRED, REQUIRED< VERIFY_CA, VERIFY_IDENTITY, you passed: %s", val );
+    rb_raise(cMysql2Error, "ssl_mode= takes DISABLED, PREFERRED, REQUIRED, VERIFY_CA, VERIFY_IDENTITY, you passed: %s", val );
   }
   int result = mysql_options( wrapper->client, MYSQL_OPT_SSL_MODE, &setting );
 

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -13,13 +13,13 @@ def asplode(lib)
 end
 
 def add_ssl_defines(header)
-  all_modes_found = %w( SSL_MODE_DISABLED SSL_MODE_PREFERRED SSL_MODE_REQUIRED SSL_MODE_VERIFY_CA SSL_MODE_VERIFY_IDENTITY).inject( true ) do |m, ssl_mode|
+  all_modes_found = %w(SSL_MODE_DISABLED SSL_MODE_PREFERRED SSL_MODE_REQUIRED SSL_MODE_VERIFY_CA SSL_MODE_VERIFY_IDENTITY).inject(true) do |m, ssl_mode|
     m && have_const(ssl_mode, header)
   end
   $CFLAGS << ' -DFULL_SSL_MODE_SUPPORT' if all_modes_found
-  
-    # if we only have ssl toggle (--ssl,--disable-ssl) from 5.7.3 to 5.7.10
-  have_const('MYSQL_OPT_SSL_ENFORCE', header) unless all_modes_found
+  # if we only have ssl toggle (--ssl,--disable-ssl) from 5.7.3 to 5.7.10
+  has_no_support = all_modes_found ? false : !have_const('MYSQL_OPT_SSL_ENFORCE', header)
+  $CFLAGS << ' -DNO_SSL_MODE_SUPPORT' if has_no_support
 end
 
 # 2.0-only

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -62,6 +62,14 @@ elsif (mc = (with_config('mysql-config') || Dir[GLOB].first))
   abort "-----\nCannot execute mysql_config at #{mc}\n-----" unless File.executable?(mc)
   warn "-----\nUsing mysql_config at #{mc}\n-----"
   ver = `#{mc} --version`.chomp.to_f
+  major, minor, inc = `#{mc} --version`.chomp.split('.').map( &:to_i )
+  if major > 5 || major == 5 && minor == 7 && inc >= 11
+    $CFLAGS << ' -D SSL_MODE_SUPPORT'
+  elsif major == 5 && minor == 7 && inc >= 3 && inc < 11
+    $CFLAGS << ' -D SSL_TOGGLE_SUPPORT'
+  else
+    $CFLAGS << ' -D NO_SSL_MODE_SUPPORT'
+  end
   includes = `#{mc} --include`.chomp
   abort unless $CHILD_STATUS.success?
   libs = `#{mc} --libs_r`.chomp

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -12,16 +12,14 @@ def asplode(lib)
   end
 end
 
-def add_ssl_defines( header )
+def add_ssl_defines(header)
   all_modes_found = %w( SSL_MODE_DISABLED SSL_MODE_PREFERRED SSL_MODE_REQUIRED SSL_MODE_VERIFY_CA SSL_MODE_VERIFY_IDENTITY).inject( true ) do |m, ssl_mode|
-    m && have_const( ssl_mode, header )
+    m && have_const(ssl_mode, header)
   end
   $CFLAGS << ' -DFULL_SSL_MODE_SUPPORT' if all_modes_found
-  unless all_modes_found
+  
     # if we only have ssl toggle (--ssl,--disable-ssl) from 5.7.3 to 5.7.10
-    have_const( 'MYSQL_OPT_SSL_ENFORCE', header )
-  end
-
+  have_const('MYSQL_OPT_SSL_ENFORCE', header) unless all_modes_found
 end
 
 # 2.0-only
@@ -93,10 +91,10 @@ end
 
 if have_header('mysql.h')
   prefix = nil
-  add_ssl_defines( 'mysql.h' )
+  add_ssl_defines('mysql.h')
 elsif have_header('mysql/mysql.h')
   prefix = 'mysql'
-  add_ssl_defines( 'mysql/mysql.h' )
+  add_ssl_defines('mysql/mysql.h')
 else
   asplode 'mysql.h'
 end

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -91,13 +91,13 @@ end
 
 if have_header('mysql.h')
   prefix = nil
-  add_ssl_defines('mysql.h')
 elsif have_header('mysql/mysql.h')
   prefix = 'mysql'
-  add_ssl_defines('mysql/mysql.h')
 else
   asplode 'mysql.h'
 end
+
+add_ssl_defines([prefix, 'mysql.h'].compact.join('/'))
 
 %w(errmsg.h mysqld_error.h).each do |h|
   header = [prefix, h].compact.join '/'

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -47,6 +47,8 @@ module Mysql2
 
       ssl_options = opts.values_at(:sslkey, :sslcert, :sslca, :sslcapath, :sslcipher)
       ssl_set(*ssl_options) if ssl_options.any?
+      self.ssl_mode=( opts[:ssl_mode] ) if opts[:ssl_mode]
+
 
       case opts[:flags]
       when Array

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -48,8 +48,7 @@ module Mysql2
       ssl_options = opts.values_at(:sslkey, :sslcert, :sslca, :sslcapath, :sslcipher)
       ssl_set(*ssl_options) if ssl_options.any?
       if opts[:ssl_mode]
-        m = parse_ssl_mode( opts[:ssl_mode] )
-        self.ssl_mode = m if m
+        self.ssl_mode = parse_ssl_mode(opts[:ssl_mode]) if opts[:ssl_mode]
       end
 
 

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -18,9 +18,6 @@ module Mysql2
       }
     end
 
-    # rubocop:disable Metrics/AbcSize
-    # rubocop:disable Metrics/CyclomaticComplexity
-    # rubocop:disable Metrics/MethodLength
     def initialize(opts = {})
       opts = Mysql2::Util.key_hash_as_symbols(opts)
       @read_timeout = nil

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -51,7 +51,6 @@ module Mysql2
         self.ssl_mode = parse_ssl_mode(opts[:ssl_mode]) if opts[:ssl_mode]
       end
 
-
       case opts[:flags]
       when Array
         flags = parse_flags_array(opts[:flags], @query_options[:connect_flags])
@@ -91,13 +90,13 @@ module Mysql2
       connect user, pass, host, port, database, socket, flags
     end
 
-    def parse_ssl_mode( mode )
+    def parse_ssl_mode(mode)
       m = mode.to_s.upcase
-      if m.start_with?( 'SSL_MODE_' )
-        return Mysql2::Client.const_get( m ) if Mysql2::Client.const_defined?( m ) 
+      if m.start_with?('SSL_MODE_')
+        return Mysql2::Client.const_get(m) if Mysql2::Client.const_defined?(m)
       else
         x = 'SSL_MODE_' + m
-        return Mysql2::Client.const_get( x ) if Mysql2::Client.const_defined?( x ) 
+        return Mysql2::Client.const_get(x) if Mysql2::Client.const_defined?(x) 
       end
       warn "ssl_mode must be one of SSL_MODE_DISABLED, SSL_MODE_PREFERRED, SSL_MODE_REQUIRED, SSL_MODE_VERIFY_CA, SSL_MODE_VERIFY_IDENTITY"
       return nil

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -96,8 +96,7 @@ module Mysql2
         x = 'SSL_MODE_' + m
         return Mysql2::Client.const_get(x) if Mysql2::Client.const_defined?(x)
       end
-      warn "ssl_mode must be one of SSL_MODE_DISABLED, SSL_MODE_PREFERRED, SSL_MODE_REQUIRED, SSL_MODE_VERIFY_CA, SSL_MODE_VERIFY_IDENTITY"
-      return nil
+      warn "Unknown MySQL ssl_mode flag: #{mode}"
     end
 
     def parse_flags_array(flags, initial = 0)

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -47,9 +47,7 @@ module Mysql2
 
       ssl_options = opts.values_at(:sslkey, :sslcert, :sslca, :sslcapath, :sslcipher)
       ssl_set(*ssl_options) if ssl_options.any?
-      if opts[:ssl_mode]
-        self.ssl_mode = parse_ssl_mode(opts[:ssl_mode]) if opts[:ssl_mode]
-      end
+      self.ssl_mode = parse_ssl_mode(opts[:ssl_mode]) if opts[:ssl_mode]
 
       case opts[:flags]
       when Array
@@ -96,7 +94,7 @@ module Mysql2
         return Mysql2::Client.const_get(m) if Mysql2::Client.const_defined?(m)
       else
         x = 'SSL_MODE_' + m
-        return Mysql2::Client.const_get(x) if Mysql2::Client.const_defined?(x) 
+        return Mysql2::Client.const_get(x) if Mysql2::Client.const_defined?(x)
       end
       warn "ssl_mode must be one of SSL_MODE_DISABLED, SSL_MODE_PREFERRED, SSL_MODE_REQUIRED, SSL_MODE_VERIFY_CA, SSL_MODE_VERIFY_IDENTITY"
       return nil

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -92,18 +92,13 @@ module Mysql2
       connect user, pass, host, port, database, socket, flags
     end
 
-    def parse_ssl_mode( m )
-      return nil if m.nil?
-      if m.is_a?( String ) || m.is_a?( Symbol )
-        m.to_s.upcase!
-        if m.start_with?( 'SSL_MODE_' )
-          return Mysql2::Client.const_get( m ) if Mysql2::Client.const_defined?( m ) 
-        else
-          x = 'SSL_MODE_' + m
-          return Mysql2::Client.const_get( x ) if Mysql2::Client.const_defined?( x ) 
-        end
-      elsif [SSL_MODE_DISABLED, SSL_MODE_PREFERRED, SSL_MODE_REQUIRED, SSL_MODE_VERIFY_CA, SSL_MODE_VERIFY_IDENTITY].include?( m.to_i )
-        return m
+    def parse_ssl_mode( mode )
+      m = mode.to_s.upcase
+      if m.start_with?( 'SSL_MODE_' )
+        return Mysql2::Client.const_get( m ) if Mysql2::Client.const_defined?( m ) 
+      else
+        x = 'SSL_MODE_' + m
+        return Mysql2::Client.const_get( x ) if Mysql2::Client.const_defined?( x ) 
       end
       warn "ssl_mode must be one of SSL_MODE_DISABLED, SSL_MODE_PREFERRED, SSL_MODE_REQUIRED, SSL_MODE_VERIFY_CA, SSL_MODE_VERIFY_IDENTITY"
       return nil

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -18,6 +18,9 @@ module Mysql2
       }
     end
 
+    # rubocop:disable Metrics/AbcSize
+    # rubocop:disable Metrics/CyclomaticComplexity
+    # rubocop:disable Metrics/MethodLength
     def initialize(opts = {})
       opts = Mysql2::Util.key_hash_as_symbols(opts)
       @read_timeout = nil

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -94,8 +94,8 @@ module Mysql2
 
     def parse_ssl_mode( m )
       return nil if m.nil?
-      if m.is_a?( String )
-        m.upcase!
+      if m.is_a?( String ) || m.is_a?( Symbol )
+        m.to_s.upcase!
         if m.start_with?( 'SSL_MODE_' )
           return Mysql2::Client.const_get( m ) if Mysql2::Client.const_defined?( m ) 
         else
@@ -105,7 +105,8 @@ module Mysql2
       elsif [SSL_MODE_DISABLED, SSL_MODE_PREFERRED, SSL_MODE_REQUIRED, SSL_MODE_VERIFY_CA, SSL_MODE_VERIFY_IDENTITY].include?( m.to_i )
         return m
       end
-      raise "ssl_mode must be one of SSL_MODE_DISABLED, SSL_MODE_PREFERRED, SSL_MODE_REQUIRED, SSL_MODE_VERIFY_CA, SSL_MODE_VERIFY_IDENTITY"
+      warn "ssl_mode must be one of SSL_MODE_DISABLED, SSL_MODE_PREFERRED, SSL_MODE_REQUIRED, SSL_MODE_VERIFY_CA, SSL_MODE_VERIFY_IDENTITY"
+      return nil
     end
 
     def parse_flags_array(flags, initial = 0)


### PR DESCRIPTION
In mysql 5.7.11, an ssl_mode option becomes available to set, and setting values to it before the connection happens can allow connections to servers that I could not otherwise connect to using 5.7.11.

http://dev.mysql.com/doc/refman/5.7/en/mysql-options.html

It fails with a warning when it is not supported; is that the behaviour you'd want?
