### PR TITLE
Remove Enumerable include from Statement class

### DIFF
--- a/lib/mysql2/statement.rb
+++ b/lib/mysql2/statement.rb
@@ -1,7 +1,5 @@
 module Mysql2
   class Statement
-    include Enumerable
-
     def execute(*args, **kwargs)
       Thread.handle_interrupt(::Mysql2::Util::TIMEOUT_ERROR_CLASS => :never) do
         _execute(*args, **kwargs)


### PR DESCRIPTION
I'm honestly not sure why this was here in the first place. Git blame seems to suggest that maybe it was added when the class was first created in anticipation for something that never materialized or has since been deprecated.

As far as I can tell, `Enumerable` offers no advantages to the class since `Statement` doesn't implement `#each`.

Here's an example of what I'm referring to
```ruby
client = Mysql2::Client.new
statement = client.prepare('select 1')

statement.respond_to? :first
#=> true
statement.first
#=> NoMethodError: undefined method `each' for #<Mysql2::Statement:0x000055f59aa8b2c8>

statement.respond_to? :any?
#=> true
statement.any?
#=> NoMethodError: undefined method `each' for #<Mysql2::Statement:0x000055f59aa8b2c8>

statement.respond_to? :min
#=> true
statement.min
#=> NoMethodError: undefined method `each' for #<Mysql2::Statement:0x000055f59aa8b2c8>
```

Also all test pass with `Enumerable` gone, so it seems reasonable to remove it.