### PR TITLE
Use `bool` instead of `my_bool` which has been removed since MySQL 8.0.1

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -111,7 +111,7 @@ static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
   int val = NUM2INT( setting );
   if (version >= 50703 && version < 50711) {
     if (val == SSL_MODE_DISABLED || val == SSL_MODE_REQUIRED) {
-      my_bool b = ( val == SSL_MODE_REQUIRED );
+      bool b = ( val == SSL_MODE_REQUIRED );
       int result = mysql_options( wrapper->client, MYSQL_OPT_SSL_ENFORCE, &b );
       return INT2NUM(result);
       
@@ -504,7 +504,7 @@ static VALUE do_send_query(void *args) {
  */
 static void *nogvl_read_query_result(void *ptr) {
   MYSQL * client = ptr;
-  my_bool res = mysql_read_query_result(client);
+  bool res = mysql_read_query_result(client);
 
   return (void *)(res == 0 ? Qtrue : Qfalse);
 }
@@ -827,7 +827,7 @@ static VALUE _mysql_client_options(VALUE self, int opt, VALUE value) {
   const void *retval = NULL;
   unsigned int intval = 0;
   const char * charval = NULL;
-  my_bool boolval;
+  bool boolval;
 
   GET_CLIENT(self);
 

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -262,8 +262,8 @@ static void rb_mysql_result_alloc_result_buffers(VALUE self, MYSQL_FIELD *fields
   if (wrapper->result_buffers != NULL) return;
 
   wrapper->result_buffers = xcalloc(wrapper->numberOfFields, sizeof(MYSQL_BIND));
-  wrapper->is_null = xcalloc(wrapper->numberOfFields, sizeof(my_bool));
-  wrapper->error = xcalloc(wrapper->numberOfFields, sizeof(my_bool));
+  wrapper->is_null = xcalloc(wrapper->numberOfFields, sizeof(bool));
+  wrapper->error = xcalloc(wrapper->numberOfFields, sizeof(bool));
   wrapper->length = xcalloc(wrapper->numberOfFields, sizeof(unsigned long));
 
   for (i = 0; i < wrapper->numberOfFields; i++) {

--- a/ext/mysql2/result.h
+++ b/ext/mysql2/result.h
@@ -1,5 +1,6 @@
 #ifndef MYSQL2_RESULT_H
 #define MYSQL2_RESULT_H
+#include <stdbool.h>
 
 void init_mysql2_result(void);
 VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_RES *r, VALUE statement);
@@ -21,8 +22,8 @@ typedef struct {
   mysql_client_wrapper *client_wrapper;
   /* statement result bind buffers */
   MYSQL_BIND *result_buffers;
-  my_bool *is_null;
-  my_bool *error;
+  bool *is_null;
+  bool *error;
   unsigned long *length;
 } mysql2_result_wrapper;
 

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -124,7 +124,7 @@ VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql) {
 
   // set STMT_ATTR_UPDATE_MAX_LENGTH attr
   {
-    my_bool truth = 1;
+    bool truth = 1;
     if (mysql_stmt_attr_set(stmt_wrapper->stmt, STMT_ATTR_UPDATE_MAX_LENGTH, &truth)) {
       rb_raise(cMysql2Error, "Unable to initialize prepared statement: set STMT_ATTR_UPDATE_MAX_LENGTH");
     }


### PR DESCRIPTION
This pull request addresses #838

Refer "Changes in MySQL 8.0.1 (2017-04-10, Development Milestone)"
https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-1.html

> Incompatible Change: The mysql.h header file now requires a C++ or C99 compiler to compile.
> The my_bool type is no longer used in MySQL source code.
> Any third-party code that used this type to represent C boolean variables
> should use the bool or int C type instead. (Bug #25597667)