### PR TITLE
Close several unclosed clients in tests

### DIFF
--- a/spec/em/em_spec.rb
+++ b/spec/em/em_spec.rb
@@ -70,6 +70,7 @@ begin
       let(:client) { Mysql2::EM::Client.new DatabaseCredentials['root'] }
       let(:error) { StandardError.new('some error') }
       before { allow(client).to receive(:async_result).and_raise(error) }
+      after { client.close }
 
       it "should swallow exceptions raised in by the client" do
         errors = []

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -6,17 +6,14 @@ RSpec.describe Mysql2::Client do
     let(:cnf_file) { File.expand_path('../../my.cnf', __FILE__) }
 
     it "should not raise an exception for valid defaults group" do
-      @client.close
       expect {
-        opts = DatabaseCredentials['root'].merge(:default_file => cnf_file, :default_group => "test")
-        @client = Mysql2::Client.new(opts)
+        new_client(:default_file => cnf_file, :default_group => "test")
       }.not_to raise_error
     end
 
     it "should not raise an exception without default group" do
-      @client.close
       expect {
-        @client = Mysql2::Client.new(DatabaseCredentials['root'].merge(:default_file => cnf_file))
+        new_client(:default_file => cnf_file)
       }.not_to raise_error
     end
   end
@@ -25,29 +22,29 @@ RSpec.describe Mysql2::Client do
     expect {
       # The odd local host IP address forces the mysql client library to
       # use a TCP socket rather than a domain socket.
-      Mysql2::Client.new DatabaseCredentials['root'].merge('host' => '127.0.0.2', 'port' => 999999)
+      new_client('host' => '127.0.0.2', 'port' => 999999)
     }.to raise_error(Mysql2::Error)
   end
 
   it "should raise an exception on create for invalid encodings" do
     expect {
-      Mysql2::Client.new(DatabaseCredentials['root'].merge(:encoding => "fake"))
+      new_client(:encoding => "fake")
     }.to raise_error(Mysql2::Error)
   end
 
   it "should raise an exception on non-string encodings" do
     expect {
-      Mysql2::Client.new(DatabaseCredentials['root'].merge(:encoding => :fake))
+      new_client(:encoding => :fake)
     }.to raise_error(TypeError)
   end
 
   it "should not raise an exception on create for a valid encoding" do
     expect {
-      Mysql2::Client.new(DatabaseCredentials['root'].merge(:encoding => "utf8"))
+      new_client(:encoding => "utf8")
     }.not_to raise_error
 
     expect {
-      Mysql2::Client.new(DatabaseCredentials['root'].merge(:encoding => "big5"))
+      new_client(DatabaseCredentials['root'].merge(:encoding => "big5"))
     }.not_to raise_error
   end
 
@@ -90,17 +87,16 @@ RSpec.describe Mysql2::Client do
   it "should execute init command" do
     options = DatabaseCredentials['root'].dup
     options[:init_command] = "SET @something = 'setting_value';"
-    client = Mysql2::Client.new(options)
+    client = new_client(options)
     result = client.query("SELECT @something;")
     expect(result.first['@something']).to eq('setting_value')
-    client.close
   end
 
   it "should send init_command after reconnect" do
     options = DatabaseCredentials['root'].dup
     options[:init_command] = "SET @something = 'setting_value';"
     options[:reconnect] = true
-    client = Mysql2::Client.new(options)
+    client = new_client(options)
 
     result = client.query("SELECT @something;")
     expect(result.first['@something']).to eq('setting_value')
@@ -124,7 +120,6 @@ RSpec.describe Mysql2::Client do
     # At last, check that the init command executed
     result = client.query("SELECT @something;")
     expect(result.first['@something']).to eq('setting_value')
-    client.close
   end
 
   it "should have a global default_query_options hash" do
@@ -142,15 +137,13 @@ RSpec.describe Mysql2::Client do
     ssl_client = nil
     expect {
       # rubocop:disable Style/TrailingComma
-      ssl_client = Mysql2::Client.new(
-        DatabaseCredentials['root'].merge(
-          'host'     => 'mysql2gem.example.com', # must match the certificates
-          :sslkey    => '/etc/mysql/client-key.pem',
-          :sslcert   => '/etc/mysql/client-cert.pem',
-          :sslca     => '/etc/mysql/ca-cert.pem',
-          :sslcipher => 'DHE-RSA-AES256-SHA',
-          :sslverify => true
-        )
+      ssl_client = new_client(
+        'host'     => 'mysql2gem.example.com', # must match the certificates
+        :sslkey    => '/etc/mysql/client-key.pem',
+        :sslcert   => '/etc/mysql/client-cert.pem',
+        :sslca     => '/etc/mysql/ca-cert.pem',
+        :sslcipher => 'DHE-RSA-AES256-SHA',
+        :sslverify => true
       )
       # rubocop:enable Style/TrailingComma
     }.not_to raise_error
@@ -161,8 +154,6 @@ RSpec.describe Mysql2::Client do
 
     expect(ssl_client.ssl_cipher).not_to be_empty
     expect(results['Ssl_cipher']).to eql(ssl_client.ssl_cipher)
-
-    ssl_client.close
   end
 
   def run_gc
@@ -214,42 +205,35 @@ RSpec.describe Mysql2::Client do
 
   context "#automatic_close" do
     it "is enabled by default" do
-      client = Mysql2::Client.new(DatabaseCredentials['root'])
-      expect(client.automatic_close?).to be(true)
-      client.close
+      expect(new_client.automatic_close?).to be(true)
     end
 
     if RUBY_PLATFORM =~ /mingw|mswin/
       it "cannot be disabled" do
-        client = nil
         expect do
-          client = Mysql2::Client.new(DatabaseCredentials['root'].merge(:automatic_close => false))
+          client = new_client(:automatic_close => false)
           expect(client.automatic_close?).to be(true)
         end.to output(/always closed by garbage collector/).to_stderr
-        client.close
 
         expect do
-          client = Mysql2::Client.new(DatabaseCredentials['root'].merge(:automatic_close => true))
+          client = new_client(:automatic_close => true)
           expect(client.automatic_close?).to be(true)
         end.to_not output(/always closed by garbage collector/).to_stderr
-        client.close
 
         expect do
-          client = Mysql2::Client.new(DatabaseCredentials['root'].merge(:automatic_close => true))
+          client = new_client(:automatic_close => true)
           client.automatic_close = false
           expect(client.automatic_close?).to be(true)
         end.to output(/always closed by garbage collector/).to_stderr
-        client.close
       end
     else
       it "can be configured" do
-        client = Mysql2::Client.new(DatabaseCredentials['root'].merge(:automatic_close => false))
+        client = new_client(:automatic_close => false)
         expect(client.automatic_close?).to be(false)
-        client.close
       end
 
       it "can be assigned" do
-        client = Mysql2::Client.new(DatabaseCredentials['root'])
+        client = new_client
         client.automatic_close = false
         expect(client.automatic_close?).to be(false)
 
@@ -261,7 +245,6 @@ RSpec.describe Mysql2::Client do
 
         client.automatic_close = 9
         expect(client.automatic_close?).to be(true)
-        client.close
       end
 
       it "should not close connections when running in a child process" do
@@ -290,7 +273,7 @@ RSpec.describe Mysql2::Client do
     @client.query "CREATE DATABASE IF NOT EXISTS `#{database}`"
 
     expect {
-      Mysql2::Client.new(DatabaseCredentials['root'].merge('database' => database))
+      new_client('database' => database)
     }.not_to raise_error
 
     @client.query "DROP DATABASE IF EXISTS `#{database}`"
@@ -319,7 +302,7 @@ RSpec.describe Mysql2::Client do
   end
 
   it "should not try to query closed mysql connection" do
-    client = Mysql2::Client.new(DatabaseCredentials['root'].merge(:reconnect => true))
+    client = new_client(:reconnect => true)
     expect(client.close).to be_nil
     expect {
       client.query "SELECT 1"
@@ -382,72 +365,74 @@ RSpec.describe Mysql2::Client do
 
   context ":local_infile" do
     before(:all) do
-      @client_i = Mysql2::Client.new DatabaseCredentials['root'].merge(:local_infile => true)
-      local = @client_i.query "SHOW VARIABLES LIKE 'local_infile'"
-      local_enabled = local.any? { |x| x['Value'] == 'ON' }
-      pending("DON'T WORRY, THIS TEST PASSES - but LOCAL INFILE is not enabled in your MySQL daemon.") unless local_enabled
+      new_client(:local_infile => true) do |client|
+        local = client.query "SHOW VARIABLES LIKE 'local_infile'"
+        local_enabled = local.any? { |x| x['Value'] == 'ON' }
+        pending("DON'T WORRY, THIS TEST PASSES - but LOCAL INFILE is not enabled in your MySQL daemon.") unless local_enabled
 
-      @client_i.query %[
-        CREATE TABLE IF NOT EXISTS infileTest (
-          id MEDIUMINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
-          foo VARCHAR(10),
-          bar MEDIUMTEXT
-        )
-      ]
+        client.query %[
+          CREATE TABLE IF NOT EXISTS infileTest (
+            id MEDIUMINT NOT NULL AUTO_INCREMENT PRIMARY KEY,
+            foo VARCHAR(10),
+            bar MEDIUMTEXT
+          )
+        ]
+      end
     end
 
     after(:all) do
-      @client_i.query "DROP TABLE infileTest"
-      @client_i.close
+      new_client do |client|
+        client.query "DROP TABLE infileTest"
+      end
     end
 
     it "should raise an error when local_infile is disabled" do
-      client = Mysql2::Client.new DatabaseCredentials['root'].merge(:local_infile => false)
+      client = new_client(:local_infile => false)
       expect {
         client.query "LOAD DATA LOCAL INFILE 'spec/test_data' INTO TABLE infileTest"
       }.to raise_error(Mysql2::Error, /command is not allowed/)
-      client.close
     end
 
     it "should raise an error when a non-existent file is loaded" do
+      client = new_client(:local_infile => true)
       expect {
-        @client_i.query "LOAD DATA LOCAL INFILE 'this/file/is/not/here' INTO TABLE infileTest"
+        client.query "LOAD DATA LOCAL INFILE 'this/file/is/not/here' INTO TABLE infileTest"
       }.to raise_error(Mysql2::Error, 'No such file or directory: this/file/is/not/here')
     end
 
     it "should LOAD DATA LOCAL INFILE" do
-      @client_i.query "LOAD DATA LOCAL INFILE 'spec/test_data' INTO TABLE infileTest"
-      info = @client_i.query_info
+      client = new_client(:local_infile => true)
+      client.query "LOAD DATA LOCAL INFILE 'spec/test_data' INTO TABLE infileTest"
+      info = client.query_info
       expect(info).to eql(:records => 1, :deleted => 0, :skipped => 0, :warnings => 0)
 
-      result = @client_i.query "SELECT * FROM infileTest"
+      result = client.query "SELECT * FROM infileTest"
       expect(result.first).to eql('id' => 1, 'foo' => 'Hello', 'bar' => 'World')
     end
   end
 
   it "should expect connect_timeout to be a positive integer" do
     expect {
-      Mysql2::Client.new(DatabaseCredentials['root'].merge(:connect_timeout => -1))
+      new_client(:connect_timeout => -1)
     }.to raise_error(Mysql2::Error)
   end
 
   it "should expect read_timeout to be a positive integer" do
     expect {
-      Mysql2::Client.new(DatabaseCredentials['root'].merge(:read_timeout => -1))
+      new_client(:read_timeout => -1)
     }.to raise_error(Mysql2::Error)
   end
 
   it "should expect write_timeout to be a positive integer" do
     expect {
-      Mysql2::Client.new(DatabaseCredentials['root'].merge(:write_timeout => -1))
+      new_client(:write_timeout => -1)
     }.to raise_error(Mysql2::Error)
   end
 
   it "should allow nil read_timeout" do
-    client = Mysql2::Client.new(DatabaseCredentials['root'].merge(:read_timeout => nil))
+    client = new_client(:read_timeout => nil)
 
     expect(client.read_timeout).to be_nil
-    client.close
   end
 
   context "#query" do
@@ -545,7 +530,7 @@ RSpec.describe Mysql2::Client do
       end
 
       it "should timeout if we wait longer than :read_timeout" do
-        client = Mysql2::Client.new(DatabaseCredentials['root'].merge(:read_timeout => 0))
+        client = new_client(:read_timeout => 0)
         expect {
           client.query('SELECT SLEEP(0.1)')
         }.to raise_error(Mysql2::Error)
@@ -618,11 +603,10 @@ RSpec.describe Mysql2::Client do
             pending('libmysqlclient 5.5 on OSX is afflicted by an unknown bug that breaks this test. See #633 and #634.')
           end
 
-          client = Mysql2::Client.new(DatabaseCredentials['root'].merge(:reconnect => true))
+          client = new_client(:reconnect => true)
 
           expect { Timeout.timeout(0.1, ArgumentError) { client.query('SELECT SLEEP(1)') } }.to raise_error(ArgumentError)
           expect { client.query('SELECT 1') }.to_not raise_error
-          client.close
         end
 
         it "should handle Timeouts without leaving the connection hanging if reconnect is set to true after construction" do
@@ -630,7 +614,7 @@ RSpec.describe Mysql2::Client do
             pending('libmysqlclient 5.5 on OSX is afflicted by an unknown bug that breaks this test. See #633 and #634.')
           end
 
-          client = Mysql2::Client.new(DatabaseCredentials['root'])
+          client = new_client
 
           expect { Timeout.timeout(0.1, ArgumentError) { client.query('SELECT SLEEP(1)') } }.to raise_error(ArgumentError)
           expect { client.query('SELECT 1') }.to raise_error(Mysql2::Error)
@@ -639,7 +623,6 @@ RSpec.describe Mysql2::Client do
 
           expect { Timeout.timeout(0.1, ArgumentError) { client.query('SELECT SLEEP(1)') } }.to raise_error(ArgumentError)
           expect { client.query('SELECT 1') }.to_not raise_error
-          client.close
         end
       end
 
@@ -649,9 +632,9 @@ RSpec.describe Mysql2::Client do
         # Note that each thread opens its own database connection
         threads = 5.times.map do
           Thread.new do
-            client = Mysql2::Client.new(DatabaseCredentials.fetch('root'))
-            client.query("SELECT SLEEP(#{sleep_time})")
-            client.close
+            new_client do |client|
+              client.query("SELECT SLEEP(#{sleep_time})")
+            end
             Thread.current.object_id
           end
         end
@@ -688,11 +671,7 @@ RSpec.describe Mysql2::Client do
 
     context "Multiple results sets" do
       before(:each) do
-        @multi_client = Mysql2::Client.new(DatabaseCredentials['root'].merge(:flags => Mysql2::Client::MULTI_STATEMENTS))
-      end
-
-      after(:each) do
-        @multi_client.close
+        @multi_client = new_client(:flags => Mysql2::Client::MULTI_STATEMENTS)
       end
 
       it "should raise an exception when one of multiple statements fails" do
@@ -849,7 +828,7 @@ RSpec.describe Mysql2::Client do
     context 'when mysql encoding is not utf8' do
       before { pending('Encoding is undefined') unless defined?(Encoding) }
 
-      let(:client) { Mysql2::Client.new(DatabaseCredentials['root'].merge(:encoding => "ujis")) }
+      let(:client) { new_client(:encoding => "ujis") }
 
       it 'should return a internal encoding string if Encoding.default_internal is set' do
         with_internal_encoding Encoding::UTF_8 do
@@ -918,7 +897,7 @@ RSpec.describe Mysql2::Client do
       with_internal_encoding nil do
         expect(@client.server_info[:version].encoding).to eql(Encoding::UTF_8)
 
-        client2 = Mysql2::Client.new(DatabaseCredentials['root'].merge(:encoding => 'ascii'))
+        client2 = new_client(:encoding => 'ascii')
         expect(client2.server_info[:version].encoding).to eql(Encoding::ASCII)
       end
     end
@@ -936,11 +915,11 @@ RSpec.describe Mysql2::Client do
 
   it "should raise a Mysql2::Error exception upon connection failure" do
     expect {
-      Mysql2::Client.new :host => "localhost", :username => 'asdfasdf8d2h', :password => 'asdfasdfw42'
+      new_client(:host => "localhost", :username => 'asdfasdf8d2h', :password => 'asdfasdfw42')
     }.to raise_error(Mysql2::Error)
 
     expect {
-      Mysql2::Client.new DatabaseCredentials['root']
+      new_client(DatabaseCredentials['root'])
     }.not_to raise_error
   end
 

--- a/spec/mysql2/error_spec.rb
+++ b/spec/mysql2/error_spec.rb
@@ -3,19 +3,15 @@
 require 'spec_helper'
 
 RSpec.describe Mysql2::Error do
-  let(:client) { Mysql2::Client.new(DatabaseCredentials['root']) }
-
   let(:error) do
     begin
-      client.query("HAHAHA")
+      @client.query("HAHAHA")
     rescue Mysql2::Error => e
       error = e
     end
 
     error
   end
-
-  after(:each) { client.close }
 
   it "responds to error_number and sql_state, with aliases" do
     expect(error).to respond_to(:error_number)
@@ -30,7 +26,7 @@ RSpec.describe Mysql2::Error do
     let(:valid_utf8) { '造字' }
     let(:error) do
       begin
-        client.query(valid_utf8)
+        @client.query(valid_utf8)
       rescue Mysql2::Error => e
         e
       end
@@ -39,7 +35,7 @@ RSpec.describe Mysql2::Error do
     let(:invalid_utf8) { ["e5c67d1f"].pack('H*').force_encoding(Encoding::UTF_8) }
     let(:bad_err) do
       begin
-        client.query(invalid_utf8)
+        @client.query(invalid_utf8)
       rescue Mysql2::Error => e
         e
       end

--- a/spec/mysql2/error_spec.rb
+++ b/spec/mysql2/error_spec.rb
@@ -15,6 +15,8 @@ RSpec.describe Mysql2::Error do
     error
   end
 
+  after(:each) { client.close }
+
   it "responds to error_number and sql_state, with aliases" do
     expect(error).to respond_to(:error_number)
     expect(error).to respond_to(:sql_state)

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -153,18 +153,16 @@ RSpec.describe Mysql2::Result do
     end
 
     it "should raise an exception if streaming ended due to a timeout" do
-      # Create an extra client instance, since we're going to time it out
-      client = Mysql2::Client.new DatabaseCredentials['root']
-      client.query "CREATE TEMPORARY TABLE streamingTest (val BINARY(255)) ENGINE=MEMORY"
+      @client.query "CREATE TEMPORARY TABLE streamingTest (val BINARY(255)) ENGINE=MEMORY"
 
       # Insert enough records to force the result set into multiple reads
       # (the BINARY type is used simply because it forces full width results)
       10000.times do |i|
-        client.query "INSERT INTO streamingTest (val) VALUES ('Foo #{i}')"
+        @client.query "INSERT INTO streamingTest (val) VALUES ('Foo #{i}')"
       end
 
-      client.query "SET net_write_timeout = 1"
-      res = client.query "SELECT * FROM streamingTest", :stream => true, :cache_rows => false
+      @client.query "SET net_write_timeout = 1"
+      res = @client.query "SELECT * FROM streamingTest", :stream => true, :cache_rows => false
 
       expect {
         res.each_with_index do |_, i|
@@ -367,10 +365,9 @@ RSpec.describe Mysql2::Result do
           result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
           expect(result['enum_test'].encoding).to eql(Encoding::UTF_8)
 
-          client2 = Mysql2::Client.new(DatabaseCredentials['root'].merge(:encoding => 'ascii'))
+          client2 = new_client(:encoding => 'ascii')
           result = client2.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
           expect(result['enum_test'].encoding).to eql(Encoding::ASCII)
-          client2.close
         end
       end
 
@@ -400,10 +397,9 @@ RSpec.describe Mysql2::Result do
           result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
           expect(result['set_test'].encoding).to eql(Encoding::UTF_8)
 
-          client2 = Mysql2::Client.new(DatabaseCredentials['root'].merge(:encoding => 'ascii'))
+          client2 = new_client(:encoding => 'ascii')
           result = client2.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
           expect(result['set_test'].encoding).to eql(Encoding::ASCII)
-          client2.close
         end
       end
 
@@ -494,10 +490,9 @@ RSpec.describe Mysql2::Result do
               result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
               expect(result[field].encoding).to eql(Encoding::UTF_8)
 
-              client2 = Mysql2::Client.new(DatabaseCredentials['root'].merge(:encoding => 'ascii'))
+              client2 = new_client(:encoding => 'ascii')
               result = client2.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
               expect(result[field].encoding).to eql(Encoding::ASCII)
-              client2.close
             end
           end
 

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -3,6 +3,7 @@ require './spec/spec_helper.rb'
 
 RSpec.describe Mysql2::Statement do
   before :each do
+    @client.close
     @client = Mysql2::Client.new(DatabaseCredentials['root'].merge(:encoding => "utf8"))
   end
 

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -3,8 +3,7 @@ require './spec/spec_helper.rb'
 
 RSpec.describe Mysql2::Statement do
   before :each do
-    @client.close
-    @client = Mysql2::Client.new(DatabaseCredentials['root'].merge(:encoding => "utf8"))
+    @client = new_client(:encoding => "utf8")
   end
 
   def stmt_count
@@ -525,10 +524,9 @@ RSpec.describe Mysql2::Statement do
           result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
           expect(result['enum_test'].encoding).to eql(Encoding::UTF_8)
 
-          client2 = Mysql2::Client.new(DatabaseCredentials['root'].merge(:encoding => 'ascii'))
+          client2 = new_client(:encoding => 'ascii')
           result = client2.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
           expect(result['enum_test'].encoding).to eql(Encoding::US_ASCII)
-          client2.close
         end
       end
 
@@ -558,10 +556,9 @@ RSpec.describe Mysql2::Statement do
           result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
           expect(result['set_test'].encoding).to eql(Encoding::UTF_8)
 
-          client2 = Mysql2::Client.new(DatabaseCredentials['root'].merge(:encoding => 'ascii'))
+          client2 = new_client(:encoding => 'ascii')
           result = client2.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
           expect(result['set_test'].encoding).to eql(Encoding::US_ASCII)
-          client2.close
         end
       end
 
@@ -652,10 +649,9 @@ RSpec.describe Mysql2::Statement do
               result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
               expect(result[field].encoding).to eql(Encoding::UTF_8)
 
-              client2 = Mysql2::Client.new(DatabaseCredentials['root'].merge(:encoding => 'ascii'))
+              client2 = new_client(:encoding => 'ascii')
               result = client2.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first
               expect(result[field].encoding).to eql(Encoding::US_ASCII)
-              client2.close
             end
           end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -90,5 +90,6 @@ RSpec.configure do |config|
         "test", "test", 'val1', 'val1,val2'
       )
     ]
+    client.close
   end
 end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -23,73 +23,86 @@ RSpec.configure do |config|
     $VERBOSE = old_verbose
   end
 
+  def new_client(option_overrides = {})
+    client = Mysql2::Client.new(DatabaseCredentials['root'].merge(option_overrides))
+    @clients ||= []
+    @clients << client
+    return client unless block_given?
+    begin
+      yield client
+    ensure
+      client.close
+      @clients.delete(client)
+    end
+  end
+
   config.before :each do
-    @client = Mysql2::Client.new DatabaseCredentials['root']
+    @client = new_client
   end
 
   config.after :each do
-    @client.close
+    @clients.each(&:close)
   end
 
   config.before(:all) do
-    client = Mysql2::Client.new DatabaseCredentials['root']
-    client.query %[
-      CREATE TABLE IF NOT EXISTS mysql2_test (
-        id MEDIUMINT NOT NULL AUTO_INCREMENT,
-        null_test VARCHAR(10),
-        bit_test BIT(64),
-        single_bit_test BIT(1),
-        tiny_int_test TINYINT,
-        bool_cast_test TINYINT(1),
-        small_int_test SMALLINT,
-        medium_int_test MEDIUMINT,
-        int_test INT,
-        big_int_test BIGINT,
-        float_test FLOAT(10,3),
-        float_zero_test FLOAT(10,3),
-        double_test DOUBLE(10,3),
-        decimal_test DECIMAL(10,3),
-        decimal_zero_test DECIMAL(10,3),
-        date_test DATE,
-        date_time_test DATETIME,
-        timestamp_test TIMESTAMP,
-        time_test TIME,
-        year_test YEAR(4),
-        char_test CHAR(10),
-        varchar_test VARCHAR(10),
-        binary_test BINARY(10),
-        varbinary_test VARBINARY(10),
-        tiny_blob_test TINYBLOB,
-        tiny_text_test TINYTEXT,
-        blob_test BLOB,
-        text_test TEXT,
-        medium_blob_test MEDIUMBLOB,
-        medium_text_test MEDIUMTEXT,
-        long_blob_test LONGBLOB,
-        long_text_test LONGTEXT,
-        enum_test ENUM('val1', 'val2'),
-        set_test SET('val1', 'val2'),
-        PRIMARY KEY (id)
-      )
-    ]
-    client.query "DELETE FROM mysql2_test;"
-    client.query %[
-      INSERT INTO mysql2_test (
-        null_test, bit_test, single_bit_test, tiny_int_test, bool_cast_test, small_int_test, medium_int_test, int_test, big_int_test,
-        float_test, float_zero_test, double_test, decimal_test, decimal_zero_test, date_test, date_time_test, timestamp_test, time_test,
-        year_test, char_test, varchar_test, binary_test, varbinary_test, tiny_blob_test,
-        tiny_text_test, blob_test, text_test, medium_blob_test, medium_text_test,
-        long_blob_test, long_text_test, enum_test, set_test
-      )
+    new_client do |client|
+      client.query %[
+        CREATE TABLE IF NOT EXISTS mysql2_test (
+          id MEDIUMINT NOT NULL AUTO_INCREMENT,
+          null_test VARCHAR(10),
+          bit_test BIT(64),
+          single_bit_test BIT(1),
+          tiny_int_test TINYINT,
+          bool_cast_test TINYINT(1),
+          small_int_test SMALLINT,
+          medium_int_test MEDIUMINT,
+          int_test INT,
+          big_int_test BIGINT,
+          float_test FLOAT(10,3),
+          float_zero_test FLOAT(10,3),
+          double_test DOUBLE(10,3),
+          decimal_test DECIMAL(10,3),
+          decimal_zero_test DECIMAL(10,3),
+          date_test DATE,
+          date_time_test DATETIME,
+          timestamp_test TIMESTAMP,
+          time_test TIME,
+          year_test YEAR(4),
+          char_test CHAR(10),
+          varchar_test VARCHAR(10),
+          binary_test BINARY(10),
+          varbinary_test VARBINARY(10),
+          tiny_blob_test TINYBLOB,
+          tiny_text_test TINYTEXT,
+          blob_test BLOB,
+          text_test TEXT,
+          medium_blob_test MEDIUMBLOB,
+          medium_text_test MEDIUMTEXT,
+          long_blob_test LONGBLOB,
+          long_text_test LONGTEXT,
+          enum_test ENUM('val1', 'val2'),
+          set_test SET('val1', 'val2'),
+          PRIMARY KEY (id)
+        )
+      ]
+      client.query "DELETE FROM mysql2_test;"
+      client.query %[
+        INSERT INTO mysql2_test (
+          null_test, bit_test, single_bit_test, tiny_int_test, bool_cast_test, small_int_test, medium_int_test, int_test, big_int_test,
+          float_test, float_zero_test, double_test, decimal_test, decimal_zero_test, date_test, date_time_test, timestamp_test, time_test,
+          year_test, char_test, varchar_test, binary_test, varbinary_test, tiny_blob_test,
+          tiny_text_test, blob_test, text_test, medium_blob_test, medium_text_test,
+          long_blob_test, long_text_test, enum_test, set_test
+        )
 
-      VALUES (
-        NULL, b'101', b'1', 1, 1, 10, 10, 10, 10,
-        10.3, 0, 10.3, 10.3, 0, '2010-4-4', '2010-4-4 11:44:00', '2010-4-4 11:44:00', '11:44:00',
-        2009, "test", "test", "test", "test", "test",
-        "test", "test", "test", "test", "test",
-        "test", "test", 'val1', 'val1,val2'
-      )
-    ]
-    client.close
+        VALUES (
+          NULL, b'101', b'1', 1, 1, 10, 10, 10, 10,
+          10.3, 0, 10.3, 10.3, 0, '2010-4-4', '2010-4-4 11:44:00', '2010-4-4 11:44:00', '11:44:00',
+          2009, "test", "test", "test", "test", "test",
+          "test", "test", "test", "test", "test",
+          "test", "test", 'val1', 'val1,val2'
+        )
+      ]
+    end
   end
 end


### PR DESCRIPTION
## Problem

I noticed some flaky test failures that seem like they were related to unclosed connections, like this test failure in https://travis-ci.org/brianmario/mysql2/jobs/235381348

```
  1) Mysql2::Client should terminate connections when calling close
     Failure/Error:
       expect {
         Mysql2::Client.new(DatabaseCredentials['root']).close
       }.to_not change {
         @client.query("SHOW STATUS LIKE 'Aborted_%'").to_a +
           @client.query("SHOW STATUS LIKE 'Threads_connected'").to_a
       }
     
       expected result not to have changed, but did change from [{"Variable_name"=>"Aborted_clients", "Value"=>"0"}, {"Variable_name"=>"Aborted_connects", "Value"=>"0"}, {"Variable_name"=>"Threads_connected", "Value"=>"6"}] to [{"Variable_name"=>"Aborted_clients", "Value"=>"0"}, {"Variable_name"=>"Aborted_connects", "Value"=>"0"}, {"Variable_name"=>"Threads_connected", "Value"=>"5"}]
     # ./spec/mysql2/client_spec.rb:174:in `block (2 levels) in <top (required)>'
```

Notice that the test failed because an extra connection was closed.  Also, there were 6 Threads_connected at the start of the test, when there should only be one for `@client`.

## Solution

I went through the tests looking for unclosed clients and added a `close` call for the ones I found.