### PR TITLE
Fix use after free of client field when closing with reconnect option

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -266,9 +266,12 @@ static VALUE invalidate_fd(int clientfd)
 static void *nogvl_close(void *ptr) {
   mysql_client_wrapper *wrapper = ptr;
 
-  mysql_close(wrapper->client);
-  wrapper->reconnect_enabled = 0;
-  wrapper->active_thread = Qnil;
+  if (!wrapper->closed) {
+    mysql_close(wrapper->client);
+    wrapper->closed = 1;
+    wrapper->reconnect_enabled = 0;
+    wrapper->active_thread = Qnil;
+  }
 
   return NULL;
 }
@@ -319,6 +322,7 @@ static VALUE allocate(VALUE klass) {
   wrapper->connect_timeout = 0;
   wrapper->initialized = 0; /* means that that the wrapper is initialized */
   wrapper->refcount = 1;
+  wrapper->closed = 0;
   wrapper->client = (MYSQL*)xmalloc(sizeof(MYSQL));
 
   return obj;

--- a/ext/mysql2/client.h
+++ b/ext/mysql2/client.h
@@ -46,7 +46,7 @@ typedef struct {
   int automatic_close;
   int initialized;
   int refcount;
-  int freed;
+  int closed;
   MYSQL *client;
 } mysql_client_wrapper;
 

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -306,6 +306,14 @@ RSpec.describe Mysql2::Client do
     end
   end
 
+  it "should not try to query closed mysql connection" do
+    client = Mysql2::Client.new(DatabaseCredentials['root'].merge(:reconnect => true))
+    expect(client.close).to be_nil
+    expect {
+      client.query "SELECT 1"
+    }.to raise_error(Mysql2::Error)
+  end
+
   it "should respond to #query" do
     expect(@client).to respond_to(:query)
   end


### PR DESCRIPTION
## Problem

The following script would cause a crash

```ruby
require 'mysql2'
client = Mysql2::Client.new(username: 'root', reconnect: true)
client.close
client.query "SELECT 1"
```

because Mysql2::Client#close frees the `wrapper->client`, then several methods were missing any checks to make sure `wrapper->client != NULL`.

When the `reconnect: true` option isn't used, then Mysql2::Client#close will set `wrapper->connected = 0`, so the `REQUIRE_CONNECTED` macro would raise, but the `reconnect: true` option skips this check.

## Solution

~~Add a `REQUIRE_CLIENT` macro which raises if `wrapper->client == NULL`, and is used in `REQUIRE_CONNECTED` as well as in methods that didn't use the REQUIRE_CONNECTED macro.~~

Delay freeing the `wrapper->client` until the wrapper is being freed during garbage collection.  Instead, just have the Mysql2::Client#close method call mysql_close, mark the connection not connected and disable the reconnect option.  That way the `REQUIRE_CONNECTED` macro will raise after the close method is called and methods that don't use the REQUIRE_CONNECTED macro won't access freed memory.