### PR TITLE
Make sure ssl is enabled if only :sslverify is set

### DIFF
--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -47,7 +47,7 @@ module Mysql2
       self.charset_name = opts[:encoding] || 'utf8'
 
       ssl_options = opts.values_at(:sslkey, :sslcert, :sslca, :sslcapath, :sslcipher)
-      ssl_set(*ssl_options) if ssl_options.any?
+      ssl_set(*ssl_options) if ssl_options.any? || opts.key?(:sslverify)
       self.ssl_mode = parse_ssl_mode(opts[:ssl_mode]) if opts[:ssl_mode]
 
       case opts[:flags]
@@ -62,7 +62,7 @@ module Mysql2
       end
 
       # SSL verify is a connection flag rather than a mysql_ssl_set option
-      flags |= SSL_VERIFY_SERVER_CERT if opts[:sslverify] && ssl_options.any?
+      flags |= SSL_VERIFY_SERVER_CERT if opts[:sslverify]
 
       if [:user, :pass, :hostname, :dbname, :db, :sock].any? { |k| @query_options.key?(k) }
         warn "============= WARNING FROM mysql2 ============="


### PR DESCRIPTION
Previously, when "sslverify: false/true" was the only ssl related
options passed to the constructor, the module skipped the call to
"mysql_ssl_set". It seems however that for some variants for the mysql
client libraries calling "mysql_ssl_set" is the only way to enable SSL
for the client connections. (E.g. the libraries shipped as part of
mariadb 10.1 still lack support for MYSQL_OPT_SSL_ENFORCE and
MYSQL_OPT_SSL_MODE)

This change allows enabling ssl with default values for all other
options by just passing "sslverify: true" or "sslverify: false" to the
constructor. (Depending on whether server certificate verification is
wanted or not)