### PR TITLE
Update rake (and rake-compiler) to suppress the warning.

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -2,8 +2,12 @@ source 'https://rubygems.org'
 
 gemspec
 
-gem 'rake', '~> 10.4.2'
-gem 'rake-compiler', '~> 1.0'
+gem 'rake', if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.2")
+              '~> 13.0.1'
+            else
+              '< 13'
+            end
+gem 'rake-compiler', '~> 1.1.0'
 
 group :test do
   gem 'eventmachine' unless RUBY_PLATFORM =~ /mswin|mingw/


### PR DESCRIPTION
This fixes https://github.com/brianmario/mysql2/issues/1095 .

To suppress the warning:

```
/home/travis/.rvm/gems/ruby-head/gems/rake-10.4.2/lib/rake/application.rb:381: warning: deprecated Object#=~ is called on Proc; it always returns nil
```

in the process of `bundle exec rake compile`.

First I tried to update `Gemfile` like this.

```
if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new("2.2")
  gem 'rake', '~> 13.0.1'
else
  gem 'rake', '< 13'
end
```

But rubocop printed the error message. So, I modified the file as this PR.

```
Gemfile:8:3: C: Bundler/DuplicatedGem: Gem rake requirements already given on line 6 of the Gemfile.
  gem 'rake', '< 13'
  ^^^^^^^^^^^^^^^^^^
```

It was succeeded on my forked repository's Travis.
https://travis-ci.org/junaruga/mysql2/builds/631909854
