### PR TITLE
Fix vio to pvio in client.c based on undefined error

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -30,7 +30,7 @@ VALUE rb_hash_dup(VALUE other) {
     rb_raise(cMysql2Error, "MySQL client is not initialized"); \
   }
 
-#define CONNECTED(wrapper) (wrapper->client->net.vio != NULL && wrapper->client->net.fd != -1)
+#define CONNECTED(wrapper) (wrapper->client->net.pvio != NULL && wrapper->client->net.fd != -1)
 
 #define REQUIRE_CONNECTED(wrapper) \
   REQUIRE_INITIALIZED(wrapper) \


### PR DESCRIPTION
In installing mysql2 from github, I am getting a build error in c where .vio on client.c line 33 is undefined and replacing it with .pvio fixes this error.