### PR TITLE
Segfault on SIGINT (race condition)

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -596,9 +596,11 @@ static VALUE disconnect_and_raise(VALUE self, VALUE error) {
   /* Invalidate the MySQL socket to prevent further communication.
    * The GC will come along later and call mysql_close to free it.
    */
-  if (invalidate_fd(wrapper->client->net.fd) == Qfalse) {
-    fprintf(stderr, "[WARN] mysql2 failed to invalidate FD safely, closing unsafely\n");
-    close(wrapper->client->net.fd);
+  if (wrapper->client) {
+    if (invalidate_fd(wrapper->client->net.fd) == Qfalse) {
+      fprintf(stderr, "[WARN] mysql2 failed to invalidate FD safely, closing unsafely\n");
+      close(wrapper->client->net.fd);
+    }
   }
 
   rb_exc_raise(error);


### PR DESCRIPTION
We have faced a pretty weird edge case recently. Multiple threads, slow MySQL query, and Unicorn killing the worker due to timeout lead to segfault in Mysql2 gem (`disconnect_and_raise` method).

Short version: when there are multiple threads and a signal, it is possible that `disconnect_and_raise` might be called after `close`, leading to a segfault.

Reproducible on Linux x86_64 with the following code:

```ruby
clients = []
10.times do |idx|
  Thread.new do
    # Simulate SQL query
    conn = Mysql2::Client.new
    clients << conn
    conn.query('SELECT SLEEP(120)')
  end
end

Thread.new do
  # Emulates Unicorn sending SIGINT signal when timeout is reached.
  # This code will be executed with a delay of 1 second
  # so the SIGINT will arrive during sleep in the main thread.
  sleep 1
  Process.kill('INT', $$)
end
sleep 5
# Segfault here
clients.each(&:close)
```
