### PR TITLE
GitHub Actions: Add macOS cases.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,4 +1,4 @@
-name: Ubuntu
+name: Build
 on: [push, pull_request]
 jobs:
   build:
@@ -38,6 +38,12 @@ jobs:
           # `service mysql restart` fails.
           - {os: ubuntu-20.04, ruby: 2.4, db: mysql80, allow-failure: true}
           - {os: ubuntu-18.04, ruby: 'head', db: '', allow-failure: true}
+          # db: the DB's brew package name in macOS case.
+          # Allow failure due to the following test failures.
+          # https://github.com/brianmario/mysql2/issues/965
+          - {os: macos-latest, ruby: 2.4, db: 'mariadb@10.4', allow-failure: true}
+          # Allow failure due to Mysql2::Error: Unknown system variable 'session_track_system_variables'.
+          - {os: macos-latest, ruby: 2.4, db: 'mysql@5.6', allow-failure: true}
       # On the fail-fast: true, it cancels all in-progress jobs
       # if any matrix job fails unlike Travis fast_finish.
       fail-fast: false

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,12 +38,16 @@ jobs:
           # `service mysql restart` fails.
           - {os: ubuntu-20.04, ruby: 2.4, db: mysql80, allow-failure: true}
           - {os: ubuntu-18.04, ruby: 'head', db: '', allow-failure: true}
-          # db: the DB's brew package name in macOS case.
+          # db: A DB's brew package name in macOS case.
+          #     Set a name "db: 'name@X.Y'" when using an old version.
+          # MariaDB lastet version
           # Allow failure due to the following test failures.
           # https://github.com/brianmario/mysql2/issues/965
-          - {os: macos-latest, ruby: 2.4, db: 'mariadb@10.4', allow-failure: true}
-          # Allow failure due to Mysql2::Error: Unknown system variable 'session_track_system_variables'.
-          - {os: macos-latest, ruby: 2.4, db: 'mysql@5.6', allow-failure: true}
+          # https://github.com/brianmario/mysql2/issues/1152
+          - {os: macos-latest, ruby: 2.4, db: mariadb, allow-failure: true}
+          # MySQL latest version
+          # Allow failure due to the issue #1165.
+          - {os: macos-latest, ruby: 2.4, db: mysql, allow-failure: true}
       # On the fail-fast: true, it cancels all in-progress jobs
       # if any matrix job fails unlike Travis fast_finish.
       fail-fast: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -49,14 +49,5 @@ matrix:
       addons:
         hosts:
           - mysql2gem.example.com
-    - os: osx
-      rvm: 2.4
-      env: DB=mysql56
-      addons:
-        hosts:
-          - mysql2gem.example.com
   fast_finish: true
   allow_failures:
-    - os: osx
-      rvm: 2.4
-      env: DB=mysql56

--- a/.travis_setup.sh
+++ b/.travis_setup.sh
@@ -9,7 +9,7 @@ CHANGED_PWD=false
 CHANGED_PWD_BY_RECREATE=false
 
 # Install the default used DB if DB is not set.
-if [[ -n ${GITHUB_ACTION-} && -z ${DB-} ]]; then
+if [[ -n ${GITHUB_ACTIONS-} && -z ${DB-} ]]; then
   if command -v lsb_release > /dev/null; then
     case "$(lsb_release -cs)" in
     xenial | bionic)
@@ -45,7 +45,7 @@ fi
 
 # Install MariaDB client headers after Travis CI fix for MariaDB 10.2 broke earlier 10.x
 if [[ -n ${DB-} && x$DB =~ ^xmariadb10.0 ]]; then
-  if [[ -n ${GITHUB_ACTION-} ]]; then
+  if [[ -n ${GITHUB_ACTIONS-} ]]; then
     sudo apt-get install -y -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-10.0 libmariadb2
     CHANGED_PWD_BY_RECREATE=true
   else
@@ -55,7 +55,7 @@ fi
 
 # Install MariaDB client headers after Travis CI fix for MariaDB 10.2 broke earlier 10.x
 if [[ -n ${DB-} && x$DB =~ ^xmariadb10.1 ]]; then
-  if [[ -n ${GITHUB_ACTION-} ]]; then
+  if [[ -n ${GITHUB_ACTIONS-} ]]; then
     sudo apt-get install -y -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-10.1 libmariadb-dev
     CHANGED_PWD_BY_RECREATE=true
   else
@@ -70,7 +70,7 @@ if [[ -n ${DB-} && x$DB =~ ^xmariadb10.2 ]]; then
 fi
 
 # Install MariaDB 10.3 if DB=mariadb10.3
-if [[ -n ${GITHUB_ACTION-} && -n ${DB-} && x$DB =~ ^xmariadb10.3 ]]; then
+if [[ -n ${GITHUB_ACTIONS-} && -n ${DB-} && x$DB =~ ^xmariadb10.3 ]]; then
   sudo apt-get install -y -o Dpkg::Options::='--force-confnew' mariadb-server mariadb-server-10.3 libmariadb-dev
   CHANGED_PWD=true
 fi
@@ -95,7 +95,7 @@ if [[ x$OSTYPE =~ ^xdarwin ]]; then
 else
   mysqld --version
 
-  if [[ -n ${GITHUB_ACTION-} && -f /etc/mysql/debian.cnf ]]; then
+  if [[ -n ${GITHUB_ACTIONS-} && -f /etc/mysql/debian.cnf ]]; then
     MYSQL_OPTS='--defaults-extra-file=/etc/mysql/debian.cnf'
     # Install from packages in OS official packages.
     if sudo grep -q debian-sys-maint /etc/mysql/debian.cnf; then

--- a/.travis_setup.sh
+++ b/.travis_setup.sh
@@ -85,7 +85,8 @@ if [[ x$OSTYPE =~ ^xdarwin ]]; then
     brew search "${KEYWORD}"
   done
 
-  brew install "$DB" mariadb-connector-c
+  brew info "$DB"
+  brew install "$DB"
   DB_PREFIX="$(brew --prefix "${DB}")"
   export PATH="${DB_PREFIX}/bin:${PATH}"
   export LDFLAGS="-L${DB_PREFIX}/lib"

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -629,7 +629,7 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
         end
 
         # the query ran uninterrupted
-        expect(mark.fetch(:QUERY_END) - mark.fetch(:QUERY_START)).to be_within(0.1).of(query_time)
+        expect(mark.fetch(:QUERY_END) - mark.fetch(:QUERY_START)).to be_within(0.2).of(query_time)
         # signals fired while the query was running
         expect(mark.fetch(:USR1)).to be_between(mark.fetch(:QUERY_START), mark.fetch(:QUERY_END))
       end
@@ -708,7 +708,7 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
 
         # This check demonstrates that the threads are sleeping concurrently:
         # In the serial case, the difference would be a multiple of sleep time
-        expect(stop - start).to be_within(0.1).of(sleep_time)
+        expect(stop - start).to be_within(0.2).of(sleep_time)
 
         expect(values).to match_array(threads.map(&:object_id))
       end


### PR DESCRIPTION
* Migrate macOS cases in Travis to GitHub Actions.
* Increase the expected time in the test to avoid the following random failures
  on macOS.

  ```
  1) Mysql2::Client#query threaded queries should be supported
     Failure/Error: expect(stop - start).to be_within(0.1).of(sleep_time)
       expected 0.632204999999999 to be within 0.1 of 0.5
     # ./spec/mysql2/client_spec.rb:711:in `block (3 levels) in <top (required)>'
  ```

  ```
  3) Mysql2::Client#query should run signal handlers while waiting for a response
     Failure/Error: expect(mark.fetch(:QUERY_END) - mark.fetch(:QUERY_START)).to be_within(0.1).of(query_time)
       expected 1.1042130000000157 to be within 0.1 of 1.0
     # ./spec/mysql2/client_spec.rb:632:in `block (3 levels) in <top (required)>'
  ```

## Notes

* I renamed `.github/workflows/ubuntu.yml` to `build.yml` again, after adding the macOS cases to the file. I considered the name `ubuntu_macos.yml`. But thinking about we want to keep a same name for a long time, and considering the name (`name: Build`) is used as a build badge name when we will add it later. The name `Build` makes sense to me.

* In Travis macOS case, the brew package `mariadb-connector-c` was installed. So I always installed the `mariadb-connector-c` in GitHub Actions macOS case too. However when we do not actually install it on the `db: 'mysql@5.6'` case of the macOS, `rake compile` can be compiled, and there are some test failures. In `db: 'mariadb@10.4'` case, `rake compile` shows the following library missing error when `mariadb-connector-c` is not installed.
 
  ```
  checking for -lmysqlclient... no
  mysql client is missing. You may need to 'brew install mysql' or 'port install mysql', and try again.
  ```

  We might be able to install `mariadb-connector-c` conditionally on macOS case like this.

  ```
  brew install "${DB}"
  if [[ -n ${DB-} && x$DB =~ ^xmariadb ]]; then
    brew install mariadb-connector-c
  fi
  ```

