### PR TITLE
Add a Mysql2::Client#closed? method

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -472,6 +472,16 @@ static VALUE rb_mysql_client_close(VALUE self) {
   return Qnil;
 }
 
+/* call-seq:
+ *    client.closed?
+ *
+ * @return [Boolean]
+ */
+static VALUE rb_mysql_client_closed(VALUE self) {
+  GET_CLIENT(self);
+  return CONNECTED(wrapper) ? Qfalse : Qtrue;
+}
+
 /*
  * mysql_send_query is unlikely to block since most queries are small
  * enough to fit in a socket buffer, but sometimes large UPDATE and
@@ -1374,6 +1384,7 @@ void init_mysql2_client() {
   rb_define_singleton_method(cMysql2Client, "info", rb_mysql_client_info, 0);
 
   rb_define_method(cMysql2Client, "close", rb_mysql_client_close, 0);
+  rb_define_method(cMysql2Client, "closed?", rb_mysql_client_closed, 0);
   rb_define_method(cMysql2Client, "abandon_results!", rb_mysql_client_abandon_results, 0);
   rb_define_method(cMysql2Client, "escape", rb_mysql_client_real_escape, 1);
   rb_define_method(cMysql2Client, "server_info", rb_mysql_client_server_info, 0);

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -299,6 +299,17 @@ RSpec.describe Mysql2::Client do
     }.to raise_error(Mysql2::Error)
   end
 
+  context "#closed?" do
+    it "should return false when connected" do
+      expect(@client.closed?).to eql(false)
+    end
+
+    it "should return true after close" do
+      @client.close
+      expect(@client.closed?).to eql(true)
+    end
+  end
+
   it "should respond to #query" do
     expect(@client).to respond_to(:query)
   end


### PR DESCRIPTION
I would like to be able to check if the mysql connection was closed without actually pinging the server, however, I don't see that easily state accessible on the Mysql2::Client.

I did find a workaround which works

``` ruby
def connected?
  !!@connection.socket
rescue Mysql2::Error
  false
end
```

but it would be more convenient to be able to just do `@connection.connected?` which this PR adds
