### PR TITLE
Fix Travis CI errors on mysql-5.7 and CentOS cases

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -60,6 +60,7 @@ matrix:
           - mysql2gem.example.com
     - rvm: 2.4
       env: DB=mysql57
+      dist: xenial
       addons:
         hosts:
           - mysql2gem.example.com

--- a/.travis_setup_centos.sh
+++ b/.travis_setup_centos.sh
@@ -4,6 +4,11 @@ set -eux
 
 MYSQL_TEST_LOG="$(pwd)/mysql.log"
 
+# mysql_install_db uses wrong path for resolveip
+# https://jira.mariadb.org/browse/MDEV-18563
+# https://travis-ci.org/brianmario/mysql2/jobs/615263124#L2840
+ln -s "$(command -v resolveip)" /usr/libexec/resolveip
+
 mysql_install_db \
   --log-error="${MYSQL_TEST_LOG}"
 /usr/libexec/mysqld \


### PR DESCRIPTION
This PR's 2 commits fixes the errors for mysql-5.7 and CentOS cases in Travis CI.

Here is the result of my forked repository's Travis. It is succeeded.
https://travis-ci.org/junaruga/mysql2/builds/615670813

I added some notes for each commit message about the issue.
https://github.com/brianmario/mysql2/pull/1085/commits

By the way, it is possible to run Travis CI regularly cron mode monthly or weekly?
You see the last success of master branch is 6 month ago, and next build is 2 month ago.
https://travis-ci.org/brianmario/mysql2/branches

Thank you.