### PR TITLE
Implementing type reflection from mysql result

### DIFF
--- a/README.md
+++ b/README.md
@@ -165,11 +165,12 @@ client.query("SELECT * FROM users WHERE group='githubbers'", :symbolize_keys => 
 end
 ```
 
-You can get the headers and the columns in the order that they were returned
+You can get the headers, columns, and the field types in the order that they were returned
 by the query like this:
 
 ``` ruby
 headers = results.fields # <= that's an array of field names, in order
+types = results.field_types # <= that's an array of field types, in order
 results.each(:as => :array) do |row|
   # Each row is an array, ordered the same as the query results
   # An otter's den is called a "holt" or "couch"

--- a/ext/mysql2/result.h
+++ b/ext/mysql2/result.h
@@ -6,6 +6,7 @@ VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_
 
 typedef struct {
   VALUE fields;
+  VALUE fieldTypes;
   VALUE rows;
   VALUE client;
   VALUE encoding;

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -9,6 +9,7 @@ RSpec.describe Mysql2::Result do
     r = Mysql2::Result.new
     expect { r.count }.to raise_error(TypeError)
     expect { r.fields }.to raise_error(TypeError)
+    expect { r.field_types }.to raise_error(TypeError)
     expect { r.size }.to raise_error(TypeError)
     expect { r.each }.to raise_error(TypeError)
   end
@@ -116,6 +117,90 @@ RSpec.describe Mysql2::Result do
     it "should return an array of field names in proper order" do
       result = @client.query "SELECT 'a', 'b', 'c'"
       expect(result.fields).to eql(%w[a b c])
+    end
+  end
+
+  context "#field_types" do
+    let(:test_result) { @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1") }
+
+    it "method should exist" do
+      expect(test_result).to respond_to(:field_types)
+    end
+
+    it "should return correct types" do
+      expected_types = %w[
+        mediumint(9)
+        varchar(10)
+        bit(64)
+        bit(1)
+        tinyint(4)
+        tinyint(1)
+        smallint(6)
+        mediumint(9)
+        int(11)
+        bigint(20)
+        float(10,3)
+        float(10,3)
+        double(10,3)
+        decimal(10,3)
+        decimal(10,3)
+        date
+        datetime
+        timestamp
+        time
+        year(4)
+        char(10)
+        varchar(10)
+        binary(10)
+        varbinary(10)
+        tinyblob
+        tinytext
+        blob
+        text
+        mediumblob
+        mediumtext
+        longblob
+        longtext
+        enum
+        set
+      ]
+
+      expect(test_result.field_types).to eql(expected_types)
+    end
+
+    it "should return an array of field types in proper order" do
+      result = @client.query(
+        "SELECT cast('a' as char), " \
+        "cast(1.2 as decimal(15, 2)), " \
+        "cast(1.2 as decimal(15, 5)), " \
+        "cast(1.2 as decimal(15, 4)), " \
+        "cast(1.2 as decimal(15, 10)), " \
+        "cast(1.2 as decimal(14, 0)), " \
+        "cast(1.2 as decimal(15, 0)), " \
+        "cast(1.2 as decimal(16, 0)), " \
+        "cast(1.0 as decimal(16, 1))",
+      )
+
+      expected_types = %w[
+        varchar(1)
+        decimal(15,2)
+        decimal(15,5)
+        decimal(15,4)
+        decimal(15,10)
+        decimal(14,0)
+        decimal(15,0)
+        decimal(16,0)
+        decimal(16,1)
+      ]
+
+      expect(result.field_types).to eql(expected_types)
+    end
+
+    it "should return json type on mysql 8.0" do
+      next unless /8.\d+.\d+/ =~ @client.server_info[:version]
+
+      result = @client.query("SELECT JSON_OBJECT('key', 'value')")
+      expect(result.field_types).to eql(['json'])
     end
   end
 


### PR DESCRIPTION
Add `Mysql2::Result#field_types` method to get field types from result.

Resolve: #1067 