### PR TITLE
Fix fragile and crashing specs on macOS

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -40,6 +40,17 @@ RSpec.configure do |config|
     # rubocop:enable Lint/UnifiedInteger
   end
 
+  # Use monotonic time if possible (ruby >= 2.1.0)
+  if defined?(Process::CLOCK_MONOTONIC)
+    def clock_time
+      Process.clock_gettime Process::CLOCK_MONOTONIC
+    end
+  else
+    def clock_time
+      Time.now.to_f
+    end
+  end
+
   config.before :each do
     @client = new_client
   end


### PR DESCRIPTION
* Use monotonic time if possible to guard against clock skew
* Relax time comparisons to make test failures under load less likely
* Fix memory corruption segfaults on macOS due to mixing Threads and Timeout

Without the timeout thread safety fix, the specs always crash in the
"threaded queries should be supported" spec for various reasons on
macOS 10.14.4 with ruby 2.6.1 / MySQL 8.0.15.

Some observed errors:

    malloc: *** error for object 0x7fcbba90ef80: pointer being freed was not allocated
    malloc: *** set a breakpoint in malloc_error_break to debug

    lib/mysql2/client.rb:131:in `_query': Bad file descriptor (Errno::EBADF)

Now specs run fine, even during Prime95 load test on i9-8950HK (6c/12t).