### PR TITLE
Keyword arguments have to be explicitly double-splatted in Ruby 2.7+

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ bundler_args: --without benchmarks development
 # Pin Rubygems to a working version. Sometimes it breaks upstream. Update now and then.
 before_install:
   - gem --version
-  - gem update --system 2.7.6 --quiet
+  - gem update --system --quiet
   - gem update bundler
   - gem --version
   - bash .travis_setup.sh

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ bundler_args: --without benchmarks development
 # Pin Rubygems to a working version. Sometimes it breaks upstream. Update now and then.
 before_install:
   - gem --version
-  - gem update --system --quiet
+  - gem update --system --quiet || gem update --system 2.7.10 --quiet
   - gem update bundler
   - gem --version
   - bash .travis_setup.sh

--- a/lib/mysql2/error.rb
+++ b/lib/mysql2/error.rb
@@ -52,7 +52,7 @@ module Mysql2
     def initialize(msg, server_version = nil, error_number = nil, sql_state = nil)
       @server_version = server_version
       @error_number = error_number
-      @sql_state = sql_state ? sql_state.encode(ENCODE_OPTS) : nil
+      @sql_state = sql_state ? sql_state.encode(**ENCODE_OPTS) : nil
 
       super(clean_message(msg))
     end
@@ -91,9 +91,9 @@ module Mysql2
     # Returns a valid UTF-8 string.
     def clean_message(message)
       if @server_version && @server_version > 50500
-        message.encode(ENCODE_OPTS)
+        message.encode(**ENCODE_OPTS)
       else
-        message.encode(Encoding::UTF_8, ENCODE_OPTS)
+        message.encode(Encoding::UTF_8, **ENCODE_OPTS)
       end
     end
   end


### PR DESCRIPTION
The Ruby core team decided to introduce a slight incompatibility to
keyword arguments from Ruby 3.0, i.e. complete separation between
keyword arguments literal and Hash literal.

https://bugs.ruby-lang.org/issues/14183
https://github.com/ruby/ruby/pull/2395

With that, current Ruby master warns when a Hash object was passed in as
keyword arguments:

```
$ ruby -ve 'def f(x: nil) p x; end; hash = {x: 1}; f(hash)'
ruby 2.7.0dev (2019-09-02T05:20:05Z master 83498854eb) [x86_64-darwin18]
warning: The last argument is used as the keyword parameter
warning: for `f' defined here
1
```

To eliminate this warning, we need to prefix a "double splat" (**) to
avoid ambiguity:

```
$ ruby -ve 'def f(x: nil) p x;end; hash = {x: 1}; f(**hash)'
ruby 2.7.0dev (2019-09-02T05:20:05Z master 83498854eb) [x86_64-darwin18]
1
```

See also:

* https://github.com/ruby-i18n/i18n/pull/486
* https://buildkite.com/rails/rails/builds/63974#7fb9ad05-a745-4022-b634-aa3eb9042b11/6-1865

```
/usr/local/lib/ruby/gems/2.7.0/gems/mysql2-0.5.2/lib/mysql2/error.rb:55: warning: The last argument is used as the keyword parameter
/usr/local/lib/ruby/gems/2.7.0/gems/mysql2-0.5.2/lib/mysql2/error.rb:94: warning: The last argument is used as the keyword parameter
```