### PR TITLE
RFC: non-blocking behavior for `next_result`

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -539,12 +539,31 @@ static VALUE disconnect_and_raise(VALUE self, VALUE error) {
   return Qnil;
 }
 
+static void wait_for_fd(int fd, struct timeval *tvp) {
+  int retval;
+
+  for(;;) {
+    retval = rb_wait_for_single_fd(fd, RB_WAITFD_IN, tvp);
+
+    if (retval == 0) {
+      rb_raise(cMysql2Error, "Timeout waiting for a response from the last query. (waited %d seconds)", FIX2INT(tvp->tv_sec));
+    }
+
+    if (retval < 0) {
+      rb_sys_fail(0);
+    }
+
+    if (retval > 0) {
+      break;
+    }
+  }
+}
+
 static VALUE do_query(void *args) {
   struct async_query_args *async_args;
   struct timeval tv;
   struct timeval* tvp;
   long int sec;
-  int retval;
   VALUE read_timeout;
 
   async_args = (struct async_query_args *)args;
@@ -565,21 +584,7 @@ static VALUE do_query(void *args) {
     tvp->tv_usec = 0;
   }
 
-  for(;;) {
-    retval = rb_wait_for_single_fd(async_args->fd, RB_WAITFD_IN, tvp);
-
-    if (retval == 0) {
-      rb_raise(cMysql2Error, "Timeout waiting for a response from the last query. (waited %d seconds)", FIX2INT(read_timeout));
-    }
-
-    if (retval < 0) {
-      rb_sys_fail(0);
-    }
-
-    if (retval > 0) {
-      break;
-    }
-  }
+  wait_for_fd(async_args->fd, tvp);
 
   return Qnil;
 }
@@ -1022,6 +1027,12 @@ static VALUE rb_mysql_client_more_results(VALUE self)
       return Qtrue;
 }
 
+static void *nogvl_next_result(void *ptr) {
+  mysql_client_wrapper *wrapper = ptr;
+
+  return (void *)INT2NUM(mysql_next_result(wrapper->client));
+}
+
 /* call-seq:
  *    client.next_result
  *
@@ -1032,7 +1043,11 @@ static VALUE rb_mysql_client_next_result(VALUE self)
 {
     int ret;
     GET_CLIENT(self);
-    ret = mysql_next_result(wrapper->client);
+
+    wait_for_fd(wrapper->client->net.fd, NULL);
+    VALUE v = (VALUE)rb_thread_call_without_gvl(nogvl_next_result, wrapper, RUBY_UBF_IO, 0);
+    ret = NUM2INT(v);
+
     if (ret > 0) {
       rb_raise_mysql2_error(wrapper);
       return Qfalse;

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1,4 +1,5 @@
 #include <mysql2_ext.h>
+#include <violite.h>
 
 #include <time.h>
 #include <errno.h>
@@ -559,20 +560,15 @@ static void wait_for_fd(int fd, struct timeval *tvp) {
   }
 }
 
-static VALUE do_query(void *args) {
-  struct async_query_args *async_args;
-  struct timeval tv;
-  struct timeval* tvp;
+static struct timeval *get_read_timeout(VALUE self, struct timeval *tvp)
+{
   long int sec;
   VALUE read_timeout;
 
-  async_args = (struct async_query_args *)args;
-  read_timeout = rb_iv_get(async_args->self, "@read_timeout");
+  read_timeout = rb_iv_get(self, "@read_timeout");
 
-  tvp = NULL;
   if (!NIL_P(read_timeout)) {
     Check_Type(read_timeout, T_FIXNUM);
-    tvp = &tv;
     sec = FIX2INT(read_timeout);
     /* TODO: support partial seconds?
        also, this check is here for sanity, we also check up in Ruby */
@@ -582,8 +578,19 @@ static VALUE do_query(void *args) {
       rb_raise(cMysql2Error, "read_timeout must be a positive integer, you passed %ld", sec);
     }
     tvp->tv_usec = 0;
+    return tvp;
+  } else {
+    return NULL;
   }
+}
 
+
+static VALUE do_query(void *args) {
+  struct async_query_args *async_args;
+  struct timeval tv, *tvp;
+
+  async_args = (struct async_query_args *)args;
+  tvp = get_read_timeout(async_args->self, &tv);
   wait_for_fd(async_args->fd, tvp);
 
   return Qnil;
@@ -1042,9 +1049,21 @@ static void *nogvl_next_result(void *ptr) {
 static VALUE rb_mysql_client_next_result(VALUE self)
 {
     int ret;
+    struct timeval tv, *tvp;
     GET_CLIENT(self);
 
-    wait_for_fd(wrapper->client->net.fd, NULL);
+    if (mysql_more_results(wrapper->client) == 0)
+      return Qfalse;
+
+    /* if both queries were ready by the time we finished the first query,
+     * the underlying mysql client library will have read both results into the buffer,
+     * defeating our attempt to poll() until ready.  detect that case by peeking at the "vio" buffer.
+     */
+    if ( !wrapper->client->net.vio->has_data(wrapper->client->net.vio) ) {
+      tvp = get_read_timeout(self, &tv);
+      wait_for_fd(wrapper->client->net.fd, tvp);
+    }
+
     VALUE v = (VALUE)rb_thread_call_without_gvl(nogvl_next_result, wrapper, RUBY_UBF_IO, 0);
     ret = NUM2INT(v);
 

--- a/ext/mysql2/violite.h
+++ b/ext/mysql2/violite.h
@@ -1,0 +1,280 @@
+/* Copyright (c) 2000, 2015, Oracle and/or its affiliates. All rights
+ * reserved.
+
+   This program is free software; you can redistribute it and/or modify
+   it under the terms of the GNU General Public License as published by
+   the Free Software Foundation; version 2 of the License.
+
+   This program is distributed in the hope that it will be useful,
+   but WITHOUT ANY WARRANTY; without even the implied warranty of
+   MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+   GNU General Public License for more details.
+
+   You should have received a copy of the GNU General Public License
+   along with this program; if not, write to the Free Software
+   Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301  USA */
+
+/*
+ * Vio Lite.
+ * Purpose: include file for Vio that will work with C and C++
+ */
+
+#ifndef vio_violite_h_
+#define	vio_violite_h_
+
+#include <sys/socket.h>
+
+typedef unsigned char uchar;
+typedef uint16_t uint16;
+
+struct st_mysql_socket
+{
+  /** The real socket descriptor. */
+  int fd;
+
+  /**
+    The instrumentation hook.
+    Note that this hook is not conditionally defined,
+    for binary compatibility of the @c MYSQL_SOCKET interface.
+  */
+  void *m_psi;
+};
+
+
+enum enum_vio_type
+{
+  VIO_TYPE_TCPIP, VIO_TYPE_SOCKET, VIO_TYPE_NAMEDPIPE, VIO_TYPE_SSL,
+  VIO_TYPE_SHARED_MEMORY
+};
+
+/**
+  VIO I/O events.
+*/
+enum enum_vio_io_event
+{
+  VIO_IO_EVENT_READ,
+  VIO_IO_EVENT_WRITE,
+  VIO_IO_EVENT_CONNECT
+};
+
+#define VIO_LOCALHOST 1                         /* a localhost connection */
+#define VIO_BUFFERED_READ 2                     /* use buffered read */
+#define VIO_READ_BUFFER_SIZE 16384              /* size of read buffer */
+#define VIO_DESCRIPTION_SIZE 30                 /* size of description */
+
+Vio* vio_new(my_socket sd, enum enum_vio_type type, uint flags);
+Vio*  mysql_socket_vio_new(struct st_mysql_socket mysql_socket, enum enum_vio_type type, uint flags);
+#ifdef __WIN__
+Vio* vio_new_win32pipe(HANDLE hPipe);
+Vio* vio_new_win32shared_memory(HANDLE handle_file_map,
+                                HANDLE handle_map,
+                                HANDLE event_server_wrote,
+                                HANDLE event_server_read,
+                                HANDLE event_client_wrote,
+                                HANDLE event_client_read,
+                                HANDLE event_conn_closed);
+#else
+#define HANDLE void *
+#endif /* __WIN__ */
+
+void    vio_delete(Vio* vio);
+int vio_shutdown(Vio* vio);
+my_bool vio_reset(Vio* vio, enum enum_vio_type type,
+                  my_socket sd, void *ssl, uint flags);
+size_t  vio_read(Vio *vio, uchar *	buf, size_t size);
+size_t  vio_read_buff(Vio *vio, uchar * buf, size_t size);
+size_t  vio_write(Vio *vio, const uchar * buf, size_t size);
+/* setsockopt TCP_NODELAY at IPPROTO_TCP level, when possible */
+int vio_fastsend(Vio *vio);
+/* setsockopt SO_KEEPALIVE at SOL_SOCKET level, when possible */
+int vio_keepalive(Vio *vio, my_bool	onoff);
+/* Whenever we should retry the last read/write operation. */
+my_bool vio_should_retry(Vio *vio);
+/* Check that operation was timed out */
+my_bool vio_was_timeout(Vio *vio);
+/* Short text description of the socket for those, who are curious.. */
+const char* vio_description(Vio *vio);
+/* Return the type of the connection */
+enum enum_vio_type vio_type(Vio* vio);
+/* Return last error number */
+int	vio_errno(Vio*vio);
+/* Get socket number */
+my_socket vio_fd(Vio*vio);
+/* Remote peer's address and name in text form */
+my_bool vio_peer_addr(Vio *vio, char *buf, uint16 *port, size_t buflen);
+/* Wait for an I/O event notification. */
+int vio_io_wait(Vio *vio, enum enum_vio_io_event event, int timeout);
+my_bool vio_is_connected(Vio *vio);
+/* Set timeout for a network operation. */
+int vio_timeout(Vio *vio, uint which, int timeout_sec);
+/* Connect to a peer. */
+my_bool vio_socket_connect(Vio *vio, struct sockaddr *addr, socklen_t len,
+                           int timeout);
+
+my_bool vio_get_normalized_ip_string(const struct sockaddr *addr, int addr_length,
+                                     char *ip_string, size_t ip_string_size);
+
+my_bool vio_is_no_name_error(int err_code);
+
+int vio_getnameinfo(const struct sockaddr *sa,
+                    char *hostname, size_t hostname_size,
+                    char *port, size_t port_size,
+                    int flags);
+
+#ifdef HAVE_OPENSSL
+#include <openssl/opensslv.h>
+#if OPENSSL_VERSION_NUMBER < 0x0090700f
+#define DES_cblock des_cblock
+#define DES_key_schedule des_key_schedule
+#define DES_set_key_unchecked(k,ks) des_set_key_unchecked((k),*(ks))
+#define DES_ede3_cbc_encrypt(i,o,l,k1,k2,k3,iv,e) des_ede3_cbc_encrypt((i),(o),(l),*(k1),*(k2),*(k3),(iv),(e))
+#endif
+/* apple deprecated openssl in MacOSX Lion */
+#ifdef __APPLE__
+#pragma GCC diagnostic ignored "-Wdeprecated-declarations"
+#endif
+
+#define HEADER_DES_LOCL_H dummy_something
+#define YASSL_MYSQL_COMPATIBLE
+#ifndef YASSL_PREFIX
+#define YASSL_PREFIX
+#endif
+/* Set yaSSL to use same type as MySQL do for socket handles */
+typedef my_socket YASSL_SOCKET_T;
+#define YASSL_SOCKET_T_DEFINED
+#include <openssl/ssl.h>
+#include <openssl/err.h>
+
+#ifndef EMBEDDED_LIBRARY
+enum enum_ssl_init_error
+{
+  SSL_INITERR_NOERROR= 0, SSL_INITERR_CERT, SSL_INITERR_KEY,
+  SSL_INITERR_NOMATCH, SSL_INITERR_BAD_PATHS, SSL_INITERR_CIPHERS,
+  SSL_INITERR_MEMFAIL, SSL_INITERR_DHFAIL, SSL_INITERR_LASTERR
+};
+const char* sslGetErrString(enum enum_ssl_init_error err);
+
+struct st_VioSSLFd
+{
+  SSL_CTX *ssl_context;
+};
+
+int sslaccept(struct st_VioSSLFd*, Vio *, long timeout, unsigned long *errptr);
+int sslconnect(struct st_VioSSLFd*, Vio *, long timeout, unsigned long *errptr);
+
+struct st_VioSSLFd
+*new_VioSSLConnectorFd(const char *key_file, const char *cert_file,
+                       const char *ca_file,  const char *ca_path,
+                       const char *cipher, enum enum_ssl_init_error *error,
+                       const char *crl_file, const char *crl_path);
+struct st_VioSSLFd
+*new_VioSSLAcceptorFd(const char *key_file, const char *cert_file,
+                      const char *ca_file,const char *ca_path,
+                      const char *cipher, enum enum_ssl_init_error *error,
+                      const char *crl_file, const char *crl_path);
+void free_vio_ssl_acceptor_fd(struct st_VioSSLFd *fd);
+#endif /* ! EMBEDDED_LIBRARY */
+#endif /* HAVE_OPENSSL */
+
+void ssl_start(void);
+void vio_end(void);
+
+#if !defined(DONT_MAP_VIO)
+#define vio_delete(vio)                         (vio)->viodelete(vio)
+#define vio_errno(vio)                          (vio)->vioerrno(vio)
+#define vio_read(vio, buf, size)                ((vio)->read)(vio,buf,size)
+#define vio_write(vio, buf, size)               ((vio)->write)(vio, buf, size)
+#define vio_fastsend(vio)                       (vio)->fastsend(vio)
+#define vio_keepalive(vio, set_keep_alive)  (vio)->viokeepalive(vio, set_keep_alive)
+#define vio_should_retry(vio)                   (vio)->should_retry(vio)
+#define vio_was_timeout(vio)                    (vio)->was_timeout(vio)
+#define vio_shutdown(vio)                       ((vio)->vioshutdown)(vio)
+#define vio_peer_addr(vio, buf, prt, buflen)    (vio)->peer_addr(vio, buf, prt, buflen)
+#define vio_io_wait(vio, event, timeout)        (vio)->io_wait(vio, event, timeout)
+#define vio_is_connected(vio)                   (vio)->is_connected(vio)
+#endif /* !defined(DONT_MAP_VIO) */
+
+/* This enumerator is used in parser - should be always visible */
+enum SSL_type
+{
+  SSL_TYPE_NOT_SPECIFIED= -1,
+  SSL_TYPE_NONE,
+  SSL_TYPE_ANY,
+  SSL_TYPE_X509,
+  SSL_TYPE_SPECIFIED
+};
+
+
+/* HFTODO - hide this if we don't want client in embedded server */
+/* This structure is for every connection on both sides */
+struct st_vio
+{
+  struct st_mysql_socket  mysql_socket;           /* Instrumented socket */
+  my_bool       localhost;              /* Are we from localhost? */
+  struct sockaddr_storage   local;      /* Local internet address */
+  struct sockaddr_storage   remote;     /* Remote internet address */
+  int addrLen;                          /* Length of remote address */
+  enum enum_vio_type    type;           /* Type of connection */
+  my_bool               inactive; /* Connection inactive (has been shutdown) */
+  char                  desc[VIO_DESCRIPTION_SIZE]; /* Description string. This
+                                                      member MUST NOT be
+                                                      used directly, but only
+                                                      via function
+                                                      "vio_description" */
+  char                  *read_buffer;   /* buffer for vio_read_buff */
+  char                  *read_pos;      /* start of unfetched data in the
+                                           read buffer */
+  char                  *read_end;      /* end of unfetched data */
+  int                   read_timeout;   /* Timeout value (ms) for read ops. */
+  int                   write_timeout;  /* Timeout value (ms) for write ops. */
+
+  /*
+     VIO vtable interface to be implemented by VIO's like SSL, Socket,
+     Named Pipe, etc.
+  */
+
+  /*
+     viodelete is responsible for cleaning up the VIO object by freeing
+     internal buffers, closing descriptors, handles.
+  */
+  void    (*viodelete)(Vio*);
+  int     (*vioerrno)(Vio*);
+  size_t  (*read)(Vio*, uchar *, size_t);
+  size_t  (*write)(Vio*, const uchar *, size_t);
+  int     (*timeout)(Vio*, uint, my_bool);
+  int     (*viokeepalive)(Vio*, my_bool);
+  int     (*fastsend)(Vio*);
+  my_bool (*peer_addr)(Vio*, char *, uint16*, size_t);
+  void    (*in_addr)(Vio*, struct sockaddr_storage*);
+  my_bool (*should_retry)(Vio*);
+  my_bool (*was_timeout)(Vio*);
+  /*
+     vioshutdown is resposnible to shutdown/close the channel, so that no
+     further communications can take place, however any related buffers,
+     descriptors, handles can remain valid after a shutdown.
+  */
+  int     (*vioshutdown)(Vio*);
+  my_bool (*is_connected)(Vio*);
+  my_bool (*has_data) (Vio*);
+  int (*io_wait)(Vio*, enum enum_vio_io_event, int);
+  my_bool (*connect)(Vio*, struct sockaddr *, socklen_t, int);
+#ifdef _WIN32
+  OVERLAPPED overlapped;
+  HANDLE hPipe;
+#endif
+#ifdef HAVE_OPENSSL
+  void    *ssl_arg;
+#endif
+#ifdef HAVE_SMEM
+  HANDLE  handle_file_map;
+  char    *handle_map;
+  HANDLE  event_server_wrote;
+  HANDLE  event_server_read;
+  HANDLE  event_client_wrote;
+  HANDLE  event_client_read;
+  HANDLE  event_conn_closed;
+  size_t  shared_memory_remain;
+  char    *shared_memory_pos;
+#endif /* HAVE_SMEM */
+};
+#endif /* vio_violite_h_ */

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -604,7 +604,7 @@ describe Mysql2::Client do
             @multi_client.next_result
           }
         }.to raise_error(ArgumentError)
-        expect(Time.now.to_f - time_top).to be <= 0.5
+        (Time.now.to_f - time_top).should be <= 0.5
 
       end
 

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -596,6 +596,18 @@ describe Mysql2::Client do
         @multi_client.more_results?.should be_false
       end
 
+      it "should allow for interruption" do
+        time_top = Time.now.to_f
+        expect {
+          Timeout.timeout(0.2, ArgumentError) {
+            @multi_client.query('SELECT 1; SELECT SLEEP(2)')
+            @multi_client.next_result
+          }
+        }.to raise_error(ArgumentError)
+        expect(Time.now.to_f - time_top).to be <= 0.5
+
+      end
+
       it "#more_results? should work with stored procedures" do
         @multi_client.query("DROP PROCEDURE IF EXISTS test_proc")
         @multi_client.query("CREATE PROCEDURE test_proc() BEGIN SELECT 1 AS 'set_1'; SELECT 2 AS 'set_2'; END")


### PR DESCRIPTION
We were a multi-statement query in our, and discovered that when queries other than the first query blocked, (`SELECT 1; SELECT SLEEP(3)`)  the call to `next_result` became completely uninterruptible.  This was fixed well enough by by wrapping the `next_result` call in `rb_thread_call_without_gvl`, but we subsequently found that the `next_result` call still wouldn't respond to `Thread#raise`, which we needed in order to perform some timeout logic.  

Went down the rabbit hole further to find that the `vio` suite of functions will over-read a buffer, so mysql2's methodology of calling `rb_wait_for_single_fd` really won't work reliably for `next_result` -- reading the first result in the `do_query` path will trigger a read of the result of the results (if they're ready), meaning that we'll poll forever; ugly.  I worked around this by directly calling `vio_has_data`, but in order to do that I had to include all of `violite.h`, and I can't say I'm particularly happy about it. 

Anyway, we probably are simply backing off our using of multi-statement selects, if you wanted to merge this (or had better ideas about how to properly poll for results when the c client library had buffered stuff), great.

(note, PR targets 0.3 just because thats what we're on still). 
