### PR TITLE
0.2.x update for ruby 2.5

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -297,7 +297,7 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, ID db_timezone, ID app_timezo
             break;
           }
           msec = msec_char_to_uint(msec_char, sizeof(msec_char));
-          val = rb_funcall(rb_cTime, db_timezone, 6, opt_time_year, opt_time_month, opt_time_month, UINT2NUM(hour), UINT2NUM(min), UINT2NUM(sec), UINT2NUM(msec));
+          val = rb_funcall(rb_cTime, db_timezone, 7, opt_time_year, opt_time_month, opt_time_month, UINT2NUM(hour), UINT2NUM(min), UINT2NUM(sec), UINT2NUM(msec));
           if (!NIL_P(app_timezone)) {
             if (app_timezone == intern_local) {
               val = rb_funcall(val, intern_localtime, 0);

--- a/lib/mysql2/error.rb
+++ b/lib/mysql2/error.rb
@@ -16,7 +16,7 @@ module Mysql2
     def initialize(msg, server_version=nil)
       self.server_version = server_version
 
-      super(clean_message(msg))
+      super(mysql2_clean_message(msg))
     end
 
     def sql_state=(state)
@@ -52,7 +52,9 @@ module Mysql2
     # Except for if we're on 1.8, where we'll do nothing ;)
     #
     # Returns a valid UTF-8 string in Ruby 1.9+, the original string on Ruby 1.8
-    def clean_message(message)
+    
+    # the name `mysql2_clean_message` is used to avoid conflict with `clean_message` method in activesupport 2.3
+    def mysql2_clean_message(message)
       return message if !message.respond_to?(:encoding)
 
       if @server_version && @server_version > 50500

--- a/lib/mysql2/version.rb
+++ b/lib/mysql2/version.rb
@@ -1,3 +1,3 @@
 module Mysql2
-  VERSION = "0.2.24"
+  VERSION = "0.2.25"
 end


### PR DESCRIPTION
Mysql2 0.2.24 does not compile in ruby 2.5 due to extra check this ruby performs on rb_funcall.
In particular, file result.c had a bug - wrong number (6) of arguments on line 300.
* This pull request fixes number of arguments to valid value of 7.
* Also, to publish these change as a gem, a gem version is updated to 0.2.25.

I ask to merge this changeset in master repository and also ask to build and publish gem version 0.2.25.