### PR TITLE
Register C global variables to Ruby GC to avoid problems with GC.compact

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1453,6 +1453,7 @@ void init_mysql2_client() {
   mMysql2      = rb_define_module("Mysql2"); Teach RDoc about Mysql2 constant.
 #endif
   cMysql2Client = rb_define_class_under(mMysql2, "Client", rb_cObject);
+  rb_global_variable(&cMysql2Client);
 
   rb_define_alloc_func(cMysql2Client, allocate);
 

--- a/ext/mysql2/mysql2_ext.c
+++ b/ext/mysql2/mysql2_ext.c
@@ -4,9 +4,14 @@ VALUE mMysql2, cMysql2Error, cMysql2TimeoutError;
 
 /* Ruby Extension initializer */
 void Init_mysql2() {
-  mMysql2      = rb_define_module("Mysql2");
+  mMysql2 = rb_define_module("Mysql2");
+  rb_global_variable(&mMysql2);
+
   cMysql2Error = rb_const_get(mMysql2, rb_intern("Error"));
+  rb_global_variable(&cMysql2Error);
+
   cMysql2TimeoutError = rb_const_get(cMysql2Error, rb_intern("TimeoutError"));
+  rb_global_variable(&cMysql2TimeoutError);
 
   init_mysql2_client();
   init_mysql2_result();

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1162,9 +1162,13 @@ VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_
 
 void init_mysql2_result() {
   cDate = rb_const_get(rb_cObject, rb_intern("Date"));
+  rb_global_variable(&cDate);
   cDateTime = rb_const_get(rb_cObject, rb_intern("DateTime"));
+  rb_global_variable(&cDateTime);
 
   cMysql2Result = rb_define_class_under(mMysql2, "Result", rb_cObject);
+  rb_global_variable(&cMysql2Result);
+  
   rb_define_method(cMysql2Result, "each", rb_mysql_result_each, -1);
   rb_define_method(cMysql2Result, "fields", rb_mysql_result_fetch_fields, 0);
   rb_define_method(cMysql2Result, "field_types", rb_mysql_result_fetch_field_types, 0);

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -572,10 +572,17 @@ static VALUE rb_mysql_stmt_close(VALUE self) {
 
 void init_mysql2_statement() {
   cDate = rb_const_get(rb_cObject, rb_intern("Date"));
+  rb_global_variable(&cDate);
+
   cDateTime = rb_const_get(rb_cObject, rb_intern("DateTime"));
+  rb_global_variable(&cDateTime);
+
   cBigDecimal = rb_const_get(rb_cObject, rb_intern("BigDecimal"));
+  rb_global_variable(&cBigDecimal);
 
   cMysql2Statement = rb_define_class_under(mMysql2, "Statement", rb_cObject);
+  rb_global_variable(&cMysql2Statement);
+
   rb_define_method(cMysql2Statement, "param_count", rb_mysql_stmt_param_count, 0);
   rb_define_method(cMysql2Statement, "field_count", rb_mysql_stmt_field_count, 0);
   rb_define_method(cMysql2Statement, "_execute", rb_mysql_stmt_execute, -1);


### PR DESCRIPTION
Since Ruby 2.7, C global variables holding references to Ruby objects must be declared to the GC even if they are also held from the Ruby side, otherwise a call to GC.compact might move them to another location.

For instance here's an exception we've seen caused by this:

```
bundler/gems/mysql2-d3c815c68f22/lib/mysql2/client.rb:131:in `_query': NoMethodError: undefined method `new_with_args' for "2":String (ActiveRecord::StatementInvalid)
    from bundler/gems/mysql2-d3c815c68f22/lib/mysql2/client.rb:131:in `block in query'
    from bundler/gems/mysql2-d3c815c68f22/lib/mysql2/client.rb:130:in `handle_interrupt'
    from bundler/gems/mysql2-d3c815c68f22/lib/mysql2/client.rb:130:in `query'
```

In this instance `Mysql2::Error` was moved to another location, and `cMysql2Error` was now pointing to an instance of `"2"`.

We had a similar issue in https://github.com/Shopify/liquid-c/pull/55, however here I tried to reproduce it in the test suite by repeatedly calling `GC.compact`, but without any success. Maybe the mysql2 test suite is not producing enough GC objects to demonstrate the bug.

cc @csfrancis @XrXr @rafaelfranca