### PR TITLE
Make the benchmarks group optional.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,7 +58,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
       - run: ruby -v
-      - run: bundle install --without benchmarks development
+      - run: bundle install --without development
       - if: matrix.db != ''
         run: echo 'DB=${{ matrix.db }}' >> $GITHUB_ENV
       - run: sudo echo "127.0.0.1 mysql2gem.example.com" | sudo tee -a /etc/hosts

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,7 @@
 sudo: required
 dist: trusty
 language: ruby
-bundler_args: --without benchmarks development
+bundler_args: --without development
 # Pin Rubygems to a working version. Sometimes it breaks upstream. Update now and then.
 before_install:
   - gem --version

--- a/Gemfile
+++ b/Gemfile
@@ -19,12 +19,13 @@ group :test do
   gem 'rubocop', '~> 0.50.0'
 end
 
-group :benchmarks do
+group :benchmarks, optional: true do
   gem 'activerecord', '>= 3.0'
   gem 'benchmark-ips'
   gem 'do_mysql'
   gem 'faker'
-  gem 'mysql'
+  # The installation of the mysql latest version 2.9.1 fails on Ruby >= 2.4.
+  gem 'mysql' if Gem::Version.new(RUBY_VERSION) < Gem::Version.new('2.4')
   gem 'sequel'
 end
 

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,7 +7,7 @@ install:
   - ruby --version
   - gem --version
   - bundler --version
-  - bundle install --without benchmarks --path vendor/bundle
+  - bundle install --path vendor/bundle
   - IF DEFINED MINGW_PACKAGE_PREFIX (ridk exec pacman -S --noconfirm --needed %MINGW_PACKAGE_PREFIX%-libmariadbclient)
 build_script:
   - bundle exec rake compile

--- a/ci/container.sh
+++ b/ci/container.sh
@@ -3,7 +3,7 @@
 set -eux
 
 ruby -v
-bundle install --path vendor/bundle --without benchmarks development
+bundle install --path vendor/bundle --without development
 
 # Start mysqld service.
 bash ci/setup_container.sh


### PR DESCRIPTION
I have a suggestion that is to make the benchmark group optional. Right now the installation of the benchmark group by `bundle install` fails on Ruby  >= 2.4. I think this error might prevent a contributor from contributing. I think fixing this issue leads to the contributor's smooth onboarding. 

Here is [the current GitHub Actions log](https://github.com/junaruga/mysql2/runs/1977334233?check_suite_focus=true) when trying to install the benchmarks group. You see it fails on Ruby >= 2.4.

```
$ bundle install --without development
...
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.
...
 current directory:
/opt/hostedtoolcache/Ruby/2.4.10/x64/lib/ruby/gems/2.4.0/gems/mysql-2.9.1/ext/mysql_api
make "DESTDIR="
compiling mysql.c
mysql.c: In function ‘stmt_bind_result’:
mysql.c:1320:74: error: ‘rb_cFixnum’ undeclared (first use in this function);
did you mean ‘rb_isalnum’?
else if (argv[i] == rb_cNumeric || argv[i] == rb_cInteger || argv[i] ==
rb_cFixnum)
^~~~~~~~~~
rb_isalnum
...
```

After making the benchmark optional, we can install the benchmarks group like this when we need it.

```
$ bundle install --with benchmarks
```

I am also thinking if we can make the development group optional too. The pros is we can test the `bundle install` without command line options on the supported platforms in CI. The cons is we have to run `bundle install --with development` when we need the gems in the development group.

What do you think?


