### PR TITLE
Updating the mysql2_mysql_enc_to_rb conversion table to 8.0 List

### DIFF
--- a/ext/mysql2/mysql_enc_to_ruby.h
+++ b/ext/mysql2/mysql_enc_to_ruby.h
@@ -245,5 +245,15 @@ static const char *mysql2_mysql_enc_to_rb[] = {
   "UTF-8",
   "UTF-8",
   "UTF-8",
+  "UTF-8",
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
+  NULL,
   "UTF-8"
 };
+
+#define CHARSETNR_SIZE (sizeof(mysql2_mysql_enc_to_rb)/sizeof(mysql2_mysql_enc_to_rb[0]))

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -179,7 +179,8 @@ static VALUE mysql2_set_field_string_encoding(VALUE val, MYSQL_FIELD field, rb_e
     const char *enc_name;
     int enc_index;
 
-    enc_name = mysql2_mysql_enc_to_rb[field.charsetnr-1];
+    enc_name = (field.charsetnr-1 < CHARSETNR_SIZE) ? mysql2_mysql_enc_to_rb[field.charsetnr-1] : NULL;
+    
     if (enc_name != NULL) {
       /* use the field encoding we were able to match */
       enc_index = rb_enc_find_index(enc_name);


### PR DESCRIPTION
This commit fixes #975 what happened is that I used the collation utf8mb4_general_ci which is listed as charsetnr 254 in the C API our conversion table mysql2_mysql_enc_to_rb did not have entries that went past 245 previously. Thus, functions that used the result of this selection would be given an index into undefined memory and when they tried to read it they would blow past the end of the segment causing the issue in #975. I've added a check to return NULL if we see a charsetnr that is larger than the conversion table.