### PR TITLE
Fix flaky test that used Process.wait without specifying a pid

### DIFF
--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -247,17 +247,13 @@ RSpec.describe Mysql2::Client do
         client = Mysql2::Client.new(DatabaseCredentials['root'])
         client.automatic_close = false
 
-        # this empty `fork` call fixes this tests on RBX; without it, the next
-        # `fork` call hangs forever. WTF?
-        fork {}
-
-        fork do
+        child = fork do
           client.query('SELECT 1')
           client = nil
           run_gc
         end
 
-        Process.wait
+        Process.wait(child)
 
         # this will throw an error if the underlying socket was shutdown by the
         # child's GC


### PR DESCRIPTION
## Problem

In CI build (https://travis-ci.org/brianmario/mysql2/jobs/235381342) for another PR I got this flaky test failure

```
  1) Mysql2::Client#automatic_close should not close connections when running in a child process
     Failure/Error: expect { client.query('SELECT 1') }.to_not raise_exception
     
       expected no Exception, got #<Mysql2::Error: MySQL server has gone away> with backtrace:
         # ./lib/mysql2/client.rb:120:in `_query'
         # ./lib/mysql2/client.rb:120:in `block in query'
         # ./lib/mysql2/client.rb:119:in `handle_interrupt'
         # ./lib/mysql2/client.rb:119:in `query'
         # ./spec/mysql2/client_spec.rb:264:in `block (4 levels) in <top (required)>'
         # ./spec/mysql2/client_spec.rb:264:in `block (3 levels) in <top (required)>'
     # ./spec/mysql2/client_spec.rb:264:in `block (3 levels) in <top (required)>'
```

The problem was that [Process.wait](http://ruby-doc.org/core-2.3.3/Process.html#method-c-wait) was being called without specifying a pid, which defaults to pid=-1, "Waits for any child process (the default if no pid is given)."  So it was actually waiting for the empty fork that was added as a hack for some version of rubinius

## Solution

Passed pid for the fork we care about into Process.wait.

I also removed the empty fork now, since CI no longer runs with rubinius.