### PR TITLE
Client session tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,6 +197,23 @@ statement = @client.prepare("SELECT * FROM users WHERE last_login >= ? AND locat
 result = statement.execute(1, "CA", :as => :array)
 ```
 
+Session Tracking information can be accessed with
+
+```ruby
+c = Mysql2::Client.new(
+  host: "127.0.0.1",
+  username: "root",
+  flags: "SESSION_TRACK",
+  init_command: "SET @@SESSION.session_track_schema=ON"
+)
+c.query("INSERT INTO test VALUES (1)")
+session_track_type = Mysql2::Client::SESSION_TRACK_SCHEMA
+session_track_data = c.session_track(session_track_type)
+```
+
+The types of session track types can be found at
+[https://dev.mysql.com/doc/refman/5.7/en/mysql-session-track-get-first.html](https://dev.mysql.com/doc/refman/5.7/en/mysql-session-track-get-first.html)
+
 ## Connection options
 
 You may set the following connection options in Mysql2::Client.new(...):

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1642,6 +1642,13 @@ void init_mysql2_client() {
 
 #ifdef CLIENT_SESSION_TRACK
   rb_const_set(cMysql2Client, rb_intern("SESSION_TRACK"), INT2NUM(CLIENT_SESSION_TRACK));
+  /* From mysql_com.h -- but stable from at least 5.7.4 through 8.0.20 */
+  rb_const_set(cMysql2Client, rb_intern("SESSION_TRACK_SYSTEM_VARIABLES"), INT2NUM(SESSION_TRACK_SYSTEM_VARIABLES));
+  rb_const_set(cMysql2Client, rb_intern("SESSION_TRACK_SCHEMA"), INT2NUM(SESSION_TRACK_SCHEMA));
+  rb_const_set(cMysql2Client, rb_intern("SESSION_TRACK_STATE_CHANGE"), INT2NUM(SESSION_TRACK_STATE_CHANGE));
+  rb_const_set(cMysql2Client, rb_intern("SESSION_TRACK_GTIDS"), INT2NUM(SESSION_TRACK_GTIDS));
+  rb_const_set(cMysql2Client, rb_intern("SESSION_TRACK_TRANSACTION_CHARACTERISTICS"), INT2NUM(SESSION_TRACK_TRANSACTION_CHARACTERISTICS));
+  rb_const_set(cMysql2Client, rb_intern("SESSION_TRACK_TRANSACTION_STATE"), INT2NUM(SESSION_TRACK_TRANSACTION_STATE));
 #endif
 
 #if defined(FULL_SSL_MODE_SUPPORT) // MySQL 5.7.11 and above

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1021,6 +1021,7 @@ static VALUE rb_mysql_client_last_id(VALUE self) {
   return ULL2NUM(mysql_insert_id(wrapper->client));
 }
 
+#ifdef CLIENT_SESSION_TRACK
 /* call-seq:
  *    client.session_track
  *
@@ -1046,6 +1047,7 @@ static VALUE rb_mysql_client_session_track(VALUE self, VALUE type) {
   }
   return rbAry;
 }
+#endif
 
 /* call-seq:
  *    client.affected_rows
@@ -1451,7 +1453,6 @@ void init_mysql2_client() {
   rb_define_method(cMysql2Client, "socket", rb_mysql_client_socket, 0);
   rb_define_method(cMysql2Client, "async_result", rb_mysql_client_async_result, 0);
   rb_define_method(cMysql2Client, "last_id", rb_mysql_client_last_id, 0);
-  rb_define_method(cMysql2Client, "session_track", rb_mysql_client_session_track, 1);
   rb_define_method(cMysql2Client, "affected_rows", rb_mysql_client_affected_rows, 0);
   rb_define_method(cMysql2Client, "prepare", rb_mysql_client_prepare_statement, 1);
   rb_define_method(cMysql2Client, "thread_id", rb_mysql_client_thread_id, 0);
@@ -1641,6 +1642,8 @@ void init_mysql2_client() {
 #endif
 
 #ifdef CLIENT_SESSION_TRACK
+  rb_define_method(cMysql2Client, "session_track", rb_mysql_client_session_track, 1);
+
   rb_const_set(cMysql2Client, rb_intern("SESSION_TRACK"), INT2NUM(CLIENT_SESSION_TRACK));
   /* From mysql_com.h -- but stable from at least 5.7.4 through 8.0.20 */
   rb_const_set(cMysql2Client, rb_intern("SESSION_TRACK_SYSTEM_VARIABLES"), INT2NUM(SESSION_TRACK_SYSTEM_VARIABLES));

--- a/lib/mysql2/version.rb
+++ b/lib/mysql2/version.rb
@@ -1,3 +1,3 @@
 module Mysql2
-  VERSION = "0.5.2".freeze
+  VERSION = "0.5.3".freeze
 end

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -1,6 +1,6 @@
 require 'spec_helper'
 
-RSpec.describe Mysql2::Client do
+RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
   context "using defaults file" do
     let(:cnf_file) { File.expand_path('../../my.cnf', __FILE__) }
 


### PR DESCRIPTION
This adds support for Oracle/Percona MySQL 5.7+ session tracking to the client.

Docs on the function: https://dev.mysql.com/doc/refman/5.7/en/mysql-session-track-get-first.html

At Shopify, we wanted to be able to tell which GTID was generated by a given `COMMIT` so that when we are reading from delayed replicas we can be sure that a given replica has the data that we want on it. This is pretty much the exact flow that's described by the [Oracle worklog entry describing the implementation of the feature](https://dev.mysql.com/worklog/task/?id=6128)

Example usage:

```ruby
require 'mysql2'
c = Mysql2::Client.new(:host => "127.0.0.1", :username => "root", :password => "test1", :flags => "SESSION_TRACK", :database => "test");
c.query("SET SESSION session_track_gtids=OWN_GTID")
c.query("INSERT INTO test VALUES (1)");
gtid = c.session_track(Mysql2::Client::SESSION_TRACK_GTIDS)[0]

c2 = Mysql2::Client.new(:host => "replica.host")
c2.query("SELECT WAIT_FOR_EXECUTED_GTID_SET('#{gtid}')")
# waits forever, by default, probably not what people want
c2.query("SELECT * FROM test")
```

I mirrored the implementation of `client.last_id` -- I noticed that wasn't documented in the `README.md` so I hadn't added this, but if you have any suggestions about how or where to document this feature I'd appreciate that.

I believe that all the `ifdef`ing is right to not compile this feature for MariaDB (which doesn't support it).