### PR TITLE
Remove test_files (i.e. specs, examples) from gem

### DIFF
--- a/mysql2.gemspec
+++ b/mysql2.gemspec
@@ -11,9 +11,6 @@ Mysql2::GEMSPEC = Gem::Specification.new do |s|
   s.rdoc_options = ["--charset=UTF-8"]
   s.summary = 'A simple, fast Mysql library for Ruby, binding to libmysql'
   s.required_ruby_version = '>= 2.0.0'
-
   s.files = `git ls-files README.md CHANGELOG.md LICENSE ext lib support`.split
-  s.test_files = `git ls-files spec examples`.split
-
   s.metadata['msys2_mingw_dependencies'] = 'libmariadbclient'
 end


### PR DESCRIPTION
I'd like to propose removing the RSpecs and Examples from the packaged gem that's distributed. There doesn't seem to be any practical use of these files within a release version of the gem file. Another set of "test" files, benchmarks, is already not included. The benefit of removing these files would be a reduced gem file size as well as eliminating false positive vulnerabilities from security scanners (the test files include private certificates).