### PR TITLE
Add support for returning result rows as structs. (:as => :struct)

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -656,7 +656,7 @@ static VALUE do_query(void *args) {
     tvp->tv_usec = 0;
   }
 
-  for(;;) {
+  for (;;) {
     retval = rb_wait_for_single_fd(async_args->fd, RB_WAITFD_IN, tvp);
 
     if (retval == 0) {

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -656,7 +656,7 @@ static VALUE do_query(void *args) {
     tvp->tv_usec = 0;
   }
 
-  for (;;) {
+  for(;;) {
     retval = rb_wait_for_single_fd(async_args->fd, RB_WAITFD_IN, tvp);
 
     if (retval == 0) {

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -304,7 +304,7 @@ static VALUE cast_row_as_struct(VALUE self, VALUE rowVal, mysql2_result_wrapper 
     for (i = 0; i < wrapper->numberOfFields; i++) {
       argv_fields[i] = rb_mysql_result_fetch_field(self, i, 1);
     }
-    wrapper->rowStruct = rb_funcallv(rb_cStruct, intern_new, (int) wrapper->numberOfFields, argv_fields);
+    wrapper->rowStruct = rb_funcall2(rb_cStruct, intern_new, (int) wrapper->numberOfFields, argv_fields);
   }
 
   return rb_struct_alloc(wrapper->rowStruct, rowVal); 

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -861,7 +861,6 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
   }
 
   symbolizeKeys = RTEST(rb_hash_aref(opts, sym_symbolize_keys));
-  rowsAs        = AS_HASH;
   castBool      = RTEST(rb_hash_aref(opts, sym_cast_booleans));
   cacheRows     = RTEST(rb_hash_aref(opts, sym_cache_rows));
   cast          = RTEST(rb_hash_aref(opts, sym_cast));
@@ -872,6 +871,8 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
   } else if (as_opt == sym_struct) {
     rowsAs = AS_STRUCT;
     symbolizeKeys = 1;  /* force */
+  } else {
+    rowsAs = AS_HASH;
   }
 
   if (wrapper->is_streaming && cacheRows) {

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -722,7 +722,6 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
   return rowVal;
 }
 
-
 static VALUE rb_mysql_result_fetch_fields(VALUE self) {
   unsigned int i = 0;
   short int symbolizeKeys = 0;

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -37,8 +37,11 @@ static VALUE cMysql2Result, cDateTime, cDate;
 static VALUE opt_decimal_zero, opt_float_zero, opt_time_year, opt_time_month, opt_utc_offset;
 static ID intern_new, intern_utc, intern_local, intern_localtime, intern_local_offset,
   intern_civil, intern_new_offset, intern_merge, intern_BigDecimal;
-static VALUE sym_symbolize_keys, sym_as, sym_array, sym_struct, sym_database_timezone,
-  sym_application_timezone, sym_local, sym_utc, sym_cast_booleans, sym_cache_rows, sym_cast, sym_stream, sym_name;
+static VALUE sym_symbolize_keys, sym_as, sym_array, sym_database_timezone,
+  sym_application_timezone, sym_local, sym_utc, sym_cast_booleans,
+  sym_cache_rows, sym_cast, sym_stream, sym_name;
+
+static VALUE sym_struct;
 
 /* internal rowsAs constants */
 #define AS_HASH   0
@@ -541,14 +544,14 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
           val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc);
         }
       } else {
-        switch (type) {
+        switch(type) {
         case MYSQL_TYPE_NULL:       /* NULL-type field */
           val = Qnil;
           break;
         case MYSQL_TYPE_BIT:        /* BIT field (MySQL 5.0.3 and up) */
           if (args->castBool && fields[i].length == 1) {
             val = *row[i] == 1 ? Qtrue : Qfalse;
-          } else {
+          }else{
             val = rb_str_new(row[i], fieldLengths[i]);
           }
           break;
@@ -568,9 +571,9 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
         case MYSQL_TYPE_NEWDECIMAL: /* Precision math DECIMAL or NUMERIC field (MySQL 5.0.3 and up) */
           if (fields[i].decimals == 0) {
             val = rb_cstr2inum(row[i], 10);
-          } else if (strtod(row[i], NULL) == 0.000000) {
+          } else if (strtod(row[i], NULL) == 0.000000){
             val = rb_funcall(rb_mKernel, intern_BigDecimal, 1, opt_decimal_zero);
-          } else {
+          }else{
             val = rb_funcall(rb_mKernel, intern_BigDecimal, 1, rb_str_new(row[i], fieldLengths[i]));
           }
           break;
@@ -580,7 +583,7 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
           column_to_double = strtod(row[i], NULL);
           if (column_to_double == 0.000000){
             val = opt_float_zero;
-          } else {
+          }else{
             val = rb_float_new(column_to_double);
           }
           break;
@@ -844,7 +847,7 @@ static VALUE rb_mysql_result_each_(VALUE self,
 
 static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
   result_each_args args;
-  VALUE defaults, opts, block, (*fetch_row_func)(VALUE, MYSQL_FIELD *fields, const result_each_args *args);
+  VALUE defaults, opts, as_opt, block, (*fetch_row_func)(VALUE, MYSQL_FIELD *fields, const result_each_args *args);
   ID db_timezone, app_timezone, dbTz, appTz;
   int symbolizeKeys, rowsAs, castBool, cacheRows, cast;
 
@@ -868,9 +871,10 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
   cacheRows     = RTEST(rb_hash_aref(opts, sym_cache_rows));
   cast          = RTEST(rb_hash_aref(opts, sym_cast));
 
-  if (rb_hash_aref(opts, sym_as) == sym_array) {
+  as_opt = rb_hash_aref(opts, sym_as);
+  if (as_opt == sym_array) {
     rowsAs = AS_ARRAY;
-  } else if (rb_hash_aref(opts, sym_as) == sym_struct) {
+  } else if (as_opt == sym_struct) {
     rowsAs = AS_STRUCT;
     symbolizeKeys = 1;  /* force */
   }
@@ -1034,10 +1038,10 @@ void init_mysql2_result() {
   sym_cast_booleans   = ID2SYM(rb_intern("cast_booleans"));
   sym_database_timezone     = ID2SYM(rb_intern("database_timezone"));
   sym_application_timezone  = ID2SYM(rb_intern("application_timezone"));
-  sym_cache_rows      = ID2SYM(rb_intern("cache_rows"));
-  sym_cast            = ID2SYM(rb_intern("cast"));
-  sym_stream          = ID2SYM(rb_intern("stream"));
-  sym_name            = ID2SYM(rb_intern("name"));
+  sym_cache_rows     = ID2SYM(rb_intern("cache_rows"));
+  sym_cast           = ID2SYM(rb_intern("cast"));
+  sym_stream         = ID2SYM(rb_intern("stream"));
+  sym_name           = ID2SYM(rb_intern("name"));
 
   opt_decimal_zero = rb_str_new2("0.0");
   rb_global_variable(&opt_decimal_zero); /*never GC */

--- a/ext/mysql2/result.h
+++ b/ext/mysql2/result.h
@@ -10,6 +10,7 @@ typedef struct {
   VALUE client;
   VALUE encoding;
   VALUE statement;
+  VALUE rowStruct;
   my_ulonglong numberOfFields;
   my_ulonglong numberOfRows;
   unsigned long lastRowProcessed;

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -123,6 +123,11 @@ RSpec.describe Mysql2::Result do
       result = @client.query "SELECT 'a', 'b', 'c'"
       expect(result.fields).to eql(%w[a b c])
     end
+
+    it "should return an array of symbolized field names if :as was set to :struct" do
+      result = @client.query "SELECT 'a', 'b', 'c'", as: :struct
+      expect(result.fields.first).to be_an_instance_of(Symbol)
+    end
   end
 
   context "streaming" do

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Mysql2::Result do
       expect(result.fields).to eql(%w[a b c])
     end
 
-    it "field names should be symbols if :as is set to :struct" do
+    it "should return field names as symbols if rows are structs" do
       result = @client.query "SELECT 'a', 'b', 'c'", as: :struct
       expect(result.fields.first).to be_an_instance_of(Symbol)
     end

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -124,7 +124,7 @@ RSpec.describe Mysql2::Result do
       expect(result.fields).to eql(%w[a b c])
     end
 
-    it "should return an array of symbolized field names if :as was set to :struct" do
+    it "field names should be symbols if :as is set to :struct" do
       result = @client.query "SELECT 'a', 'b', 'c'", as: :struct
       expect(result.fields.first).to be_an_instance_of(Symbol)
     end

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -72,6 +72,12 @@ RSpec.describe Mysql2::Result do
       end
     end
 
+    it "should be able to return results as a struct" do
+      @result.each(as: :struct) do |row|
+        expect(row).to be_kind_of(Struct)
+      end
+    end
+
     it "should cache previously yielded results by default" do
       expect(@result.first.object_id).to eql(@result.first.object_id)
     end

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -294,6 +294,13 @@ RSpec.describe Mysql2::Statement do
       end
     end
 
+    it "should be able to return results as a struct" do
+      @result = @client.prepare("SELECT 1").execute(as: :struct)
+      @result.each do |row|
+        expect(row).to be_kind_of(Struct)
+      end
+    end
+
     it "should cache previously yielded results by default" do
       @result = @client.prepare("SELECT 1").execute
       expect(@result.first.object_id).to eql(@result.first.object_id)
@@ -327,6 +334,11 @@ RSpec.describe Mysql2::Statement do
     it "should return an array of field names in proper order" do
       stmt = @client.prepare("SELECT 'a', 'b', 'c'")
       expect(stmt.fields).to eql(%w[a b c])
+    end
+
+    it "should return field names as symbols if rows are structs" do
+      result = @client.prepare("SELECT 'a', 'b', 'c'").execute(as: :struct)
+      expect(result.fields.first).to be_an_instance_of(Symbol)
     end
 
     it "should return nil for statement with no result fields" do


### PR DESCRIPTION
This patch adds a new query option to return result rows as structs.

At [Bandcamp](https://bandcamp.com) we've been using this patch (and the other) in our fork of the mysql2 gem since the beginning. We think dot notation is cleaner and more object-oriented-looking, and wanted to use it in our code that processes query results. I believe it can also make the code faster if it's doing a lot of column accesses.

This is a default for all our queries:

```
opts = Mysql2::Client.default_query_options
opts[:as] = :struct
```
And query results can be used like this:

```
band = query(<<-SQL
    SELECT band.name, bio.bio
    FROM bands AS band
    LEFT JOIN bios AS bio ON bio.band_id = band.id
    WHERE band.id = #{band_id}
    SQL
).first

puts "#{band.name} - #{band.bio}"
```

I've been meaning to make these two pull requests since forever. We've had years of experience with them and think they're useful. If you have any questions about how Bandcamp's Linux/MySQL/Ruby stack works, just ask.

