### PR TITLE
Minimal required changes to make it work for mariadb 10.2

### DIFF
--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -25,7 +25,6 @@ end
 # MariaDB 10.2+ Needs mysql/mysql_version.h loaded to get the constants we need
 have_header('mysql/mysql_version.h')
 
-
 # 2.1+
 have_func('rb_absint_size')
 have_func('rb_absint_singlebit_p')

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -22,9 +22,6 @@ def add_ssl_defines(header)
   $CFLAGS << ' -DNO_SSL_MODE_SUPPORT' if has_no_support
 end
 
-# MariaDB 10.2+ Needs mysql/mysql_version.h loaded to get the constants we need
-have_header('mysql/mysql_version.h')
-
 # 2.1+
 have_func('rb_absint_size')
 have_func('rb_absint_singlebit_p')

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -22,6 +22,10 @@ def add_ssl_defines(header)
   $CFLAGS << ' -DNO_SSL_MODE_SUPPORT' if has_no_support
 end
 
+# MariaDB 10.2+ Needs mysql/mysql_version.h loaded to get the constants we need
+have_header('mysql/mysql_version.h')
+
+
 # 2.1+
 have_func('rb_absint_size')
 have_func('rb_absint_singlebit_p')

--- a/ext/mysql2/mysql2_ext.h
+++ b/ext/mysql2/mysql2_ext.h
@@ -14,13 +14,12 @@ void Init_mysql2(void);
 #include <mysql_com.h>
 #include <errmsg.h>
 #include <mysqld_error.h>
+#include <mysql_version.h>
 #else
 #include <mysql/mysql.h>
 #include <mysql/mysql_com.h>
 #include <mysql/errmsg.h>
 #include <mysql/mysqld_error.h>
-#endif
-#ifdef HAVE_MYSQL_MYSQL_VERSION_H
 #include <mysql/mysql_version.h>
 #endif
 

--- a/ext/mysql2/mysql2_ext.h
+++ b/ext/mysql2/mysql2_ext.h
@@ -20,6 +20,9 @@ void Init_mysql2(void);
 #include <mysql/errmsg.h>
 #include <mysql/mysqld_error.h>
 #endif
+#ifdef HAVE_MYSQL_MYSQL_VERSION_H
+#include <mysql/mysql_version.h>
+#endif
 
 #ifdef HAVE_RUBY_ENCODING_H
 #include <ruby/encoding.h>


### PR DESCRIPTION
Updated extconf.rb to check if we have the header
Update mysql2_ext.h to load it if the def is set

Signed-off-by: Scott M. Likens <scott@likens.us>

Refs #851 