### PR TITLE
Drop 1.9.3 support

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,7 +1,7 @@
 inherit_from: .rubocop_todo.yml
 
 AllCops:
-  TargetRubyVersion: 1.9
+  TargetRubyVersion: 2.0
 
   DisplayCopNames: true
   Exclude:
@@ -20,10 +20,6 @@ Layout/IndentHeredoc:
 
 Lint/EndAlignment:
   EnforcedStyleAlignWith: variable
-
-Style/Encoding:
-  AutoCorrectEncodingComment: '# encoding: UTF-8'
-  EnforcedStyle: always
 
 Style/TrailingCommaInArguments:
   EnforcedStyleForMultiline: consistent_comma

--- a/.travis.yml
+++ b/.travis.yml
@@ -23,7 +23,6 @@ rvm:
   - 2.2
   - 2.1
   - 2.0.0
-  - 1.9.3
   - ruby-head
 matrix:
   include:

--- a/Gemfile
+++ b/Gemfile
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 source 'https://rubygems.org'
 
 gemspec
@@ -10,9 +8,8 @@ gem 'rake-compiler', '~> 1.0'
 group :test do
   gem 'eventmachine' unless RUBY_PLATFORM =~ /mswin|mingw/
   gem 'rspec', '~> 3.2'
-  # https://github.com/bbatsov/rubocop/pull/3328
   # https://github.com/bbatsov/rubocop/pull/4789
-  gem 'rubocop', '~> 0.50.0' unless RUBY_VERSION =~ /1.9/
+  gem 'rubocop', '~> 0.50.0'
 end
 
 group :benchmarks do

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ The Mysql2 gem is meant to serve the extremely common use-case of connecting, qu
 Some database libraries out there serve as direct 1:1 mappings of the already complex C APIs available.
 This one is not.
 
-It also forces the use of UTF-8 [or binary] for the connection [and all strings in 1.9, unless Encoding.default_internal is set then it'll convert from UTF-8 to that encoding] and uses encoding-aware MySQL API calls where it can.
+It also forces the use of UTF-8 [or binary] for the connection and uses encoding-aware MySQL API calls where it can.
 
 The API consists of three classes:
 
@@ -510,7 +510,7 @@ As for field values themselves, I'm workin on it - but expect that soon.
 
 This gem is tested with the following Ruby versions on Linux and Mac OS X:
 
- * Ruby MRI 1.9.3, 2.0.0, 2.1.x, 2.2.x, 2.3.x, 2.4.x
+ * Ruby MRI 2.0.0, 2.1.x, 2.2.x, 2.3.x, 2.4.x
  * Rubinius 2.x and 3.x do work but may fail under some workloads
 
 This gem is tested with the following MySQL and MariaDB versions:

--- a/Rakefile
+++ b/Rakefile
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require 'rake'
 
 # Load custom tasks (careful attention to define tasks before prerequisites)
@@ -12,7 +10,7 @@ load 'tasks/benchmarks.rake'
 begin
   require 'rubocop/rake_task'
   RuboCop::RakeTask.new
-  task default: [:spec, :rubocop]
+  task default: %i[spec rubocop]
 rescue LoadError
   warn 'RuboCop is not available'
   task default: :spec

--- a/benchmark/active_record.rb
+++ b/benchmark/active_record.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
 
 require 'rubygems'

--- a/benchmark/active_record_threaded.rb
+++ b/benchmark/active_record_threaded.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
 
 require 'rubygems'

--- a/benchmark/allocations.rb
+++ b/benchmark/allocations.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
 
 require 'rubygems'

--- a/benchmark/escape.rb
+++ b/benchmark/escape.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
 
 require 'rubygems'

--- a/benchmark/query_with_mysql_casting.rb
+++ b/benchmark/query_with_mysql_casting.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
 
 require 'rubygems'

--- a/benchmark/query_without_mysql_casting.rb
+++ b/benchmark/query_without_mysql_casting.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
 
 require 'rubygems'

--- a/benchmark/sequel.rb
+++ b/benchmark/sequel.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
 
 require 'rubygems'

--- a/benchmark/setup_db.rb
+++ b/benchmark/setup_db.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 $LOAD_PATH.unshift File.expand_path(File.dirname(__FILE__) + '/../lib')
 
 # This script is for generating psudo-random data into a single table consisting of nearly every

--- a/examples/eventmachine.rb
+++ b/examples/eventmachine.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 $LOAD_PATH.unshift 'lib'
 
 require 'rubygems'

--- a/examples/threaded.rb
+++ b/examples/threaded.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 $LOAD_PATH.unshift 'lib'
 require 'mysql2'
 require 'timeout'

--- a/ext/mysql2/client.h
+++ b/ext/mysql2/client.h
@@ -1,12 +1,6 @@
 #ifndef MYSQL2_CLIENT_H
 #define MYSQL2_CLIENT_H
 
-#ifndef HAVE_RB_THREAD_CALL_WITHOUT_GVL
-/* emulate rb_thread_call_without_gvl with rb_thread_blocking_region */
-#define rb_thread_call_without_gvl(func, data1, ubf, data2) \
-  rb_thread_blocking_region((rb_blocking_function_t *)func, data1, ubf, data2)
-#endif /* ! HAVE_RB_THREAD_CALL_WITHOUT_GVL */
-
 typedef struct {
   VALUE encoding;
   VALUE active_thread; /* rb_thread_current() or Qnil */

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require 'mkmf'
 require 'English'
 
@@ -26,9 +24,6 @@ end
 # 2.1+
 have_func('rb_absint_size')
 have_func('rb_absint_singlebit_p')
-
-# 2.0-only
-have_header('ruby/thread.h') && have_func('rb_thread_call_without_gvl', 'ruby/thread.h')
 
 # Missing in RBX (https://github.com/rubinius/rubinius/issues/3771)
 have_func('rb_wait_for_single_fd')
@@ -57,14 +52,6 @@ GLOB = "{#{dirs.join(',')}}/{mysql_config,mysql_config5,mariadb_config}".freeze
 # If the user has provided a --with-mysql-dir argument, we must respect it or fail.
 inc, lib = dir_config('mysql')
 if inc && lib
-  # TODO: Remove when 2.0.0 is the minimum supported version
-  # Ruby versions not incorporating the mkmf fix at
-  # https://bugs.ruby-lang.org/projects/ruby-trunk/repository/revisions/39717
-  # do not properly search for lib directories, and must be corrected
-  unless lib && lib[-3, 3] == 'lib'
-    @libdir_basename = 'lib'
-    inc, lib = dir_config('mysql')
-  end
   abort "-----\nCannot find include dir(s) #{inc}\n-----" unless inc && inc.split(File::PATH_SEPARATOR).any? { |dir| File.directory?(dir) }
   abort "-----\nCannot find library dir(s) #{lib}\n-----" unless lib && lib.split(File::PATH_SEPARATOR).any? { |dir| File.directory?(dir) }
   warn "-----\nUsing --with-mysql-dir=#{File.dirname inc}\n-----"

--- a/ext/mysql2/mysql2_ext.h
+++ b/ext/mysql2/mysql2_ext.h
@@ -18,15 +18,7 @@ void Init_mysql2(void);
 #endif
 
 #include <ruby/encoding.h>
-// ruby/thread.h was added in 2.0.0. See:
-// https://github.com/ruby/ruby/commit/c51a826
-//
-// Rubinius doesn't define this, but it ships an empty thread.h (the symbols we
-// care about are in ruby.h); this is safe to remove when < 2.0.0 is no longer
-// supported.
-#ifdef HAVE_RUBY_THREAD_H
 #include <ruby/thread.h>
-#endif
 
 #if defined(__GNUC__) && (__GNUC__ >= 3)
 #define RB_MYSQL_NORETURN __attribute__ ((noreturn))

--- a/lib/mysql2.rb
+++ b/lib/mysql2.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require 'date'
 require 'bigdecimal'
 
@@ -75,13 +73,11 @@ module Mysql2
     # Timeout::ExitException was removed in Ruby 2.3.0, 2.2.3, and 2.1.8,
     # but is present in earlier 2.1.x and 2.2.x, so we provide a shim.
     #
-    if Thread.respond_to?(:handle_interrupt)
-      require 'timeout'
-      TIMEOUT_ERROR_CLASS = if defined?(::Timeout::ExitException)
-        ::Timeout::ExitException
-      else
-        ::Timeout::Error
-      end
+    require 'timeout'
+    TIMEOUT_ERROR_CLASS = if defined?(::Timeout::ExitException)
+      ::Timeout::ExitException
+    else
+      ::Timeout::Error
     end
   end
 end

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 module Mysql2
   class Client
     attr_reader :query_options, :read_timeout
@@ -33,7 +31,7 @@ module Mysql2
       opts[:connect_timeout] = 120 unless opts.key?(:connect_timeout)
 
       # TODO: stricter validation rather than silent massaging
-      [:reconnect, :connect_timeout, :local_infile, :read_timeout, :write_timeout, :default_file, :default_group, :secure_auth, :init_command, :automatic_close, :enable_cleartext_plugin].each do |key|
+      %i[reconnect connect_timeout local_infile read_timeout write_timeout default_file default_group secure_auth init_command automatic_close enable_cleartext_plugin].each do |key|
         next unless opts.key?(key)
         case key
         when :reconnect, :local_infile, :secure_auth, :automatic_close, :enable_cleartext_plugin
@@ -71,7 +69,7 @@ module Mysql2
       conn_attrs = opts[:connect_attrs] || {}
       conn_attrs[:program_name] = $PROGRAM_NAME unless conn_attrs.key?(:program_name)
 
-      if [:user, :pass, :hostname, :dbname, :db, :sock].any? { |k| @query_options.key?(k) }
+      if %i[user pass hostname dbname db sock].any? { |k| @query_options.key?(k) }
         warn "============= WARNING FROM mysql2 ============="
         warn "The options :user, :pass, :hostname, :dbname, :db, and :sock are deprecated and will be removed at some point in the future."
         warn "Instead, please use :username, :password, :host, :port, :database, :socket, :flags for the options."
@@ -124,14 +122,8 @@ module Mysql2
       end
     end
 
-    if Thread.respond_to?(:handle_interrupt)
-      def query(sql, options = {})
-        Thread.handle_interrupt(::Mysql2::Util::TIMEOUT_ERROR_CLASS => :never) do
-          _query(sql, @query_options.merge(options))
-        end
-      end
-    else
-      def query(sql, options = {})
+    def query(sql, options = {})
+      Thread.handle_interrupt(::Mysql2::Util::TIMEOUT_ERROR_CLASS => :never) do
         _query(sql, @query_options.merge(options))
       end
     end

--- a/lib/mysql2/console.rb
+++ b/lib/mysql2/console.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 # Loaded by script/console. Land helpers here.
 
 Pry.config.prompt = lambda do |context, *|

--- a/lib/mysql2/em.rb
+++ b/lib/mysql2/em.rb
@@ -1,5 +1,3 @@
-# encoding: utf-8
-
 require 'eventmachine'
 require 'mysql2'
 

--- a/lib/mysql2/error.rb
+++ b/lib/mysql2/error.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 module Mysql2
   class Error < StandardError
     ENCODE_OPTS = {

--- a/lib/mysql2/field.rb
+++ b/lib/mysql2/field.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 module Mysql2
   Field = Struct.new(:name, :type)
 end

--- a/lib/mysql2/result.rb
+++ b/lib/mysql2/result.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 module Mysql2
   class Result
     attr_reader :server_flags

--- a/lib/mysql2/statement.rb
+++ b/lib/mysql2/statement.rb
@@ -1,17 +1,9 @@
-# encoding: UTF-8
-
 module Mysql2
   class Statement
     include Enumerable
 
-    if Thread.respond_to?(:handle_interrupt)
-      def execute(*args)
-        Thread.handle_interrupt(::Mysql2::Util::TIMEOUT_ERROR_CLASS => :never) do
-          _execute(*args)
-        end
-      end
-    else
-      def execute(*args)
+    def execute(*args)
+      Thread.handle_interrupt(::Mysql2::Util::TIMEOUT_ERROR_CLASS => :never) do
         _execute(*args)
       end
     end

--- a/lib/mysql2/version.rb
+++ b/lib/mysql2/version.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 module Mysql2
   VERSION = "0.4.10".freeze
 end

--- a/mysql2.gemspec
+++ b/mysql2.gemspec
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require File.expand_path('../lib/mysql2/version', __FILE__)
 
 Mysql2::GEMSPEC = Gem::Specification.new do |s|
@@ -12,7 +10,7 @@ Mysql2::GEMSPEC = Gem::Specification.new do |s|
   s.homepage = 'http://github.com/brianmario/mysql2'
   s.rdoc_options = ["--charset=UTF-8"]
   s.summary = 'A simple, fast Mysql library for Ruby, binding to libmysql'
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.0.0'
 
   s.files = `git ls-files README.md CHANGELOG.md LICENSE ext lib support`.split
   s.test_files = `git ls-files spec examples`.split

--- a/spec/em/em_spec.rb
+++ b/spec/em/em_spec.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require 'spec_helper'
 begin
   require 'eventmachine'

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require 'spec_helper'
 
 RSpec.describe Mysql2::Client do
@@ -607,10 +605,6 @@ RSpec.describe Mysql2::Client do
       end
 
       it 'should be impervious to connection-corrupting timeouts in #execute' do
-        # the statement handle gets corrupted and will segfault the tests if interrupted,
-        # so we can't even use pending on this test, really have to skip it on older Rubies.
-        skip('`Thread.handle_interrupt` is not defined') unless Thread.respond_to?(:handle_interrupt)
-
         # attempt to break the connection
         stmt = @client.prepare('SELECT SLEEP(?)')
         expect { Timeout.timeout(0.1) { stmt.execute(0.2) } }.to raise_error(Timeout::Error)

--- a/spec/mysql2/error_spec.rb
+++ b/spec/mysql2/error_spec.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require 'spec_helper'
 
 RSpec.describe Mysql2::Error do

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require 'spec_helper'
 
 RSpec.describe Mysql2::Result do

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require './spec/spec_helper.rb'
 
 RSpec.describe Mysql2::Statement do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require 'rspec'
 require 'mysql2'
 require 'timeout'

--- a/support/mysql_enc_to_ruby.rb
+++ b/support/mysql_enc_to_ruby.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 $LOAD_PATH.unshift File.expand_path('../../lib', __FILE__)
 require 'mysql2'
 

--- a/support/ruby_enc_to_mysql.rb
+++ b/support/ruby_enc_to_mysql.rb
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 mysql_to_rb = {
   "big5"     => "Big5",
   "dec8"     => nil,

--- a/tasks/benchmarks.rake
+++ b/tasks/benchmarks.rake
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 BENCHMARKS = Dir["#{File.dirname(__FILE__)}/../benchmark/*.rb"].map do |path|
   File.basename(path, '.rb')
 end - ['setup_db']

--- a/tasks/compile.rake
+++ b/tasks/compile.rake
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require "rake/extensiontask"
 
 load File.expand_path('../../mysql2.gemspec', __FILE__) unless defined? Mysql2::GEMSPEC

--- a/tasks/generate.rake
+++ b/tasks/generate.rake
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 task :encodings do
   sh "ruby support/mysql_enc_to_ruby.rb > ./ext/mysql2/mysql_enc_to_ruby.h"
   sh "ruby support/ruby_enc_to_mysql.rb | gperf > ./ext/mysql2/mysql_enc_name_to_ruby.h"

--- a/tasks/rspec.rake
+++ b/tasks/rspec.rake
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 begin
   require 'rspec'
   require 'rspec/core/rake_task'

--- a/tasks/vendor_mysql.rake
+++ b/tasks/vendor_mysql.rake
@@ -1,5 +1,3 @@
-# encoding: UTF-8
-
 require 'rake/clean'
 require 'rake/extensioncompiler'
 


### PR DESCRIPTION
@sodabrew I might've missed something, but doesn't look like there's a huge upshot to doing this (at least not until we're ready to drop 2.0.0).