### PR TITLE
Fix a segmentation fault which Mysql2::Statement#fields causes.

### DIFF
--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -479,7 +479,7 @@ static VALUE fields(VALUE self) {
 #endif
 
   metadata = mysql_stmt_result_metadata(stmt);
-  if (metadata == NULL) {
+  if (!metadata) {
     return rb_ary_new();
   }
   fields      = mysql_fetch_fields(metadata);

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -478,7 +478,10 @@ static VALUE fields(VALUE self) {
   }
 #endif
 
-  metadata    = mysql_stmt_result_metadata(stmt);
+  metadata = mysql_stmt_result_metadata(stmt);
+  if (metadata == NULL) {
+    return rb_ary_new();
+  }
   fields      = mysql_fetch_fields(metadata);
   field_count = mysql_stmt_field_count(stmt);
   field_list  = rb_ary_new2((long)field_count);

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -329,6 +329,7 @@ RSpec.describe Mysql2::Statement do
     before(:each) do
       @client.query "USE test"
       @test_result = @client.prepare("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").execute
+      @client.query 'CREATE TABLE IF NOT EXISTS fieldsTest (blah varchar(10))'
     end
 
     it "method should exist" do
@@ -338,6 +339,11 @@ RSpec.describe Mysql2::Statement do
     it "should return an array of field names in proper order" do
       result = @client.prepare("SELECT 'a', 'b', 'c'").execute
       expect(result.fields).to eql(%w(a b c))
+    end
+
+    it "should return an empty array for some statements that are not SELECT" do
+      result = @client.prepare("INSERT INTO fieldsTest (blah) VALUES (?)")
+      expect(result.fields).to eql([])
     end
   end
 

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -329,7 +329,6 @@ RSpec.describe Mysql2::Statement do
     before(:each) do
       @client.query "USE test"
       @test_result = @client.prepare("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").execute
-      @client.query 'CREATE TABLE IF NOT EXISTS fieldsTest (blah varchar(10))'
     end
 
     it "method should exist" do
@@ -342,7 +341,7 @@ RSpec.describe Mysql2::Statement do
     end
 
     it "should return an empty array for some statements that are not SELECT" do
-      result = @client.prepare("INSERT INTO fieldsTest (blah) VALUES (?)")
+      result = @client.prepare("INSERT INTO mysql2_test (id) VALUES (?)")
       expect(result.fields).to eql([])
     end
   end


### PR DESCRIPTION
I found a bug(segmentation fault) about `Mysql2::Statement#fields`.

### environment

- ruby 2.4.1
- mysql 5.7.16
- mysql2 0.4.6
- MacOS 10.12.5

### example

This is probably minimal example.

```ruby
stmt = client.prepare("SELECT * FROM hoge where id = '?'")
puts stmt.fields # => work!

stmt = client.prepare("INSERT INTO hoge(blah) VALUES (?)")
puts stmt.fields # => segmentation fault
```

I think that it doesn't be passed the expected value for `mysql_fetch_fields` because `mysql_stmt_result_metadata` returns NULL for `INSERT`, `UPDATE`, `DELETE` etc.
(ref: https://dev.mysql.com/doc/refman/5.7/en/mysql-stmt-result-metadata.html)

And therefore, in case metadata is `NULL`, I change `fields` function to return an empty array.
Please review this 🙏 