### PR TITLE
Random SEGV in do_send_query()

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -797,6 +797,7 @@ static VALUE rb_mysql_query(VALUE self, VALUE sql, VALUE current) {
 
 #ifndef _WIN32
   rb_rescue2(do_send_query, (VALUE)&args, disconnect_and_raise, self, rb_eException, (VALUE)0);
+  (void)RB_GC_GUARD(sql);
 
   if (rb_hash_aref(current, sym_async) == Qtrue) {
     return Qnil;
@@ -810,6 +811,7 @@ static VALUE rb_mysql_query(VALUE self, VALUE sql, VALUE current) {
   }
 #else
   do_send_query((VALUE)&args);
+  (void)RB_GC_GUARD(sql);
 
   /* this will just block until the result is ready */
   return rb_ensure(rb_mysql_client_async_result, self, disconnect_and_mark_inactive, self);


### PR DESCRIPTION
We found an random SEGV in mysql2 0.5.3, such as:
```
-- C level backtrace information -------------------------------------------
/usr/local/lib/libruby.so.2.6(rb_vm_bugreport+0x4f1) [0x7f53f023c251] vm_dump.c:715
/usr/local/lib/libruby.so.2.6(rb_bug_context+0xe7) [0x7f53f008ca27] error.c:609
/usr/local/lib/libruby.so.2.6(sigsegv+0x42) [0x7f53f01a5672] signal.c:998
/lib/x86_64-linux-gnu/libpthread.so.0(__restore_rt+0x0) [0x7f53efbac0e0]
/lib/x86_64-linux-gnu/libc.so.6(0x7f53eed5a0ba) [0x7f53eed5a0ba]
/usr/lib/x86_64-linux-gnu/libmariadbclient.so.18(0x7f53e3c595a9) [0x7f53e3c595a9]
/usr/lib/x86_64-linux-gnu/libmariadbclient.so.18(0x7f53e3c59b3f) [0x7f53e3c59b3f]
/usr/lib/x86_64-linux-gnu/libmariadbclient.so.18(0x7f53e3c512e4) [0x7f53e3c512e4]
/usr/lib/x86_64-linux-gnu/libmariadbclient.so.18(mysql_send_query+0x3e) [0x7f53e3c4e96e]
/home/circleci/project/vendor/bundle/ruby/2.6.0/gems/mysql2-0.5.3/lib/mysql2/mysql2.so(nogvl_send_query+0x14) [0x7f53e42267a4] client.c:511
/usr/local/lib/libruby.so.2.6(rb_thread_call_without_gvl+0x7d) [0x7f53f01e9d2d] thread.c:1442
/home/circleci/project/vendor/bundle/ruby/2.6.0/gems/mysql2-0.5.3/lib/mysql2/mysql2.so(do_send_query+0x1d) [0x7f53e422709d] client.c:519
/usr/local/lib/libruby.so.2.6(rb_rescue2+0xe6) [0x7f53f0096ac6] eval.c:935
/home/circleci/project/vendor/bundle/ruby/2.6.0/gems/mysql2-0.5.3/lib/mysql2/mysql2.so(rb_mysql_query+0xf7) [0x7f53e4228747] client.c:787
```
(this log is token from CircleCI)

In `rb_mysql_query()`, the raw pointer of the sql string is extracted,
and it is passed to `do_send_query()` via `args`.
`do_send_query()` internally releases the GVL, then ruby might do GC
in the function.
Then, the sql string may be GC'ed, and causes SEGV.
Therefore, should guard the sql string until `do_send_query()` ends.