### PR TITLE
Change default CI Ruby version to 2.4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,7 +18,7 @@ addons:
     - mysql-client-core-5.6
     - mysql-client-5.6
 rvm:
-  - 2.4
+  - 2.4.0
   - 2.3
   - 2.2
   - 2.1
@@ -49,25 +49,25 @@ matrix:
           - mysql-server-5.5
           - mysql-client-core-5.5
           - mysql-client-5.5
-    - rvm: 2.0.0
+    - rvm: 2.4.0
       env: DB=mariadb55
       addons:
         mariadb: 5.5
         hosts:
           - mysql2gem.example.com
-    - rvm: 2.0.0
+    - rvm: 2.4.0
       env: DB=mariadb10.0
       addons:
         mariadb: 10.0
         hosts:
           - mysql2gem.example.com
-    - rvm: 2.0.0
+    - rvm: 2.4.0
       env: DB=mariadb10.1
       addons:
         mariadb: 10.1
         hosts:
           - mysql2gem.example.com
-    - rvm: 2.0.0
+    - rvm: 2.4.0
       env: DB=mysql55
       dist: precise
       addons:
@@ -78,17 +78,17 @@ matrix:
           - mysql-server-5.5
           - mysql-client-core-5.5
           - mysql-client-5.5
-    - rvm: 2.0.0
+    - rvm: 2.4.0
       env: DB=mysql57
       addons:
         hosts:
           - mysql2gem.example.com
-    - rvm: 2.0.0
+    - rvm: 2.4.0
       env: DB=mysql80
       addons:
         hosts:
           - mysql2gem.example.com
-    - rvm: 2.0.0
+    - rvm: 2.4.0
       env: DB=mysql56
       os: osx
       addons:
@@ -97,6 +97,6 @@ matrix:
   fast_finish: true
   allow_failures:
     - rvm: ruby-head
-    - rvm: 2.0.0
+    - rvm: 2.4.0
       env: DB=mysql56
       os: osx


### PR DESCRIPTION
This PR is an alternative of https://github.com/brianmario/mysql2/pull/820.
Current travis CI x rvm interprets `rvm 2.4` as "ruby 2.4.0rc1".
We should explicitly set "2.4.0" :(

https://travis-ci.org/brianmario/mysql2/jobs/189050416 line 292 says "ruby 2.4.0rc1 (2016-12-12 trunk 57064) [x86_64-linux]".