### PR TITLE
Delete existing mysql data at installation MySQL 5.7.

### DIFF
--- a/.travis_mysql57.sh
+++ b/.travis_mysql57.sh
@@ -3,6 +3,8 @@
 set -eux
 
 apt-get purge -qq '^mysql*' '^libmysql*'
+rm -fr /etc/mysql
+rm -fr /var/lib/mysql
 apt-key adv --keyserver pgp.mit.edu --recv-keys 5072E1F5
 add-apt-repository 'deb http://repo.mysql.com/apt/ubuntu/ trusty mysql-5.7'
 apt-get update -qq


### PR DESCRIPTION
Delete Travis default MySQL data directories. MySQL 5.7 test passes.