### PR TITLE
Fix compat with RubyInstaller-2.4 on Windows

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -3,7 +3,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem 'rake', '~> 10.4.2'
-gem 'rake-compiler', '~> 0.9.5'
+gem 'rake-compiler', '~> 1.0'
 
 group :test do
   gem 'eventmachine' unless RUBY_PLATFORM =~ /mswin|mingw/
@@ -22,7 +22,7 @@ end
 
 group :development do
   gem 'pry'
-  gem 'rake-compiler-dock', '~> 0.5.1'
+  gem 'rake-compiler-dock', '~> 0.6.0'
 end
 
 platforms :rbx do

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -2,12 +2,14 @@
 version: "{build}"
 clone_depth: 10
 install:
+  - SET PATH=C:\MinGW\msys\1.0\bin;%PATH%
   - SET PATH=C:\Ruby%ruby_version%\bin;%PATH%
   - ruby --version
   - gem --version
   - gem install bundler --quiet --no-ri --no-rdoc
   - bundler --version
   - bundle install --without benchmarks --path vendor/bundle
+  - IF DEFINED MINGW_PACKAGE_PREFIX (ridk exec pacman -S --noconfirm --needed %MINGW_PACKAGE_PREFIX%-libmariadbclient)
 build_script:
   - bundle exec rake compile
 test_script:
@@ -20,11 +22,14 @@ test_script:
     FLUSH PRIVILEGES;
     "
   - bundle exec rake spec
-# Where do I get Unix find?
-#on_failure:
-#  - find tmp -name "*.log" -exec cat {};
+on_failure:
+  - find tmp -name "*.log" | xargs cat
 environment:
   matrix:
+    - ruby_version: "24-x64"
+      MINGW_PACKAGE_PREFIX: "mingw-w64-x86_64"
+    - ruby_version: "24"
+      MINGW_PACKAGE_PREFIX: "mingw-w64-i686"
     - ruby_version: "23-x64"
     - ruby_version: "23"
     - ruby_version: "22-x64"

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -92,7 +92,7 @@ elsif (mc = (with_config('mysql-config') || Dir[GLOB].first))
 else
   _, usr_local_lib = dir_config('mysql', '/usr/local')
 
-  asplode("mysql client") unless find_library('mysqlclient', 'mysql_query', usr_local_lib, "#{usr_local_lib}/mysql")
+  asplode("mysql client") unless find_library('mysqlclient', nil, usr_local_lib, "#{usr_local_lib}/mysql")
 
   rpath_dir = usr_local_lib
 end
@@ -177,7 +177,7 @@ unless enabled_sanitizers.empty?
   $CFLAGS << ' -g -fno-omit-frame-pointer'
 end
 
-if RUBY_PLATFORM =~ /mswin|mingw/
+if RUBY_PLATFORM =~ /mswin|mingw/ && !defined?(RubyInstaller)
   # Build libmysql.a interface link library
   require 'rake'
 

--- a/lib/mysql2.rb
+++ b/lib/mysql2.rb
@@ -13,16 +13,20 @@ if RUBY_PLATFORM =~ /mswin|mingw/
     ENV['RUBY_MYSQL2_LIBMYSQL_DLL']
   elsif File.exist?(File.expand_path('../vendor/libmysql.dll', File.dirname(__FILE__)))
     # Use vendor/libmysql.dll if it exists, convert slashes for Win32 LoadLibrary
-    File.expand_path('../vendor/libmysql.dll', File.dirname(__FILE__)).tr('/', '\\')
+    File.expand_path('../vendor/libmysql.dll', File.dirname(__FILE__))
+  elsif defined?(RubyInstaller)
+    # RubyInstaller-2.4+ native build doesn't need DLL preloading
   else
     # This will use default / system library paths
     'libmysql.dll'
   end
 
-  require 'Win32API'
-  LoadLibrary = Win32API.new('Kernel32', 'LoadLibrary', ['P'], 'I')
-  if 0 == LoadLibrary.call(dll_path)
-    abort "Failed to load libmysql.dll from #{dll_path}"
+  if dll_path
+    require 'Win32API'
+    LoadLibrary = Win32API.new('Kernel32', 'LoadLibrary', ['P'], 'I')
+    if 0 == LoadLibrary.call(dll_path)
+      abort "Failed to load libmysql.dll from #{dll_path}"
+    end
   end
 end
 

--- a/mysql2.gemspec
+++ b/mysql2.gemspec
@@ -13,4 +13,6 @@ Mysql2::GEMSPEC = Gem::Specification.new do |s|
 
   s.files = `git ls-files README.md CHANGELOG.md LICENSE ext lib support`.split
   s.test_files = `git ls-files spec examples`.split
+
+  s.metadata['msys2_mingw_dependencies'] = 'libmariadbclient'
 end

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -712,7 +712,6 @@ RSpec.describe Mysql2::Statement do
 
     it 'should return number of rows affected by an insert' do
       stmt = @client.prepare 'INSERT INTO lastIdTest (blah) VALUES (?)'
-      expect(stmt.affected_rows).to eq 0
       stmt.execute 1
       expect(stmt.affected_rows).to eq 1
     end


### PR DESCRIPTION
Since RubyInstaller-2.4+ is bundled with MSYS2 and the libmariadbclient can be installed per gemspec library dependency, it is easy to build the mysql2 gem in Windows.

The MSYS2/MINGW dependency feature is documented here: https://github.com/oneclick/rubyinstaller2/wiki/For-gem-developers#msys2-library-dependency

This also adds ruby-2.4 binaries (per rake-compiler-dock-0.6.0), so that the mysql2 is still useabel as a binary gem.

Fixes #861

The change in the spec is required for mariadbclient. It throws an error if no query was executed.

Due to the stdcall convention on i686, the mysql_query() function check fails, so that it is omitted, now.