### PR TITLE
Run GC.verify_compaction_references on CI

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -4,6 +4,12 @@ require 'timeout'
 require 'yaml'
 DatabaseCredentials = YAML.load_file('spec/configuration.yml')
 
+if GC.respond_to?(:verify_compaction_references)
+  # This method was added in Ruby 3.0.0. Calling it this way asks the GC to
+  # move objects around, helping to find object movement bugs.
+  GC.verify_compaction_references(double_heap: true, toward: :empty)
+end
+
 RSpec.configure do |config|
   config.disable_monkey_patching!
 


### PR DESCRIPTION
This is a followup to https://github.com/brianmario/mysql2/pull/1115

In 3.0 a new API was introduced that ask the GC to move all objects. This is useful to test for bugs like the ones that were fixed in #1115. 

cc @sodabrew 