### PR TITLE
MYSQL_SECURE_AUTH has been removed in MySQL 8.0.3 RC

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -883,10 +883,12 @@ static VALUE _mysql_client_options(VALUE self, int opt, VALUE value) {
       retval = &boolval;
       break;
 
+#if defined(MYSQL_SECURE_AUTH)
     case MYSQL_SECURE_AUTH:
       boolval = (value == Qfalse ? 0 : 1);
       retval = &boolval;
       break;
+#endif
 
     case MYSQL_READ_DEFAULT_FILE:
       charval = (const char *)StringValueCStr(value);
@@ -1311,9 +1313,11 @@ static VALUE set_ssl_options(VALUE self, VALUE key, VALUE cert, VALUE ca, VALUE 
   return self;
 }
 
+#if defined(MYSQL_SECURE_AUTH)
 static VALUE set_secure_auth(VALUE self, VALUE value) {
   return _mysql_client_options(self, MYSQL_SECURE_AUTH, value);
 }
+#endif
 
 static VALUE set_read_default_file(VALUE self, VALUE value) {
   return _mysql_client_options(self, MYSQL_READ_DEFAULT_FILE, value);
@@ -1425,7 +1429,9 @@ void init_mysql2_client() {
   rb_define_private_method(cMysql2Client, "write_timeout=", set_write_timeout, 1);
   rb_define_private_method(cMysql2Client, "local_infile=", set_local_infile, 1);
   rb_define_private_method(cMysql2Client, "charset_name=", set_charset_name, 1);
+#if defined(MYSQL_SECURE_AUTH)
   rb_define_private_method(cMysql2Client, "secure_auth=", set_secure_auth, 1);
+#endif
   rb_define_private_method(cMysql2Client, "default_file=", set_read_default_file, 1);
   rb_define_private_method(cMysql2Client, "default_group=", set_read_default_group, 1);
   rb_define_private_method(cMysql2Client, "init_command=", set_init_command, 1);

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1430,9 +1430,7 @@ void init_mysql2_client() {
   rb_define_private_method(cMysql2Client, "write_timeout=", set_write_timeout, 1);
   rb_define_private_method(cMysql2Client, "local_infile=", set_local_infile, 1);
   rb_define_private_method(cMysql2Client, "charset_name=", set_charset_name, 1);
-#if defined(MYSQL_SECURE_AUTH)
   rb_define_private_method(cMysql2Client, "secure_auth=", set_secure_auth, 1);
-#endif
   rb_define_private_method(cMysql2Client, "default_file=", set_read_default_file, 1);
   rb_define_private_method(cMysql2Client, "default_group=", set_read_default_group, 1);
   rb_define_private_method(cMysql2Client, "init_command=", set_init_command, 1);

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1313,11 +1313,12 @@ static VALUE set_ssl_options(VALUE self, VALUE key, VALUE cert, VALUE ca, VALUE 
   return self;
 }
 
-#if defined(MYSQL_SECURE_AUTH)
 static VALUE set_secure_auth(VALUE self, VALUE value) {
+/* This option was deprecated in MySQL 5.x and removed in MySQL 8.0 */
+#if defined(MYSQL_SECURE_AUTH)
   return _mysql_client_options(self, MYSQL_SECURE_AUTH, value);
-}
 #endif
+}
 
 static VALUE set_read_default_file(VALUE self, VALUE value) {
   return _mysql_client_options(self, MYSQL_READ_DEFAULT_FILE, value);


### PR DESCRIPTION
https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-3.html#mysqld-8-0-3-capi
> The deprecated secure_auth system variable and --secure-auth client option have been removed.
> The MYSQL_SECURE_AUTH option for the mysql_options() C API function was removed.

This pull request addresses #891