### PR TITLE
Handle read_timeout for queries executed within EventMachine

### DIFF
--- a/lib/mysql2/em.rb
+++ b/lib/mysql2/em.rb
@@ -3,6 +3,8 @@ require 'mysql2'
 
 module Mysql2
   module EM
+    class ReadTimeout < ::RuntimeError; end
+
     class Client < ::Mysql2::Client
       module Watcher
         def initialize(client, deferable)
@@ -41,6 +43,12 @@ module Mysql2
         if ::EM.reactor_running?
           super(sql, opts.merge(async: true))
           deferable = ::EM::DefaultDeferrable.new
+          if @read_timeout
+            deferable.timeout(@read_timeout, Mysql2::EM::ReadTimeout.new)
+            deferable.errback do |error|
+              raise error if error.is_a?(Mysql2::EM::ReadTimeout)
+            end
+          end
           @watch = ::EM.watch(socket, Watcher, self, deferable)
           @watch.notify_readable = true
           deferable


### PR DESCRIPTION
Hello, I'm not sure if this is the best approach to handle a `read_timeout` when a query is being run within an EventMachine reactor loop, but I wanted to give it a try and pick your brain on the topic :) 

The `read_timeout` option is only used when a query is executed synchronously, so it will be completely ignored for `EM` clients.

https://github.com/brianmario/mysql2/blob/b3fe727b56ba5c8cb5678200f2e99a7119bc41cc/ext/mysql2/client.c#L782-L792

In order to expose a similar behaviour I've introduced a [Deferrable Timeout](https://www.rubydoc.info/github/eventmachine/eventmachine/EventMachine/Deferrable#timeout-instance_method) which will raise a `Mysql2::EM::ReadTimeout`.

In case of a read timeout from the normal non-evented client, a `Mysql::Error` is raised, but I am not sure it would be ok to raise that exception in this case.

I also understand that a change like this one would break compatibility. Maybe there is a better way to expose this timeout logic to the client code. On the other hand it is also a bit counter intuitive to have a `read_timeout` option that doesn't do anything when the client is evented :)

Please let me know what you think about it.
Have a nice day!


