### PR TITLE
Improve Homebrew compatibility

### DIFF
--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -21,6 +21,11 @@ def add_ssl_defines(header)
   $CFLAGS << ' -DNO_SSL_MODE_SUPPORT' if has_no_support
 end
 
+# Homebrew openssl
+if RUBY_PLATFORM =~ /darwin/
+  $LDFLAGS << ' -L/usr/local/opt/openssl/lib'
+end
+
 # 2.1+
 have_func('rb_absint_size')
 have_func('rb_absint_singlebit_p')

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -47,7 +47,9 @@ dirs = ENV.fetch('PATH').split(File::PATH_SEPARATOR) + %w[
   /usr/local/mysql-*
   /usr/local/lib/mysql5*
   /usr/local/opt/mysql5*
+  /usr/local/opt/mysql@*
   /usr/local/opt/mysql-client
+  /usr/local/opt/mysql-client@*
 ].map { |dir| dir << '/bin' }
 
 # For those without HOMEBREW_ROOT in PATH

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -22,9 +22,7 @@ def add_ssl_defines(header)
 end
 
 # Homebrew openssl
-if RUBY_PLATFORM =~ /darwin/
-  $LDFLAGS << ' -L/usr/local/opt/openssl/lib'
-end
+$LDFLAGS << ' -L/usr/local/opt/openssl/lib' if RUBY_PLATFORM =~ /darwin/
 
 # 2.1+
 have_func('rb_absint_size')

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -42,6 +42,7 @@ dirs = ENV.fetch('PATH').split(File::PATH_SEPARATOR) + %w[
   /usr/local/mysql-*
   /usr/local/lib/mysql5*
   /usr/local/opt/mysql5*
+  /usr/local/opt/mysql-client
 ].map { |dir| dir << '/bin' }
 
 # For those without HOMEBREW_ROOT in PATH


### PR DESCRIPTION
Hi!

When I develop on my Mac, I usually install the Homebrew package `mysql-client` instead of `mysql`, since I don't really need the server (I usually run that in Docker). But unfortunately mysql2 doesn't compile out of the box.

I have worked around it by first running:
```
bundle config build.mysql2 --with-mysql-dir="/usr/local/opt/mysql-client"
```

But now I decided to look into contributing a fix.

Hopefully this will be accepted and included in the next version. Thanks!