### PR TITLE
Fixed enable_cleartext_plugin mode

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -903,7 +903,7 @@ static VALUE _mysql_client_options(VALUE self, int opt, VALUE value) {
       retval  = charval;
       break;
 
-#ifdef MYSQL_ENABLE_CLEARTEXT_PLUGIN
+#ifdef HAVE_CONST_MYSQL_ENABLE_CLEARTEXT_PLUGIN
     case MYSQL_ENABLE_CLEARTEXT_PLUGIN:
       boolval = (value == Qfalse ? 0 : 1);
       retval = &boolval;
@@ -1328,7 +1328,7 @@ static VALUE set_init_command(VALUE self, VALUE value) {
 }
 
 static VALUE set_enable_cleartext_plugin(VALUE self, VALUE value) {
-#ifdef MYSQL_ENABLE_CLEARTEXT_PLUGIN
+#ifdef HAVE_CONST_MYSQL_ENABLE_CLEARTEXT_PLUGIN
   return _mysql_client_options(self, MYSQL_ENABLE_CLEARTEXT_PLUGIN, value);
 #else
   rb_raise(cMysql2Error, "enable-cleartext-plugin is not available, you may need a newer MySQL client library");

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -114,6 +114,7 @@ mysql_h = [prefix, 'mysql.h'].compact.join('/')
 add_ssl_defines(mysql_h)
 have_struct_member('MYSQL', 'net.vio', mysql_h)
 have_struct_member('MYSQL', 'net.pvio', mysql_h)
+have_const('MYSQL_ENABLE_CLEARTEXT_PLUGIN', mysql_h)
 
 # This is our wishlist. We use whichever flags work on the host.
 # -Wall and -Wextra are included by default.

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -1027,7 +1027,7 @@ RSpec.describe Mysql2::Client do
   end
 
   it "should be able to connect using plaintext password" do
-    client = new_client(enable_cleartext_plugin: true)
+    client = new_client(:enable_cleartext_plugin => true)
     client.query('SELECT 1')
   end
 

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -1026,6 +1026,11 @@ RSpec.describe Mysql2::Client do
     expect(@client.ping).to eql(false)
   end
 
+  it "should be able to connect using plaintext password" do
+    client = new_client(enable_cleartext_plugin: true)
+    client.query('SELECT 1')
+  end
+
   unless RUBY_VERSION =~ /1.8/
     it "should respond to #encoding" do
       expect(@client).to respond_to(:encoding)


### PR DESCRIPTION
Fixed enable_cleartext_plugin mode by properly detecting existence of MYSQL_ENABLE_CLEARTEXT_PLUGIN constant, previous code was assuming that MYSQL_ENABLE_CLEARTEXT_PLUGIN is a preprocessor definition while it actually is a C enum.

Added simple test for enable_cleartext_plugin