### PR TITLE
Replace Win32API with Fiddle, update appveyor.yml

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -25,6 +25,10 @@ on_failure:
   - find tmp -name "*.log" | xargs cat
 environment:
   matrix:
+    - ruby_version: "26-x64"
+      MINGW_PACKAGE_PREFIX: "mingw-w64-x86_64"
+    - ruby_version: "25-x64"
+      MINGW_PACKAGE_PREFIX: "mingw-w64-x86_64"
     - ruby_version: "24-x64"
       MINGW_PACKAGE_PREFIX: "mingw-w64-x86_64"
     - ruby_version: "24"

--- a/lib/mysql2.rb
+++ b/lib/mysql2.rb
@@ -20,9 +20,12 @@ if RUBY_PLATFORM =~ /mswin|mingw/
   end
 
   if dll_path
-    require 'Win32API'
-    LoadLibrary = Win32API.new('Kernel32', 'LoadLibrary', ['P'], 'I')
-    if LoadLibrary.call(dll_path).zero?
+    require 'fiddle'
+    kernel32 = Fiddle.dlopen 'kernel32'
+    load_library = Fiddle::Function.new(
+      kernel32['LoadLibraryW'], [Fiddle::TYPE_VOIDP], Fiddle::TYPE_INT,
+    )
+    if load_library.call(dll_path.encode('utf-16le')).zero?
       abort "Failed to load libmysql.dll from #{dll_path}"
     end
   end


### PR DESCRIPTION
My fork's Appveyor build passed and is at:
https://ci.appveyor.com/project/MSP-Greg/mysql2/builds/25306388

