### PR TITLE
Set charset name utf8mb4 by default

### DIFF
--- a/README.md
+++ b/README.md
@@ -233,7 +233,7 @@ Mysql2::Client.new(
   :database,
   :socket = '/path/to/mysql.sock',
   :flags = REMEMBER_OPTIONS | LONG_PASSWORD | LONG_FLAG | TRANSACTIONS | PROTOCOL_41 | SECURE_CONNECTION | MULTI_STATEMENTS,
-  :encoding = 'utf8',
+  :encoding = 'utf8mb4',
   :read_timeout = seconds,
   :write_timeout = seconds,
   :connect_timeout = seconds,
@@ -309,7 +309,7 @@ Use the value `mysql2` as the adapter name. For example:
 ``` yaml
 development:
   adapter: mysql2
-  encoding: utf8
+  encoding: utf8mb4
   database: my_db_name
   username: root
   password: my_password

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -43,8 +43,8 @@ module Mysql2
         end
       end
 
-      # force the encoding to utf8
-      self.charset_name = opts[:encoding] || 'utf8'
+      # force the encoding to utf8mb4
+      self.charset_name = opts[:encoding] || 'utf8mb4'
 
       ssl_options = opts.values_at(:sslkey, :sslcert, :sslca, :sslcapath, :sslcipher)
       ssl_set(*ssl_options) if ssl_options.any? || opts.key?(:sslverify)


### PR DESCRIPTION
mysql2 gem dropped testing for MySQL 5.1 which was released in Dec 2008
and already EOL in Dec 2013 at efa47a935447bb96f178c11ce32834f877c36b77.

If we no longer support MySQL 5.1, utf8 (utf8mb3) is not appropriate
default encoding for MySQL 5.5 or higher, utf8mb4 should be set for
that.

FYI, Rails 6.0 no longer support MySQL 5.1 and set utf8mb4 by default.

https://github.com/rails/rails/pull/33608
https://github.com/rails/rails/pull/33853