### PR TITLE
Fix leaky test that caused a re-assigned socket to be closed on GC.

### DIFF
--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -638,10 +638,11 @@ RSpec.describe Mysql2::Client do
       end
 
       it "evented async queries should be supported" do
+        skip("ruby 1.8 doesn't support IO.for_fd options") if RUBY_VERSION.start_with?("1.8.")
         # should immediately return nil
         expect(@client.query("SELECT sleep(0.1)", :async => true)).to eql(nil)
 
-        io_wrapper = IO.for_fd(@client.socket)
+        io_wrapper = IO.for_fd(@client.socket, :autoclose => false)
         loops = 0
         loop do
           if IO.select([io_wrapper], nil, nil, 0.05)


### PR DESCRIPTION
## Problem

As mentioned in https://github.com/brianmario/mysql2/pull/848#issuecomment-305120156, there is a leaky test failure that looks like

```ruby
  1) Mysql2::Client#automatic_close should not close connections when running in a child process
     Failure/Error: expect { client.query('SELECT 1') }.to_not raise_exception
     
       expected no Exception, got #<Mysql2::Error: MySQL server has gone away> with backtrace:
         # ./lib/mysql2/client.rb:120:in `_query'
         # ./lib/mysql2/client.rb:120:in `block in query'
         # ./lib/mysql2/client.rb:119:in `handle_interrupt'
         # ./lib/mysql2/client.rb:119:in `query'
         # ./spec/mysql2/client_spec.rb:265:in `block (4 levels) in <top (required)>'
         # ./spec/mysql2/client_spec.rb:265:in `block (3 levels) in <top (required)>'
     # ./spec/mysql2/client_spec.rb:265:in `block (3 levels) in <top (required)>'
```

which doesn't happen when running the test in isolation.  Normally the test doesn't fail reliably, but by specifying a seed I was able to reproduce the test failure reliably in PR https://github.com/brianmario/mysql2/pull/848.  I incrementally removed some test code without changing the test order to find the test causing the side-effect that lead to the test failure, which I found to be `[`IO.for_fd(@client.socket)`](https://github.com/brianmario/mysql2/blob/a3d8e4b27516cbcd04936c8eb68b1234aa069b59/spec/mysql2/client_spec.rb#L644)`

`IO.for_fd` by default will automatically close the fd when the IO object is GCed unless the `autoclose: false` option was provided.  Since `@client` is closed at the end of the test, that fd number could have been re-assigned to another object, which will get closed instead.

The reason https://github.com/brianmario/mysql2/pull/848 made this fail more reliably is that previously the tests weren't closing all the clients, which made it much more likely that some unclosed client will have its socket closed instead of the one for the current test.

## Solution

Use the `autoclose: false` option with `IO.for_fd`.