### PR TITLE
Fix crash if a Mysql2::Client object is allocated but never connected

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -323,9 +323,9 @@ static VALUE allocate(VALUE klass) {
   wrapper->server_version = 0;
   wrapper->reconnect_enabled = 0;
   wrapper->connect_timeout = 0;
-  wrapper->initialized = 0; /* means that that the wrapper is initialized */
+  wrapper->initialized = 0; /* will be set true after calling mysql_init */
+  wrapper->closed = 1; /* will be set false after calling mysql_real_connect */
   wrapper->refcount = 1;
-  wrapper->closed = 0;
   wrapper->client = (MYSQL*)xmalloc(sizeof(MYSQL));
 
   return obj;
@@ -467,6 +467,7 @@ static VALUE rb_mysql_connect(VALUE self, VALUE user, VALUE pass, VALUE host, VA
       rb_raise_mysql2_error(wrapper);
   }
 
+  wrapper->closed = 0;
   wrapper->server_version = mysql_get_server_version(wrapper->client);
   return self;
 }


### PR DESCRIPTION
Reproducible with any older version of the mysql2 gem:

        ruby -r mysql2 -I lib -e 'Mysql2::Client.allocate.close'

Before this fix, the line above would crash out with a memory error:

        malloc: *** error for object 0x...: pointer being freed was not allocated
        malloc: *** set a breakpoint in malloc_error_break to debug
        Abort trap: 6

Alternative to #1097 