### PR TITLE
Adds conditional for MYSQL_SECURE_AUTH

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -883,10 +883,12 @@ static VALUE _mysql_client_options(VALUE self, int opt, VALUE value) {
       retval = &boolval;
       break;
 
+  #if defined(MYSQL_SECURE_AUTH)
     case MYSQL_SECURE_AUTH:
       boolval = (value == Qfalse ? 0 : 1);
       retval = &boolval;
       break;
+  #endif
 
     case MYSQL_READ_DEFAULT_FILE:
       charval = (const char *)StringValueCStr(value);
@@ -1311,9 +1313,9 @@ static VALUE set_ssl_options(VALUE self, VALUE key, VALUE cert, VALUE ca, VALUE 
   return self;
 }
 
-static VALUE set_secure_auth(VALUE self, VALUE value) {
+#if defined(MYSQL_SECURE_AUTH)
   return _mysql_client_options(self, MYSQL_SECURE_AUTH, value);
-}
+#endif
 
 static VALUE set_read_default_file(VALUE self, VALUE value) {
   return _mysql_client_options(self, MYSQL_READ_DEFAULT_FILE, value);
@@ -1425,7 +1427,9 @@ void init_mysql2_client() {
   rb_define_private_method(cMysql2Client, "write_timeout=", set_write_timeout, 1);
   rb_define_private_method(cMysql2Client, "local_infile=", set_local_infile, 1);
   rb_define_private_method(cMysql2Client, "charset_name=", set_charset_name, 1);
+#if defined(MYSQL_SECURE_AUTH)
   rb_define_private_method(cMysql2Client, "secure_auth=", set_secure_auth, 1);
+#endif
   rb_define_private_method(cMysql2Client, "default_file=", set_read_default_file, 1);
   rb_define_private_method(cMysql2Client, "default_group=", set_read_default_group, 1);
   rb_define_private_method(cMysql2Client, "init_command=", set_init_command, 1);


### PR DESCRIPTION
Tries to fix #891 and adds a third conditional at #892 that was missing on line https://github.com/brianmario/mysql2/blob/master/ext/mysql2/client.c#L1428.

Since MYSQL_SECURE_AUTH was removed on 8.0.3