### PR TITLE
Expose windows client authentication

### DIFF
--- a/README.md
+++ b/README.md
@@ -218,6 +218,7 @@ Mysql2::Client.new(
   :ssl_mode = :disabled / :preferred / :required / :verify_ca / :verify_identity,
   :default_file = '/path/to/my.cfg',
   :default_group = 'my.cfg section',
+  :default_auth = 'authentication_windows_client'
   :init_command => sql
   )
 ```

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -903,6 +903,11 @@ static VALUE _mysql_client_options(VALUE self, int opt, VALUE value) {
       retval  = charval;
       break;
 
+    case MYSQL_DEFAULT_AUTH:
+      charval = (const char *)StringValueCStr(value);
+      retval  = charval;
+      break;
+
 #ifdef HAVE_CONST_MYSQL_ENABLE_CLEARTEXT_PLUGIN
     case MYSQL_ENABLE_CLEARTEXT_PLUGIN:
       boolval = (value == Qfalse ? 0 : 1);
@@ -1336,6 +1341,10 @@ static VALUE set_init_command(VALUE self, VALUE value) {
   return _mysql_client_options(self, MYSQL_INIT_COMMAND, value);
 }
 
+static VALUE set_default_auth(VALUE self, VALUE value) {
+  return _mysql_client_options(self, MYSQL_DEFAULT_AUTH, value);
+}
+
 static VALUE set_enable_cleartext_plugin(VALUE self, VALUE value) {
 #ifdef HAVE_CONST_MYSQL_ENABLE_CLEARTEXT_PLUGIN
   return _mysql_client_options(self, MYSQL_ENABLE_CLEARTEXT_PLUGIN, value);
@@ -1437,6 +1446,7 @@ void init_mysql2_client() {
   rb_define_private_method(cMysql2Client, "default_file=", set_read_default_file, 1);
   rb_define_private_method(cMysql2Client, "default_group=", set_read_default_group, 1);
   rb_define_private_method(cMysql2Client, "init_command=", set_init_command, 1);
+  rb_define_private_method(cMysql2Client, "default_auth=", set_default_auth, 1);
   rb_define_private_method(cMysql2Client, "ssl_set", set_ssl_options, 5);
   rb_define_private_method(cMysql2Client, "ssl_mode=", rb_set_ssl_mode_option, 1);
   rb_define_private_method(cMysql2Client, "enable_cleartext_plugin=", set_enable_cleartext_plugin, 1);

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -31,7 +31,7 @@ module Mysql2
       opts[:connect_timeout] = 120 unless opts.key?(:connect_timeout)
 
       # TODO: stricter validation rather than silent massaging
-      %i[reconnect connect_timeout local_infile read_timeout write_timeout default_file default_group secure_auth init_command automatic_close enable_cleartext_plugin].each do |key|
+      %i[reconnect connect_timeout local_infile read_timeout write_timeout default_file default_group secure_auth init_command automatic_close enable_cleartext_plugin default_auth].each do |key|
         next unless opts.key?(key)
         case key
         when :reconnect, :local_infile, :secure_auth, :automatic_close, :enable_cleartext_plugin


### PR DESCRIPTION
Verified that this works by:

- Enabling the windows auth plugin in mySQL Enterprise version
- In mySQL, create a user that references a Windows username 
- In Rails db config, set the username to the mySQL username, no password, default_auth = 'authentication_windows_client'
- Running Rails as the Windows user from step 2
 