### PR TITLE
extended keyword for the explain statement has been removed

### DIFF
--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -328,7 +328,7 @@ RSpec.describe Mysql2::Client do
       it "should > 0" do
         # "the statement produces extra information that can be viewed by issuing a SHOW WARNINGS"
         # https://dev.mysql.com/doc/refman/5.7/en/show-warnings.html
-        @client.query('select 1/0')
+        @client.query('DROP TABLE IF EXISTS test.no_such_table')
         expect(@client.warning_count).to be > 0
       end
     end

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -327,8 +327,8 @@ RSpec.describe Mysql2::Client do
     context "when has a warnings" do
       it "should > 0" do
         # "the statement produces extra information that can be viewed by issuing a SHOW WARNINGS"
-        # http://dev.mysql.com/doc/refman/5.0/en/explain-extended.html
-        @client.query("explain extended select 1")
+        # https://dev.mysql.com/doc/refman/5.7/en/show-warnings.html
+        @client.query('select 1/0')
         expect(@client.warning_count).to be > 0
       end
     end


### PR DESCRIPTION
This pull request addresses #893

```ruby
$ bundle exec rspec ./spec/mysql2/client_spec.rb:328
Run options: include {:locations=>{"./spec/mysql2/client_spec.rb"=>[328]}}

Randomized with seed 11457

Mysql2::Client
  #warning_count
    when has a warnings
      should > 0 (FAILED - 1)

Failures:

  1) Mysql2::Client#warning_count when has a warnings should > 0
     Failure/Error: _query(sql, @query_options.merge(options))

     Mysql2::Error:
       You have an error in your SQL syntax; check the manual that corresponds to your MySQL server version for the right syntax to use near 'select 1' at line 1
     # ./lib/mysql2/client.rb:120:in `_query'
     # ./lib/mysql2/client.rb:120:in `block in query'
     # ./lib/mysql2/client.rb:119:in `handle_interrupt'
     # ./lib/mysql2/client.rb:119:in `query'
     # ./spec/mysql2/client_spec.rb:331:in `block (4 levels) in <top (required)>'

Finished in 0.0126 seconds (files took 0.18505 seconds to load)
1 example, 1 failure

Failed examples:

rspec ./spec/mysql2/client_spec.rb:328 # Mysql2::Client#warning_count when has a warnings should > 0

Randomized with seed 11457

$
```


https://dev.mysql.com/doc/relnotes/mysql/8.0/en/news-8-0-3.html
> The deprecated EXTENDED and PARTITIONS keywords for the EXPLAIN statement have been removed. These keywords are unnecessary because their effect is always enabled.

Use another `select 1/0` which generates warnings:

```sql
mysql> select 1/0;
+------+
| 1/0  |
+------+
| NULL |
+------+
1 row in set, 1 warning (0.01 sec)

mysql> show warnings;
+---------+------+---------------+
| Level   | Code | Message       |
+---------+------+---------------+
| Warning | 1365 | Division by 0 |
+---------+------+---------------+
1 row in set (0.00 sec)

mysql>
```