### PR TITLE
Improve performance to call Mysql2::Result#each and Mysql2::Result#fields

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -37,7 +37,8 @@ extern VALUE mMysql2, cMysql2Client, cMysql2Error;
 static VALUE cMysql2Result, cDateTime, cDate;
 static VALUE opt_decimal_zero, opt_float_zero, opt_time_year, opt_time_month, opt_utc_offset;
 static ID intern_new, intern_utc, intern_local, intern_localtime, intern_local_offset,
-  intern_civil, intern_new_offset, intern_merge, intern_BigDecimal;
+  intern_civil, intern_new_offset, intern_merge, intern_BigDecimal,
+  intern_query_options;
 static VALUE sym_symbolize_keys, sym_as, sym_array, sym_database_timezone,
   sym_application_timezone, sym_local, sym_utc, sym_cast_booleans,
   sym_cache_rows, sym_cast, sym_stream, sym_name;
@@ -695,7 +696,7 @@ static VALUE rb_mysql_result_fetch_fields(VALUE self) {
 
   GET_RESULT(self);
 
-  defaults = rb_iv_get(self, "@query_options");
+  defaults = rb_ivar_get(self, intern_query_options);
   Check_Type(defaults, T_HASH);
   if (rb_hash_aref(defaults, sym_symbolize_keys) == Qtrue) {
     symbolizeKeys = 1;
@@ -818,7 +819,7 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
     rb_raise(cMysql2Error, "Statement handle already closed");
   }
 
-  defaults = rb_iv_get(self, "@query_options");
+  defaults = rb_ivar_get(self, intern_query_options);
   Check_Type(defaults, T_HASH);
   if (rb_scan_args(argc, argv, "01&", &opts, &block) == 1) {
     opts = rb_funcall(defaults, intern_merge, 1, opts);
@@ -951,7 +952,7 @@ VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_
   }
 
   rb_obj_call_init(obj, 0, NULL);
-  rb_iv_set(obj, "@query_options", options);
+  rb_ivar_set(obj, intern_query_options, options);
 
   /* Options that cannot be changed in results.each(...) { |row| }
    * should be processed here. */
@@ -980,6 +981,7 @@ void init_mysql2_result() {
   intern_civil        = rb_intern("civil");
   intern_new_offset   = rb_intern("new_offset");
   intern_BigDecimal   = rb_intern("BigDecimal");
+  intern_query_options = rb_intern("@query_options");
 
   sym_symbolize_keys  = ID2SYM(rb_intern("symbolize_keys"));
   sym_as              = ID2SYM(rb_intern("as"));

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -3,7 +3,8 @@
 extern VALUE mMysql2, cMysql2Error;
 static VALUE cMysql2Statement, cBigDecimal, cDateTime, cDate;
 static VALUE sym_stream, intern_new_with_args, intern_each, intern_to_s, intern_merge_bang;
-static VALUE intern_sec_fraction, intern_usec, intern_sec, intern_min, intern_hour, intern_day, intern_month, intern_year;
+static VALUE intern_sec_fraction, intern_usec, intern_sec, intern_min, intern_hour, intern_day, intern_month, intern_year,
+  intern_query_options;
 
 #define GET_STATEMENT(self) \
   mysql_stmt_wrapper *stmt_wrapper; \
@@ -404,7 +405,7 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
   }
 
   // Duplicate the options hash, merge! extra opts, put the copy into the Result object
-  current = rb_hash_dup(rb_iv_get(stmt_wrapper->client, "@query_options"));
+  current = rb_hash_dup(rb_ivar_get(stmt_wrapper->client, intern_query_options));
   (void)RB_GC_GUARD(current);
   Check_Type(current, T_HASH);
 
@@ -599,4 +600,5 @@ void init_mysql2_statement() {
 
   intern_to_s = rb_intern("to_s");
   intern_merge_bang = rb_intern("merge!");
+  intern_query_options = rb_intern("@query_options");
 }


### PR DESCRIPTION
This PR will reduce the time to call Mysql2::Result#each and Mysql2::Result#fields.

If table records are small enough, the performance will improve as following.

```
Mysql2::Result#each : 901.633k -> 1.550M (1.71x faster)
Mysql2::Result#fields : 3.779M -> 6.233M (1.65x faster)
```

1. Use rb_ivar_get/rb_ivar_set to improve performance
  * By convert C-string to Ruby string ID each time, it will take a slightly time to call method each time.
This patch will catch the Ruby string ID to cut off the time.
2. Check only whether block was given
  * `rb_scan_args(argc, argv, "01&", ...)` will generate `Proc` object from block. However, the object has used to only check whether block was given. To remove redundant object generating, this patch will use `rb_block_given_p()` to check whether block was given.

### Environment
- CPU : Intel(R) Core(TM) i5-3210M CPU @ 2.50GHz
- OS : Ubuntu 18.10
- Compiler : gcc version 8.3.0

### Before changing
```
Warming up --------------------------------------
               query   886.000  i/100ms
                each    67.339k i/100ms
              fields   195.612k i/100ms
Calculating -------------------------------------
               query      9.385k (± 4.5%) i/s -     46.958k in   5.016539s
                each    901.633k (± 0.2%) i/s -      4.512M in   5.003951s
              fields      3.779M (± 0.2%) i/s -     18.974M in   5.021533s
```

### After changing
```
Warming up --------------------------------------
               query   864.000  i/100ms
                each   106.916k i/100ms
              fields   251.255k i/100ms
Calculating -------------------------------------
               query      9.457k (± 3.8%) i/s -     47.520k in   5.032949s
                each      1.550M (± 0.3%) i/s -      7.805M in   5.037029s
              fields      6.233M (± 0.1%) i/s -     31.407M in   5.039049s
```

### Benchmarks
```ruby
require 'benchmark/ips'
require 'mysql2'

def setup_database(client)
  # client.query('create database benchmark')
  sql = <<SQL
create table benchmark.users (
  id int NOT NULL AUTO_INCREMENT PRIMARY KEY,
  name text,
  email text,
  created_at datetime,
  updated_at datetime
)
SQL
  client.query(sql)

  5.times do |i|
    client.query("insert into benchmark.users (name, email, created_at, updated_at) values ('foo', 'foo@example.com', '#{Time.now.strftime("%Y-%m-%d %H:%M:%S")}', '#{Time.now.strftime("%Y-%m-%d %H:%M:%S")}')")
  end
end


client = Mysql2::Client.new(
  :host     => "127.0.0.1",
  :username => "root",
  :password => "",
  :database => "benchmark"
)

# setup_database(client)

Benchmark.ips do |x|
  query = 'select * from users'.freeze
  x.report "query" do
    client.query(query)
  end

  results = client.query(query)
  x.report "each" do
    results.each {}
  end

  x.report "fields" do
    results.fields
  end
end
```
