### PR TITLE
Avoid a hash object allocation per each `query`/`execute` call

### DIFF
--- a/lib/mysql2.rb
+++ b/lib/mysql2.rb
@@ -82,5 +82,6 @@ module Mysql2
     else
       ::Timeout::Error
     end
+    TIMEOUT_ERROR_NEVER = { TIMEOUT_ERROR_CLASS => :never }.freeze
   end
 end

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -127,7 +127,7 @@ module Mysql2
     end
 
     def query(sql, options = {})
-      Thread.handle_interrupt(::Mysql2::Util::TIMEOUT_ERROR_CLASS => :never) do
+      Thread.handle_interrupt(::Mysql2::Util::TIMEOUT_ERROR_NEVER) do
         _query(sql, @query_options.merge(options))
       end
     end

--- a/lib/mysql2/statement.rb
+++ b/lib/mysql2/statement.rb
@@ -1,7 +1,7 @@
 module Mysql2
   class Statement
     def execute(*args, **kwargs)
-      Thread.handle_interrupt(::Mysql2::Util::TIMEOUT_ERROR_CLASS => :never) do
+      Thread.handle_interrupt(::Mysql2::Util::TIMEOUT_ERROR_NEVER) do
         _execute(*args, **kwargs)
       end
     end


### PR DESCRIPTION
This is a same optimization approach with https://github.com/ruby/ruby/pull/2393.