### PR TITLE
Add support for casting DATE values as Time objects. (:cast_dates_as_times => true)

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -656,7 +656,7 @@ static VALUE do_query(void *args) {
     tvp->tv_usec = 0;
   }
 
-  for(;;) {
+  for (;;) {
     retval = rb_wait_for_single_fd(async_args->fd, RB_WAITFD_IN, tvp);
 
     if (retval == 0) {

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -656,7 +656,7 @@ static VALUE do_query(void *args) {
     tvp->tv_usec = 0;
   }
 
-  for (;;) {
+  for(;;) {
     retval = rb_wait_for_single_fd(async_args->fd, RB_WAITFD_IN, tvp);
 
     if (retval == 0) {

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -215,9 +215,7 @@ static unsigned int msec_char_to_uint(char *msec_char, size_t len)
 
 static VALUE new_time(unsigned int year, unsigned int month, unsigned int day, unsigned int hour, unsigned int minute, unsigned int second, unsigned long second_part, const result_each_args *args)
 {
-  VALUE val;
-
-  val = rb_funcall(rb_cTime, args->db_timezone, 7, UINT2NUM(year), UINT2NUM(month), UINT2NUM(day), UINT2NUM(hour), UINT2NUM(minute), UINT2NUM(second), ULONG2NUM(second_part));
+  VALUE val = rb_funcall(rb_cTime, args->db_timezone, 7, UINT2NUM(year), UINT2NUM(month), UINT2NUM(day), UINT2NUM(hour), UINT2NUM(minute), UINT2NUM(second), ULONG2NUM(second_part));
   if (!NIL_P(args->app_timezone)) {
     if (args->app_timezone == intern_local) {
       val = rb_funcall(val, intern_localtime, 0);

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -531,14 +531,14 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
           val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc);
         }
       } else {
-        switch (type) {
+        switch(type) {
         case MYSQL_TYPE_NULL:       /* NULL-type field */
           val = Qnil;
           break;
         case MYSQL_TYPE_BIT:        /* BIT field (MySQL 5.0.3 and up) */
           if (args->castBool && fields[i].length == 1) {
             val = *row[i] == 1 ? Qtrue : Qfalse;
-          } else {
+          }else{
             val = rb_str_new(row[i], fieldLengths[i]);
           }
           break;
@@ -558,9 +558,9 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
         case MYSQL_TYPE_NEWDECIMAL: /* Precision math DECIMAL or NUMERIC field (MySQL 5.0.3 and up) */
           if (fields[i].decimals == 0) {
             val = rb_cstr2inum(row[i], 10);
-          } else if (strtod(row[i], NULL) == 0.000000) {
+          } else if (strtod(row[i], NULL) == 0.000000){
             val = rb_funcall(rb_mKernel, intern_BigDecimal, 1, opt_decimal_zero);
-          } else {
+          }else{
             val = rb_funcall(rb_mKernel, intern_BigDecimal, 1, rb_str_new(row[i], fieldLengths[i]));
           }
           break;
@@ -570,7 +570,7 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
           column_to_double = strtod(row[i], NULL);
           if (column_to_double == 0.000000){
             val = opt_float_zero;
-          } else {
+          }else{
             val = rb_float_new(column_to_double);
           }
           break;
@@ -1014,10 +1014,10 @@ void init_mysql2_result() {
   sym_cast_datetimes  = ID2SYM(rb_intern("cast_datetimes"));
   sym_database_timezone     = ID2SYM(rb_intern("database_timezone"));
   sym_application_timezone  = ID2SYM(rb_intern("application_timezone"));
-  sym_cache_rows      = ID2SYM(rb_intern("cache_rows"));
-  sym_cast            = ID2SYM(rb_intern("cast"));
-  sym_stream          = ID2SYM(rb_intern("stream"));
-  sym_name            = ID2SYM(rb_intern("name"));
+  sym_cache_rows     = ID2SYM(rb_intern("cache_rows"));
+  sym_cast           = ID2SYM(rb_intern("cast"));
+  sym_stream         = ID2SYM(rb_intern("stream"));
+  sym_name           = ID2SYM(rb_intern("name"));
 
   opt_decimal_zero = rb_str_new2("0.0");
   rb_global_variable(&opt_decimal_zero); /*never GC */

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -39,8 +39,9 @@ static VALUE opt_decimal_zero, opt_float_zero, opt_time_year, opt_time_month, op
 static ID intern_new, intern_utc, intern_local, intern_localtime, intern_local_offset,
   intern_civil, intern_new_offset, intern_merge, intern_BigDecimal;
 static VALUE sym_symbolize_keys, sym_as, sym_array, sym_database_timezone,
-  sym_application_timezone, sym_local, sym_utc, sym_cast_booleans, sym_cast_dates_as_times,
+  sym_application_timezone, sym_local, sym_utc, sym_cast_booleans,
   sym_cache_rows, sym_cast, sym_stream, sym_name;
+static VALUE sym_cast_dates_as_times;
 
 /* Mark any VALUEs that are only referenced in C, so the GC won't get them. */
 static void rb_mysql_result_mark(void * wrapper) {
@@ -817,7 +818,8 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
   result_each_args args;
   VALUE defaults, opts, block, (*fetch_row_func)(VALUE, MYSQL_FIELD *fields, const result_each_args *args);
   ID db_timezone, app_timezone, dbTz, appTz;
-  int symbolizeKeys, asArray, castBool, castDateAsTime, cacheRows, cast;
+  int symbolizeKeys, asArray, castBool, cacheRows, cast;
+  int castDateAsTime;
 
   GET_RESULT(self);
 

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -312,15 +312,15 @@ RSpec.describe Mysql2::Result do
       expect(test_result['date_test'].strftime("%Y-%m-%d")).to eql('2010-04-04')
     end
 
-    it "should return Time for a DATE value when :cast_datetime is enabled" do
-      result1 = @client.query('SELECT date_test FROM mysql2_test', cast_datetimes: true).first
-      expect(result1['date_test']).to be_an_instance_of(Time)
-      expect(result1['date_test'].strftime("%Y-%m-%d %H:%M:%S")).to eql('2010-04-04 00:00:00')
-    end
-
     it "should return String for an ENUM value" do
       expect(test_result['enum_test']).to be_an_instance_of(String)
       expect(test_result['enum_test']).to eql('val1')
+    end
+
+    it "should return Time for a DATE value when :cast_dates_as_times is enabled" do
+      result = @client.query('SELECT date_test FROM mysql2_test', cast_dates_as_times: true).first
+      expect(result['date_test']).to be_an_instance_of(Time)
+      expect(result['date_test'].strftime("%Y-%m-%d %H:%M:%S")).to eql('2010-04-04 00:00:00')
     end
 
     it "should raise an error given an invalid DATETIME" do

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -242,15 +242,6 @@ RSpec.describe Mysql2::Result do
       end
     end
 
-    context "cast datetimes to UTC when :cast_datetime is enabled" do
-      it "should return UTC Time for a DATETIME if :cast_datetime is enabled" do
-        result1 = @client.query('SELECT date_time_test FROM mysql2_test', database_timezone: :utc, application_timezone: :utc, cast_datetimes: true).first
-        result2 = @client.query('SELECT date_time_test FROM mysql2_test', cast_datetimes: false).first
-        expect(result1['date_time_test'].utc?).to be true
-        expect(result2['date_time_test'].utc?).to be false
-      end
-    end
-
     it "should return Fixnum for a SMALLINT value" do
       expect(num_classes).to include(test_result['small_int_test'].class)
       expect(test_result['small_int_test']).to eql(10)
@@ -319,6 +310,12 @@ RSpec.describe Mysql2::Result do
     it "should return Date for a DATE value" do
       expect(test_result['date_test']).to be_an_instance_of(Date)
       expect(test_result['date_test'].strftime("%Y-%m-%d")).to eql('2010-04-04')
+    end
+
+    it "should return Time for a DATE value when :cast_datetime is enabled" do
+      result1 = @client.query('SELECT date_test FROM mysql2_test', cast_datetimes: true).first
+      expect(result1['date_test']).to be_an_instance_of(Time)
+      expect(result1['date_test'].strftime("%Y-%m-%d %H:%M:%S")).to eql('2010-04-04 00:00:00')
     end
 
     it "should return String for an ENUM value" do

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -312,15 +312,15 @@ RSpec.describe Mysql2::Result do
       expect(test_result['date_test'].strftime("%Y-%m-%d")).to eql('2010-04-04')
     end
 
+    it "should return Time for a DATE value when :cast_dates_as_times is enabled" do
+      r = @client.query('SELECT date_test FROM mysql2_test', cast_dates_as_times: true).first
+      expect(r['date_test']).to be_an_instance_of(Time)
+      expect(r['date_test'].strftime("%Y-%m-%d %H:%M:%S")).to eql('2010-04-04 00:00:00')
+    end
+
     it "should return String for an ENUM value" do
       expect(test_result['enum_test']).to be_an_instance_of(String)
       expect(test_result['enum_test']).to eql('val1')
-    end
-
-    it "should return Time for a DATE value when :cast_dates_as_times is enabled" do
-      result = @client.query('SELECT date_test FROM mysql2_test', cast_dates_as_times: true).first
-      expect(result['date_test']).to be_an_instance_of(Time)
-      expect(result['date_test'].strftime("%Y-%m-%d %H:%M:%S")).to eql('2010-04-04 00:00:00')
     end
 
     it "should raise an error given an invalid DATETIME" do

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -242,6 +242,15 @@ RSpec.describe Mysql2::Result do
       end
     end
 
+    context "cast datetimes to UTC when :cast_datetime is enabled" do
+      it "should return UTC Time for a DATETIME if :cast_datetime is enabled" do
+        result1 = @client.query('SELECT date_time_test FROM mysql2_test', database_timezone: :utc, application_timezone: :utc, cast_datetimes: true).first
+        result2 = @client.query('SELECT date_time_test FROM mysql2_test', cast_datetimes: false).first
+        expect(result1['date_time_test'].utc?).to be true
+        expect(result2['date_time_test'].utc?).to be false
+      end
+    end
+
     it "should return Fixnum for a SMALLINT value" do
       expect(num_classes).to include(test_result['small_int_test'].class)
       expect(test_result['small_int_test']).to eql(10)

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -469,6 +469,12 @@ RSpec.describe Mysql2::Statement do
       expect(test_result['date_test'].strftime("%Y-%m-%d")).to eql('2010-04-04')
     end
 
+    it "should return Time for a DATE value when :cast_dates_as_times is enabled" do
+      r = @client.prepare('SELECT date_test FROM mysql2_test').execute(cast_dates_as_times: true).first
+      expect(r['date_test']).to be_an_instance_of(Time)
+      expect(r['date_test'].strftime("%Y-%m-%d %H:%M:%S")).to eql('2010-04-04 00:00:00')
+    end
+
     it "should return String for an ENUM value" do
       expect(test_result['enum_test']).to be_an_instance_of(String)
       expect(test_result['enum_test']).to eql('val1')


### PR DESCRIPTION
This patch adds a new query option to cast mysql DATE result values as ruby Time objects.

At [Bandcamp](https://bandcamp.com) we've been using this patch (and the other) in our fork of the mysql2 gem since the beginning. I made this patch because we use DATETIME columns in almost all our tables, but occasionally we'll use DATE. With this patch we don't have to care about mixed results.

This is a default for all our queries:

```
opts = Mysql2::Client.default_query_options
opts[:cast_dates_as_times] = true
```

I've been meaning to make these two pull requests since forever. We've had years of experience with them and think they're useful. If you have any questions about how Bandcamp's Linux/MySQL/Ruby stack works, just ask.
