### PR TITLE
Fix with --with-mysql-dir

### DIFF
--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -63,6 +63,7 @@ if inc && lib
   abort "-----\nCannot find library dir(s) #{lib}\n-----" unless lib && lib.split(File::PATH_SEPARATOR).any? { |dir| File.directory?(dir) }
   warn "-----\nUsing --with-mysql-dir=#{File.dirname inc}\n-----"
   rpath_dir = lib
+  have_library('mysqlclient')
 elsif (mc = (with_config('mysql-config') || Dir[GLOB].first))
   # If the user has provided a --with-mysql-config argument, we must respect it or fail.
   # If the user gave --with-mysql-config with no argument means we should try to find it.


### PR DESCRIPTION
When gem install with `--with-mysql-dir`, the `mysql2.so` library does not link `libmysqlclient.so`.

```
% gem install mysql2 -- --with-mysql-dir=/usr/local/mysql-5.7
Building native extensions with: '--with-mysql-dir=/usr/local/mysql-5.7'
This could take a while...
Successfully installed mysql2-0.5.0
Parsing documentation for mysql2-0.5.0
Done installing documentation for mysql2 after 0 seconds
1 gem installed

% ruby -rmysql2 -e ''                                        
ruby: symbol lookup error: /home/tommy/gems25/gems/mysql2-0.5.0/lib/mysql2/mysql2.so: undefined symbol: mysql_server_init

% ldd /home/tommy/gems25/gems/mysql2-0.5.0/lib/mysql2/mysql2.so 
	linux-vdso.so.1 =>  (0x00007ffd78134000)
	libruby.so.2.5 => /home/tommy/ruby25/lib/libruby.so.2.5 (0x00007f1822b5e000)
	libpthread.so.0 => /lib/x86_64-linux-gnu/libpthread.so.0 (0x00007f182293f000)
	libc.so.6 => /lib/x86_64-linux-gnu/libc.so.6 (0x00007f182255f000)
	libdl.so.2 => /lib/x86_64-linux-gnu/libdl.so.2 (0x00007f182235b000)
	libcrypt.so.1 => /lib/x86_64-linux-gnu/libcrypt.so.1 (0x00007f1822123000)
	libm.so.6 => /lib/x86_64-linux-gnu/libm.so.6 (0x00007f1821dcd000)
	/lib64/ld-linux-x86-64.so.2 (0x00007f18232a0000)
```
