### PR TITLE
Don't call mysql_close if mysql_init wasn't called.

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -269,7 +269,7 @@ static VALUE invalidate_fd(int clientfd)
 static void *nogvl_close(void *ptr) {
   mysql_client_wrapper *wrapper = ptr;
 
-  if (!wrapper->closed) {
+  if (wrapper->initialized && !wrapper->closed) {
     mysql_close(wrapper->client);
     wrapper->closed = 1;
     wrapper->reconnect_enabled = 0;


### PR DESCRIPTION
If an exception is thrown during the process of initializing the client object, bad things happen. I noticed today that this sample script:
```ruby
#!/usr/bin/env ruby
require 'mysql2'

module OverrideInitializeExt
  def initialize_ext
    raise 'o noes'
  end
end
Mysql2::Client.prepend(OverrideInitializeExt)
Mysql2::Client.new
```
...will cause Ruby to dump core after it handles the exception:
```
dennistay:mysql2 dennistaylor$ /tmp/mysql2_bug_test.rb 
/tmp/mysql2_bug_test.rb:8:in `initialize_ext': o noes (RuntimeError)
	from /Users/dennistaylor/.rbenv/versions/2.4.3/lib/ruby/gems/2.4.0/gems/mysql2-0.5.2/lib/mysql2/client.rb:28:in `initialize'
	from /tmp/mysql2_bug_test.rb:12:in `new'
	from /tmp/mysql2_bug_test.rb:12:in `<main>'
ruby(43937,0x106d835c0) malloc: *** error for object 0x7fd51c8c2258: pointer being freed was not allocated
ruby(43937,0x106d835c0) malloc: *** set a breakpoint in malloc_error_break to debug
Abort trap: 6 (core dumped)
```
This is because `nogvl_close` will call `mysql_close` on a `mysql_client_wrapper` structure which never had `mysql_init` called on it, so libmysqlclient tries to free things that were never allocated. This patch fixes the issue for me and doesn't introduce any regressions in the test suite.

I strove for a while to produce a test case for this, but it proved very difficult. The core dump didn't manifest under rspec, only when run as a standalone script.