### PR TITLE
Fix wrong value of type YEAR on big endian environment.

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -234,12 +234,12 @@ static void rb_mysql_result_alloc_result_buffers(VALUE self, MYSQL_FIELD *fields
         wrapper->result_buffers[i].buffer_length = sizeof(signed char);
         break;
       case MYSQL_TYPE_SHORT:        // short int
+      case MYSQL_TYPE_YEAR:         // short int
         wrapper->result_buffers[i].buffer = xcalloc(1, sizeof(short int));
         wrapper->result_buffers[i].buffer_length = sizeof(short int);
         break;
       case MYSQL_TYPE_INT24:        // int
       case MYSQL_TYPE_LONG:         // int
-      case MYSQL_TYPE_YEAR:         // int
         wrapper->result_buffers[i].buffer = xcalloc(1, sizeof(int));
         wrapper->result_buffers[i].buffer_length = sizeof(int);
         break;
@@ -365,6 +365,7 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
           }
           break;
         case MYSQL_TYPE_SHORT:        // short int
+        case MYSQL_TYPE_YEAR:         // short int
           if (result_buffer->is_unsigned) {
             val = UINT2NUM(*((unsigned short int*)result_buffer->buffer));
           } else  {
@@ -373,7 +374,6 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
           break;
         case MYSQL_TYPE_INT24:        // int
         case MYSQL_TYPE_LONG:         // int
-        case MYSQL_TYPE_YEAR:         // int
           if (result_buffer->is_unsigned) {
             val = UINT2NUM(*((unsigned int*)result_buffer->buffer));
           } else {


### PR DESCRIPTION
This PR for https://github.com/brianmario/mysql2/issues/916 issue "1.2".

I checked it like this.

```
diff --git a/ext/mysql2/result.c b/ext/mysql2/result.c
index ccb49a5..b2d4c87 100644
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -413,15 +413,25 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
           }
           break;
         case MYSQL_TYPE_SHORT:        // short int
+        case MYSQL_TYPE_YEAR:         // short int
+          printf("debug rb_mysql_result_fetch_row_stmt type: [%d]\n", result_buffer->buffer_type);
           if (result_buffer->is_unsigned) {
             val = UINT2NUM(*((unsigned short int*)result_buffer->buffer));
+            printf("debug rb_mysql_result_fetch_row_stmt type: [%d], unsinged. buffer: [%d], length: [%lu], buffer_length: [%lu]\n",
+              result_buffer->buffer_type,
+              *((unsigned short int*)result_buffer->buffer),
+              *((unsigned long*)result_buffer->length), result_buffer->buffer_length);
           } else  {
             val = INT2NUM(*((short int*)result_buffer->buffer));
+            printf("debug rb_mysql_result_fetch_row_stmt type: [%d] singed. [%d], length: [%lu], buffer_length: [%lu]\n",
+              result_buffer->buffer_type,
+              *((short int*)result_buffer->buffer),
+              *((unsigned long*)result_buffer->length), result_buffer->buffer_length);
           }
```

The result is like this on little endian. (MYSQL_TYPE_YEAR value is 13.)

```
debug rb_mysql_result_fetch_row_stmt type: [13]
debug rb_mysql_result_fetch_row_stmt type: [13], unsinged. buffer: [2009], length: [2], buffer_length: [4]
```

The value is 131661824 on big endian environment as you know.

Seeing the source code in mariadb-connector-c v3.0.2 (v3.0.3 is not released yet), the type year looks defined as short int.

https://github.com/MariaDB/mariadb-connector-c/blob/v3.0.2/libmariadb/ma_stmt_codec.c#L443
```
void ps_fetch_int16(MYSQL_BIND *r_param, const MYSQL_FIELD * const field,
                                unsigned char **row)
...
    case MYSQL_TYPE_YEAR:
    case MYSQL_TYPE_SHORT:
        ps_fetch_from_1_to_8_bytes(r_param, field, row, 2);
```

https://github.com/MariaDB/mariadb-connector-c/blob/v3.0.2/libmariadb/ma_stmt_codec.c#L254

```
r_param->is_unsigned ? NUMERIC_TRUNCATION(val, 0, UINT_MAX16) : NUMERIC_TRUNCATION(val, INT_MIN16, INT_MAX16)
```

https://github.com/MariaDB/mariadb-connector-c/blob/v3.0.2/include/ma_global.h#L549-L551

```
#define INT_MIN16       (~0x7FFF)
#define INT_MAX16       0x7FFF
#define UINT_MAX16 0xFFFF
```

unsigned YEAR: between 0 (0x00 0x00) and UINT_MAX16 (0xff 0xff) that is `unsigned int short`
signed YEAR: (I am not sure signed YEAR is possible):  between INT_MIN16 and INT_MAX16: `int short`

I tested this patch on big endian environment. And that's okay.
But I want to know why it was "int" previously.
The definition of YEAR is different between mariadb-connector-c, MySQL server and Mariadb server?
Do you remember it?

Thank you.

