### PR TITLE
Avoid invalidating re-assigned socket fd by fixing connected check

### DIFF
--- a/ext/mysql2/client.h
+++ b/ext/mysql2/client.h
@@ -44,7 +44,6 @@ typedef struct {
   unsigned int connect_timeout;
   int active;
   int automatic_close;
-  int connected;
   int initialized;
   int refcount;
   int freed;


### PR DESCRIPTION
~~Depends on and includes https://github.com/brianmario/mysql2/pull/846 to avoid crashes in tests.~~

## Problem

If a client loses its connection to mysql when reading the response, then libmysqlclient closes the connection, but the mysql2 gem doesn't set its `connected` field to `0`.  If the client is used to make another request, then it will get a write error upon which it will try to disconnect the socket manually, even though the socket's file descriptor may have already re-assigned.

I am able to reproduce this problem on macOS and linux with the following script run against master

```ruby
require 'mysql2'

client_options = { username: 'root', host: 'localhost' }

def assert(condition)
  raise unless condition
end

def assert_raises(error_class)
  yield
  raise "expected an #{error_class} exception but no exception was raised"
rescue error_class => err
  err
end

client = Mysql2::Client.new(client_options)

# kill connection with a delay to interrupt reading the
# response rather than interrupting writing the request
connection_id = client.thread_id
thread = Thread.new do
  sleep(0.5)
  supervisor = Mysql2::Client.new(client_options)
  supervisor.query("KILL #{connection_id}")
  supervisor.close
end

err = assert_raises(Mysql2::Error) do
  client.query("SELECT SLEEP(3)").to_a
end
assert err.message.match(/Lost connection to MySQL server/)

# Mysql2::Client's `connected` field hasn't been set to 0 to indicate the
# the connection has been lost
client.socket

# but libmysqlclient has detected the connection was lost and has already closed the socket
assert_raises(Errno::EBADF) do
  IO.for_fd(client.socket, autoclose: false)
end

# unix systems seem to assign the lowest-numbered unused file descriptor
# for a new file descriptor, so this connection gets the same socket number
other_client = Mysql2::Client.new(client_options)
assert client.socket == other_client.socket

# if the application tries to make another request on the client with the
# closed connection, then Mysql2::Client will try to send the request
# using libmysqlclient, which will return an error right away since it
# knows it has closed the socket.
#
# mysql2's do_send_query function will turn the error into an exception
# and raise it, which the `rb_query` function will rescue using
# `disconnect_and_raise`. `disconnect_and_raise` will use `invalidate_fd`
# to close the socket in a way that doesn't affect a parent process, but
# it is doing so on the reassigned socket number, so will actually replace
# the reassigned socket's file descriptor with /dev/null using `dup2`
err = assert_raises(Mysql2::Error) do
  client.query("SELECT 2").to_a
end
assert err.message.match(/MySQL server has gone away/)

# We can stat the file descriptor to show that the socket now points to /dev/null
assert File.open("/dev/null").stat == IO.for_fd(other_client.socket, autoclose: false).stat

# and of course making a request to /dev/null fails
err = assert_raises(Mysql2::Error) do
  other_client.query("SELECT 3").to_a
  raise "exception expected"
end
assert err.message.match(/MySQL server has gone away/)
```

The problem is the combination of the gem not keeping track of the `connected` state accurately enough and the fact that it tries to invalidate libmysqlclient's file descriptor.

Ideally we wouldn't be closing libmysqlclient's socket directly, since that seems like something that should be managed by libmysqlclient.  However, `mysql_close` sends a QUIT message, so commit https://github.com/brianmario/mysql2/commit/f4f1af84cf002f97f45836f8b5cdbdee3c3ed6ca didn't use it to avoid blocking waiting for a result.

## Solution

We need to make sure Mysql2::Client can accurately determine whether the socket has been closed by libmysqlclient, since it is getting the socket from the MYSQL struct and that `fd` field isn't getting cleared in any way to indicate that it is closed.

However, trying to keep a connected field in the mysql2 in sync with a similar state in libmysqlclient seems quite fragile, since this library doesn't directly expose this state.  Keeping these in sync would require checking for error codes whenever calling a libmysqlclient function that could close the socket and updating the `connected` field in this gem's wrapper struct accordingly, including for the success case where libmysqlclient reconnects.  Any mistakes in keeping this state in sync could result in the same bug where the wrong file descriptor may be invalidated.  As such, I decided to get rid of the `connected` field in the wrapper struct and just look in the MYSQL struct to check if there is an open socket.

libmysqlclient doesn't actually use the `net.fd` field.  It has a `/* For Perl DBI/dbd */` comment on that struct field that indicates that it only continues to exist for old client compatibility.  Instead, the `vio` field is used to read/write to the socket, which is set to `NULL` in the [end_server function](https://github.com/mysql/mysql-server/blob/ad88f2a7b5c5827cb1ba78eee3497fb851b37a9f/sql-common/client.c#L1076) after it the socket is closed through `vio_delete(mysql->net.vio)`.  So this pull request uses `net.vio != NULL` to check if libmysqlclient thinks the socket hasn't been closed.

This gem also invalidates and closes `net.fd` directly (e.g. `disconnect_and_mark_inactive`), which was one of the reasons for keeping the `connected` state in the wrapper.  I wanted the gem to also detect this disconnection, so used `net.fd = -1` to mark the fd as disconnected so that the socket fd isn't exposed in this state when the Mysql2::Client#socket ruby method is called.