### PR TITLE
Handle being terminated while reading query result

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -647,26 +647,26 @@ static VALUE do_query(void *args) {
 
   return Qnil;
 }
-#else
-static VALUE finish_and_mark_inactive(void *args) {
-  VALUE self = args;
-  MYSQL_RES *result;
+#endif
 
+static VALUE disconnect_and_mark_inactive(VALUE self) {
   GET_CLIENT(self);
 
+  /* Check if execution terminated while result was still being read. */
   if (!NIL_P(wrapper->active_thread)) {
-    /* if we got here, the result hasn't been read off the wire yet
-       so lets do that and then throw it away because we have no way
-       of getting it back up to the caller from here */
-    result = (MYSQL_RES *)rb_thread_call_without_gvl(nogvl_store_result, wrapper, RUBY_UBF_IO, 0);
-    mysql_free_result(result);
-
+    /* Invalidate the MySQL socket to prevent further communication. */
+    if (invalidate_fd(wrapper->client->net.fd) == Qfalse) {
+      rb_warn("mysql2 failed to invalidate FD safely, closing unsafely\n");
+      close(wrapper->client->net.fd);
+    }
+    /* Skip mysql client check performed before command execution. */
+    wrapper->client->status = MYSQL_STATUS_READY;
     wrapper->active_thread = Qnil;
+    wrapper->connected = 0;
   }
 
   return Qnil;
 }
-#endif
 
 void rb_mysql_client_set_active_thread(VALUE self) {
   VALUE thread_current = rb_thread_current();
@@ -760,13 +760,13 @@ static VALUE rb_query(VALUE self, VALUE sql, VALUE current) {
 
     rb_rescue2(do_query, (VALUE)&async_args, disconnect_and_raise, self, rb_eException, (VALUE)0);
 
-    return rb_mysql_client_async_result(self);
+    return rb_ensure(rb_mysql_client_async_result, self, disconnect_and_mark_inactive, self);
   }
 #else
   do_send_query(&args);
 
   /* this will just block until the result is ready */
-  return rb_ensure(rb_mysql_client_async_result, self, finish_and_mark_inactive, self);
+  return rb_ensure(rb_mysql_client_async_result, self, disconnect_and_mark_inactive, self);
 #endif
 }
 

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -538,15 +538,6 @@ RSpec.describe Mysql2::Client do
         }.to raise_error(Mysql2::Error)
       end
 
-      it 'should be impervious to connection-corrupting timeouts in #query' do
-        pending('`Thread.handle_interrupt` is not defined') unless Thread.respond_to?(:handle_interrupt)
-        # attempt to break the connection
-        expect { Timeout.timeout(0.1) { @client.query('SELECT SLEEP(0.2)') } }.to raise_error(Timeout::Error)
-
-        # expect the connection to not be broken
-        expect { @client.query('SELECT 1') }.to_not raise_error
-      end
-
       it 'should be impervious to connection-corrupting timeouts in #execute' do
         # the statement handle gets corrupted and will segfault the tests if interrupted,
         # so we can't even use pending on this test, really have to skip it on older Rubies.


### PR DESCRIPTION
The problem is that if execution is terminated while reading a result set, the next attempt to execute a query on the connection fails with "This connection is still waiting for a result, try again once you have the result". This error persists even if reconnect is enabled.

The issue stems from reading the result set using `rb_thread_call_without_gvl`. If the calling thread is terminated inside `rb_thread_call_without_gvl`, the function does not return and the caller doesn't get a chance to reset the active thread associated with the connection — which normally happens after the result set has been read.

The solution is to disconnect and mark the connection as inactive if the thread is terminated while reading a result set.