### PR TITLE
Update usage section of README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,7 +138,7 @@ results.each do |row|
   # conveniently, row is a hash
   # the keys are the fields, as you'd expect
   # the values are pre-built ruby primitives mapped from their corresponding field types in MySQL
-  puts row["id"] # row["id"].class == Fixnum
+  puts row["id"] # row["id"].is_a? Integer
   if row["dne"]  # non-existant hash entry is nil
     puts row["dne"]
   end


### PR DESCRIPTION
Follow up of #907.

Since `Fixnum` is a subclass of `Integer`, I thought it would be OK to replace it with `Integer`. Especially, It will be a calm expression for Ruby 2.4 or higher users.