### PR TITLE
Clarify Rails 4.2.11 support in Readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -572,7 +572,7 @@ This gem is tested with the following MySQL and MariaDB versions:
 
 ### Ruby on Rails / Active Record
 
-* mysql2 0.5.x works with Rails / Active Record 5.0.7, 5.1.6, and higher.
+* mysql2 0.5.x works with Rails / Active Record 4.2.11, 5.0.7, 5.1.6, and higher.
 * mysql2 0.4.x works with Rails / Active Record 4.2.5 - 5.0 and higher.
 * mysql2 0.3.x works with Rails / Active Record 3.1, 3.2, 4.x, 5.0.
 * mysql2 0.2.x works with Rails / Active Record 2.3 - 3.0.


### PR DESCRIPTION
The README states that `rails 4.2` does not support version `0.5` of the gem, however, as indicated by [this comment](https://github.com/brianmario/mysql2/issues/950#issuecomment-442228062) and [this release](https://github.com/rails/rails/compare/v4.2.10...v4.2.11), Rails `4.2.11` does actually support `0.5`.

This caused a bit of confusion at our end during the upgrade of a legacy app, as all tests seemed to pass even though the docs indicated otherwise.

I hope this small change is useful for someone in a similar situation.  Thank you :smile: 