### PR TITLE
Prepared statements should handle booleans properly

### DIFF
--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -343,6 +343,16 @@ static VALUE execute(int argc, VALUE *argv, VALUE self) {
 #endif
           set_buffer_for_string(&bind_buffers[i], &length_buffers[i], params_enc[i]);
           break;
+        case T_TRUE:
+          bind_buffers[i].buffer_type = MYSQL_TYPE_TINY;
+          bind_buffers[i].buffer = xmalloc(sizeof(signed char));
+          *(signed char*)(bind_buffers[i].buffer) = 1;
+          break;
+        case T_FALSE:
+          bind_buffers[i].buffer_type = MYSQL_TYPE_TINY;
+          bind_buffers[i].buffer = xmalloc(sizeof(signed char));
+          *(signed char*)(bind_buffers[i].buffer) = 0;
+          break;
         default:
           // TODO: what Ruby type should support MYSQL_TYPE_TIME
           if (CLASS_OF(argv[i]) == rb_cTime || CLASS_OF(argv[i]) == cDateTime) {

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -61,6 +61,12 @@ RSpec.describe Mysql2::Statement do
     expect(rows).to eq([{ "1" => 1 }])
   end
 
+  it "should handle booleans" do
+    stmt = @client.prepare('SELECT ? AS `true`, ? AS `false`')
+    result = stmt.execute(true, false)
+    expect(result.to_a).to eq(['true' => 1, 'false' => 0])
+  end
+
   it "should handle bignum but in int64_t" do
     stmt = @client.prepare('SELECT ? AS max, ? AS min')
     int64_max = (1 << 63) - 1


### PR DESCRIPTION
Without this fix, booleans always be bound as `0.0` even if `true`.

```
Failures:

  1) Mysql2::Statement should handle booleans
     Failure/Error: expect(result.to_a).to eq(['true' => 1, 'false' => 0])

       expected: [{"true"=>1, "false"=>0}]
            got: [{"true"=>0.0 (#<BigDecimal:7fc532889ba0,'0.0',9(18)>), "false"=>0.0 (#<BigDecimal:7fc532889a88,'0.0',9(18)>)}]

       (compared using ==)

       Diff:
       @@ -1,2 +1,3 @@
       -[{"true"=>1, "false"=>0}]
       +[{"true"=>0.0 (#<BigDecimal:7fc532889ba0,'0.0',9(18)>),
       +  "false"=>0.0 (#<BigDecimal:7fc532889a88,'0.0',9(18)>)}]

     # ./spec/mysql2/statement_spec.rb:67:in `block (2 levels) in <top (required)>'
```