### PR TITLE
local_infile not enabled on a big endian environment

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -872,8 +872,8 @@ static VALUE _mysql_client_options(VALUE self, int opt, VALUE value) {
       break;
 
     case MYSQL_OPT_LOCAL_INFILE:
-      intval = (value == Qfalse ? 0 : 1);
-      retval = &intval;
+      boolval = (value == Qfalse ? 0 : 1);
+      retval = &boolval;
       break;
 
     case MYSQL_OPT_RECONNECT:


### PR DESCRIPTION
The client option `local_infile` is not enabled on a big endian environment.

There is a RPM package for this `mysql2` on Fedora Project [1]
I try to build `mysql2` on several platforms for that.

Ruby: 2.4.2
DB Client: mariadb-connector-c: 3.0.2 ([2])

On little endian environment such as x86_64, it is fine.
But in big endian such as ppc64, s390x, this issue happens.

The unit test was failed as below result on the environment.
The behavior `The used command is not allowed with this MariaDB version` usually happens when `local_infile` is off.

```
Failures:
  1) Mysql2::Client :local_infile should raise an error when a non-existent file is loaded
     Failure/Error:
       expect {
         client.query "LOAD DATA LOCAL INFILE 'this/file/is/not/here' INTO TABLE infileTest"
       }.to raise_error(Mysql2::Error, 'No such file or directory: this/file/is/not/here')
       expected Mysql2::Error with "No such file or directory: this/file/is/not/here", got #<Mysql2::Error: The used command is not allowed with this MariaDB version> with backtrace:
         # ./lib/mysql2/client.rb:120:in `_query'
         # ./lib/mysql2/client.rb:120:in `block in query'
         # ./lib/mysql2/client.rb:119:in `handle_interrupt'
         # ./lib/mysql2/client.rb:119:in `query'
         # ./spec/mysql2/client_spec.rb:399:in `block (4 levels) in <top (required)>'
         # ./spec/mysql2/client_spec.rb:398:in `block (3 levels) in <top (required)>'
     # ./spec/mysql2/client_spec.rb:398:in `block (3 levels) in <top (required)>'
```

The reason is this code.
https://github.com/MariaDB/mariadb-connector-c/blob/v3.0.2/libmariadb/mariadb_lib.c#L2652

When `usigned int intval` is used for MYSQL_OPT_LOCAL_INFILE in `_mysql_client_options`, the value is set as a cast to `my_bool (= char)`in `test(*(my_bool*) arg1)`.

little endian: unsigned intval (0x01 0x00 0x00 0x00) => cast to char (0x01) -> `test` result is true => `mysql->options.client_flag|= CLIENT_LOCAL_FILES;` is run => ok
big endian: unsigned intval(0x00 0x00 0x00 0x01) -> cast to char (0x00) -> `test` result is false => `mysql->options.client_flag&= ~CLIENT_LOCAL_FILES;` is run => `local_infile` is not set to `mysql->options.client_flag`.




[1] https://src.fedoraproject.org/rpms/rubygem-mysql2
[2] https://github.com/MariaDB/mariadb-connector-c