### PR TITLE
Better error messages when the connection options have errors

### DIFF
--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -37,7 +37,7 @@ module Mysql2
         when :reconnect, :local_infile, :secure_auth, :automatic_close
           send(:"#{key}=", !!opts[key]) # rubocop:disable Style/DoubleNegation
         when :connect_timeout, :read_timeout, :write_timeout
-          send(:"#{key}=", opts[key].to_i) unless opts[key].nil?
+          send(:"#{key}=", Integer(opts[key])) unless opts[key].nil?
         else
           send(:"#{key}=", opts[key])
         end


### PR DESCRIPTION
Why:

To avoid cryptic errors and to give better error messages back to
  the user. Say the user uses this connection string:

```
DATABASE_URL="mysql2://<database>:<password>@<host>:<port>/<db>?encoding=utf8&pool=1&connect_timeout=2read_timeout=5&write_timeout=5"
```

With the current code, the `connect_timeout=2` and `read_timeout` will
be ignored (as the connection string is missing a `&`). A better
approach would be to evaluate the input as an integer and output an
error message if it isn't one. For more info see the discussion in the
PR below.

This change addresses the need by:

* https://github.com/brianmario/mysql2/pull/791