### PR TITLE
Add project metadata to the gemspec

### DIFF
--- a/mysql2.gemspec
+++ b/mysql2.gemspec
@@ -10,6 +10,13 @@ Mysql2::GEMSPEC = Gem::Specification.new do |s|
   s.homepage = 'https://github.com/brianmario/mysql2'
   s.rdoc_options = ["--charset=UTF-8"]
   s.summary = 'A simple, fast Mysql library for Ruby, binding to libmysql'
+  s.metadata = {
+    'bug_tracker_uri'   => "#{s.homepage}/issues",
+    'changelog_uri'     => "#{s.homepage}/releases/tag/#{s.version}",
+    'documentation_uri' => "https://www.rubydoc.info/gems/mysql2/#{s.version}",
+    'homepage_uri'      => s.homepage,
+    'source_code_uri'   => "#{s.homepage}/tree/#{s.version}",
+  }
   s.required_ruby_version = '>= 2.0.0'
 
   s.files = `git ls-files README.md CHANGELOG.md LICENSE ext lib support`.split


### PR DESCRIPTION
Add `bug_tracker_uri`, `changelog_uri`, `documentation_uri`, `homepage_uri`, and `source_code_uri` to the gemspec metadata.

These [project metadata](https://guides.rubygems.org/specification-reference/#metadata) will facilitate easy access to project information. The URI will be available on the [Rubygems project page](https://rubygems.org/gems/mysql2), via the rubygems API, and the `gem` and `bundle` command-line tools with the next release.