### PR TITLE
Add GitHub Actions.

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,56 @@
+name: Test
+on: [push, pull_request]
+jobs:
+  build:
+    name: >-
+      ${{ matrix.os }} ruby ${{ matrix.ruby }} ${{ matrix.db }}
+    # Run all the tests on the new environment as much as possible.
+    # https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners
+    runs-on: ${{ matrix.os }}
+    continue-on-error: ${{ matrix.allow-failure }}
+    strategy:
+      matrix:
+        os:
+          # Use ubuntu-18.04 instead of ubuntu-20.04 temporarily, due to a failing test on mysql 8.0.
+          # https://github.com/brianmario/mysql2/issues/1165
+          # - ubuntu-20.04 # focal
+          - ubuntu-18.04 # bionic
+          # - ubuntu-16.04 # xenial
+        ruby:
+          - '3.0'
+          - 2.7
+          - 2.6
+          - 2.5
+          - 2.4
+          - 2.3
+          - 2.2
+          - 2.1
+        db: ['']
+        allow-failure: [false]
+        include:
+          # Allow failure due to Mysql2::Error: Unknown system variable 'session_track_system_variables'.
+          - {os: ubuntu-16.04, ruby: 2.4, db: mariadb10.0, allow-failure: true}
+          # Comment out due to .travis_setup.sh stucking.
+          # - {os: ubuntu-18.04, ruby: 2.4, db: mariadb10.1, allow-failure: false}
+          # Allow failure due to the issue #1165.
+          - {os: ubuntu-20.04, ruby: 2.4, db: mariadb10.3, allow-failure: true}
+          - {os: ubuntu-18.04, ruby: 2.4, db: mysql57, allow-failure: false}
+          # `service mysql restart` fails.
+          - {os: ubuntu-20.04, ruby: 2.4, db: mysql80, allow-failure: true}
+          - {os: ubuntu-18.04, ruby: 'head', db: '', allow-failure: true}
+      # On the fail-fast: true, it cancels all in-progress jobs
+      # if any matrix job fails unlike Travis fast_finish.
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+      # https://github.com/ruby/setup-ruby
+      - uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: ${{ matrix.ruby }}
+      - run: ruby -v
+      - run: bundle install --without benchmarks development
+      - if: matrix.db != ''
+        run: echo 'DB=${{ matrix.db }}' >> $GITHUB_ENV
+      - run: sudo echo "127.0.0.1 mysql2gem.example.com" | sudo tee -a /etc/hosts
+      - run: bash .travis_setup.sh
+      - run: bundle exec rake

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,18 +18,9 @@ addons:
     - mysql-server-5.6
     - mysql-client-core-5.6
     - mysql-client-5.6
-rvm:
-  - 2.7
-  - 2.6
-  - 2.5
-  - 2.4
-  - 2.3
-  - 2.2
-  - 2.1
-  - 2.0.0
-  - ruby-head
 matrix:
   include:
+    - rvm: 2.0.0
     - rvm: 2.4
       env: DB=mariadb10.0
       addons:
@@ -59,18 +50,6 @@ matrix:
       addons:
         hosts:
           - mysql2gem.example.com
-    - rvm: 2.4
-      env: DB=mysql57
-      dist: xenial
-      addons:
-        hosts:
-          - mysql2gem.example.com
-    - rvm: 2.4
-      env: DB=mysql80
-      dist: xenial
-      addons:
-        hosts:
-          - mysql2gem.example.com
     - os: osx
       rvm: 2.4
       env: DB=mysql56
@@ -84,7 +63,6 @@ matrix:
       script: docker run --add-host=mysql2gem.example.com:127.0.0.1 -t mysql2
   fast_finish: true
   allow_failures:
-    - rvm: ruby-head
     - os: osx
       rvm: 2.4
       env: DB=mysql56

--- a/.travis_mysql57.sh
+++ b/.travis_mysql57.sh
@@ -6,9 +6,8 @@ apt-get purge -qq '^mysql*' '^libmysql*'
 rm -fr /etc/mysql
 rm -fr /var/lib/mysql
 apt-key add support/5072E1F5.asc
+# Verify the repository as add-apt-repository does not.
+wget -q --spider http://repo.mysql.com/apt/ubuntu/dists/$(lsb_release -cs)/mysql-5.7
 add-apt-repository 'http://repo.mysql.com/apt/ubuntu mysql-5.7'
 apt-get update -qq
 apt-get install -qq mysql-server libmysqlclient-dev
-
-# https://www.percona.com/blog/2016/03/16/change-user-password-in-mysql-5-7-with-plugin-auth_socket/
-mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY ''"

--- a/.travis_mysql80.sh
+++ b/.travis_mysql80.sh
@@ -6,9 +6,8 @@ apt-get purge -qq '^mysql*' '^libmysql*'
 rm -fr /etc/mysql
 rm -fr /var/lib/mysql
 apt-key add support/5072E1F5.asc
+# Verify the repository as add-apt-repository does not.
+wget -q --spider http://repo.mysql.com/apt/ubuntu/dists/$(lsb_release -cs)/mysql-8.0
 add-apt-repository 'http://repo.mysql.com/apt/ubuntu mysql-8.0'
 apt-get update -qq
 apt-get install -qq mysql-server libmysqlclient-dev
-
-# https://www.percona.com/blog/2016/03/16/change-user-password-in-mysql-5-7-with-plugin-auth_socket/
-mysql -u root -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY ''"

--- a/.travis_setup.sh
+++ b/.travis_setup.sh
@@ -2,6 +2,30 @@
 
 set -eux
 
+CHANGED_PWD=false
+# Change the password recreating the root user on mariadb < 10.2
+# where ALTER USER is not available.
+# https://stackoverflow.com/questions/56052177/
+CHANGED_PWD_BY_RECREATE=false
+
+# Install the default used DB if DB is not set.
+if [[ -n ${GITHUB_ACTION-} && -z ${DB-} ]]; then
+  if command -v lsb_release > /dev/null; then
+    case "$(lsb_release -cs)" in
+    xenial | bionic)
+      sudo apt-get install -qq mysql-server-5.7 mysql-client-core-5.7 mysql-client-5.7
+      CHANGED_PWD=true
+      ;;
+    focal)
+      sudo apt-get install -qq mysql-server-8.0 mysql-client-core-8.0 mysql-client-8.0
+      CHANGED_PWD=true
+      ;;
+    *)
+      ;;
+    esac
+  fi
+fi
+
 # Install MySQL 5.5 if DB=mysql55
 if [[ -n ${DB-} && x$DB =~ ^xmysql55 ]]; then
   sudo bash .travis_mysql55.sh
@@ -10,27 +34,45 @@ fi
 # Install MySQL 5.7 if DB=mysql57
 if [[ -n ${DB-} && x$DB =~ ^xmysql57 ]]; then
   sudo bash .travis_mysql57.sh
+  CHANGED_PWD=true
 fi
 
 # Install MySQL 8.0 if DB=mysql80
 if [[ -n ${DB-} && x$DB =~ ^xmysql80 ]]; then
   sudo bash .travis_mysql80.sh
+  CHANGED_PWD=true
 fi
 
 # Install MariaDB client headers after Travis CI fix for MariaDB 10.2 broke earlier 10.x
 if [[ -n ${DB-} && x$DB =~ ^xmariadb10.0 ]]; then
-  sudo apt-get install -y -o Dpkg::Options::='--force-confnew' libmariadbclient-dev
+  if [[ -n ${GITHUB_ACTION-} ]]; then
+    sudo apt-get install -y -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-10.0 libmariadb2
+    CHANGED_PWD_BY_RECREATE=true
+  else
+    sudo apt-get install -y -o Dpkg::Options::='--force-confnew' libmariadbclient-dev
+  fi
 fi
 
 # Install MariaDB client headers after Travis CI fix for MariaDB 10.2 broke earlier 10.x
 if [[ -n ${DB-} && x$DB =~ ^xmariadb10.1 ]]; then
-  sudo apt-get install -y -o Dpkg::Options::='--force-confnew' libmariadbclient-dev
+  if [[ -n ${GITHUB_ACTION-} ]]; then
+    sudo apt-get install -y -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-10.1 libmariadb-dev
+    CHANGED_PWD_BY_RECREATE=true
+  else
+    sudo apt-get install -y -o Dpkg::Options::='--force-confnew' libmariadbclient-dev
+  fi
 fi
 
 # Install MariaDB 10.2 if DB=mariadb10.2
 # NOTE this is a workaround until Travis CI merges a fix to its mariadb addon.
 if [[ -n ${DB-} && x$DB =~ ^xmariadb10.2 ]]; then
   sudo apt-get install -y -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-10.2 libmariadbclient18
+fi
+
+# Install MariaDB 10.3 if DB=mariadb10.3
+if [[ -n ${GITHUB_ACTION-} && -n ${DB-} && x$DB =~ ^xmariadb10.3 ]]; then
+  sudo apt-get install -y -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-10.3 libmariadb-dev
+  CHANGED_PWD=true
 fi
 
 # Install MySQL if OS=darwin
@@ -52,6 +94,36 @@ if [[ x$OSTYPE =~ ^xdarwin ]]; then
   $(brew --prefix "$DB")/bin/mysql -u root -e 'CREATE DATABASE IF NOT EXISTS test'
 else
   mysqld --version
+
+  if [[ -n ${GITHUB_ACTION-} && -f /etc/mysql/debian.cnf ]]; then
+    MYSQL_OPTS='--defaults-extra-file=/etc/mysql/debian.cnf'
+    # Install from packages in OS official packages.
+    if sudo grep -q debian-sys-maint /etc/mysql/debian.cnf; then
+      # bionic, focal
+      DB_SYS_USER=debian-sys-maint
+    else
+      # xenial
+      DB_SYS_USER=root
+    fi
+  else
+    # Install from official mysql packages.
+    MYSQL_OPTS=''
+    DB_SYS_USER=root
+  fi
+
+  if [ "${CHANGED_PWD}" = true ]; then
+    # https://www.percona.com/blog/2016/03/16/change-user-password-in-mysql-5-7-with-plugin-auth_socket/
+    sudo mysql ${MYSQL_OPTS} -u "${DB_SYS_USER}" \
+      -e "ALTER USER 'root'@'localhost' IDENTIFIED WITH mysql_native_password BY ''"
+  elif [ "${CHANGED_PWD_BY_RECREATE}" = true ]; then
+    sudo mysql ${MYSQL_OPTS} -u "${DB_SYS_USER}" <<SQL
+DROP USER 'root'@'localhost';
+CREATE USER 'root'@'localhost' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' WITH GRANT OPTION;
+FLUSH PRIVILEGES;
+SQL
+  fi
+
   # IF NOT EXISTS is mariadb-10+ only - https://mariadb.com/kb/en/mariadb/comment-syntax/
   mysql -u root -e 'CREATE DATABASE /*M!50701 IF NOT EXISTS */ test'
 fi

--- a/Gemfile
+++ b/Gemfile
@@ -33,8 +33,9 @@ group :development do
   gem 'rake-compiler-dock', '~> 0.7.0'
 end
 
-platforms :rbx do
-  gem 'rubysl-bigdecimal'
-  gem 'rubysl-drb'
-  gem 'rubysl-rake'
-end
+# On MRI Ruby >= 3.0, rubysl-rake causes the conflict on GitHub Actions.
+# platforms :rbx do
+#   gem 'rubysl-bigdecimal'
+#   gem 'rubysl-drb'
+#   gem 'rubysl-rake'
+# end


### PR DESCRIPTION
This is a PR to start GitHub Actions. It's a minimal start to have the compatible or covered cases on GitHub Actions from Travis eventually. This is my first experience to work on GitHub Actions.

I find GitHub Actions specific limitations.

* I am using https://github.com/ruby/setup-ruby common library to install Ruby and Bundler, and `bundle install` that is commonly used in Ruby applications. However while the current setup needs to run the `bundle install --without benchmarks development` on Travis, I could not find the way to inject it to the common library on GitHub Actions. So, I modified `Gemfile` to update the groups to be optional as `bundle install` worked. You can see the detail [here](https://bundler.io/v2.2/guides/groups.html). Without the modification, the `bundle install` fails on the environment.
* According to [the GitHub Actions available ubuntu environment](https://docs.github.com/en/free-pro-team@latest/actions/reference/workflow-syntax-for-github-actions), there are only 3 available environments, `ubuntu-20.04` (focal), `ubuntu-18.04` (bionic), `ubuntu-16.04` (xenial), while the trusty and xenial are used in Travis. See [the Ubuntu version history](https://en.wikipedia.org/wiki/Ubuntu_version_history).

I saw the following error on the cases on GitHub. Do you have any idea to fix this? This blocks the PR.

```
$ bash .travis_setup.sh
...
 + mysql -u root -e 'CREATE DATABASE /*M!50701 IF NOT EXISTS */ test'
ERROR 1045 (28000): Access denied for user 'root'@'localhost' (using password: NO)
Error: Process completed with exit code 1.
```

Thanks.
