### PR TITLE
Wait for close to be processed by server in test for Threads_connected

### DIFF
--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -178,13 +178,15 @@ RSpec.describe Mysql2::Client do
 
       # mysql_close sends a quit command without waiting for a response
       # so give the server some time to handle the detect the closed connection
+      closed = false
       10.times do
-        break unless @client.query("SHOW PROCESSLIST").detect { |row| row['Id'] == connection_id }
+        closed = @client.query("SHOW PROCESSLIST").none? { |row| row['Id'] == connection_id }
+        break if closed
         sleep(0.1)
       end
+      expect(closed).to eq(true)
     }.to_not change {
-      @client.query("SHOW STATUS LIKE 'Aborted_%'").to_a +
-        @client.query("SHOW STATUS LIKE 'Threads_connected'").to_a
+      @client.query("SHOW STATUS LIKE 'Aborted_%'").to_a
     }
   end
 


### PR DESCRIPTION
## Problem

As discussed in https://github.com/brianmario/mysql2/pull/848#issuecomment-303704563, the test I am changing fails in a flaky way due to `mysql_close` sending a quit command without waiting for a response, so the following query for the Threads_connected can return a count that includes the connection that was been closed on the client side.

## Solution

Give the server a second to detect and response to the client closing the connection by using the `SHOW PROCESSLIST` command to check if the server still thinks the client is connected.

I wrapped the contents of the test in a loop as I commented in https://github.com/brianmario/mysql2/pull/848#issuecomment-303746961 to confirm that this deals with this type of flaky test failure.