### PR TITLE
Refactor CI yaml files

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -7,7 +7,7 @@ jobs:
     # Run all the tests on the new environment as much as possible.
     # https://docs.github.com/en/free-pro-team@latest/actions/reference/specifications-for-github-hosted-runners
     runs-on: ${{ matrix.os }}
-    continue-on-error: ${{ matrix.allow-failure }}
+    continue-on-error: ${{ matrix.allow-failure || false }}
     strategy:
       matrix:
         os:
@@ -26,15 +26,14 @@ jobs:
           - 2.2
           - 2.1
         db: ['']
-        allow-failure: [false]
         include:
           # Allow failure due to Mysql2::Error: Unknown system variable 'session_track_system_variables'.
           - {os: ubuntu-16.04, ruby: 2.4, db: mariadb10.0, allow-failure: true}
           # Comment out due to ci/setup.sh stucking.
-          # - {os: ubuntu-18.04, ruby: 2.4, db: mariadb10.1, allow-failure: false}
+          # - {os: ubuntu-18.04, ruby: 2.4, db: mariadb10.1}
           # `service mysql restart` fails.
           - {os: ubuntu-20.04, ruby: 2.4, db: mariadb10.3, allow-failure: true}
-          - {os: ubuntu-18.04, ruby: 2.4, db: mysql57, allow-failure: false}
+          - {os: ubuntu-18.04, ruby: 2.4, db: mysql57}
           # Allow failure due to the issue #1165.
           - {os: ubuntu-20.04, ruby: 2.4, db: mysql80, allow-failure: true}
           - {os: ubuntu-18.04, ruby: 'head', db: '', allow-failure: true}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,10 +32,10 @@ jobs:
           - {os: ubuntu-16.04, ruby: 2.4, db: mariadb10.0, allow-failure: true}
           # Comment out due to ci/setup.sh stucking.
           # - {os: ubuntu-18.04, ruby: 2.4, db: mariadb10.1, allow-failure: false}
-          # Allow failure due to the issue #1165.
+          # `service mysql restart` fails.
           - {os: ubuntu-20.04, ruby: 2.4, db: mariadb10.3, allow-failure: true}
           - {os: ubuntu-18.04, ruby: 2.4, db: mysql57, allow-failure: false}
-          # `service mysql restart` fails.
+          # Allow failure due to the issue #1165.
           - {os: ubuntu-20.04, ruby: 2.4, db: mysql80, allow-failure: true}
           - {os: ubuntu-18.04, ruby: 'head', db: '', allow-failure: true}
           # db: A DB's brew package name in macOS case.

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -5,13 +5,14 @@ on: [push, pull_request]
 jobs:
   build:
     name: >-
-      ${{ matrix.distro }} ${{ matrix.image }}
+      ${{ matrix.distro }} ${{ matrix.image }} ${{ matrix.name_extra || '' }}
     runs-on: ubuntu-20.04 # focal
     continue-on-error: ${{ matrix.allow-failure || false }}
     strategy:
       matrix:
         include:
-          - {distro: centos, image: 'centos:7'}
+          # CentOS 7 system Ruby is the fixed version 2.0.0.
+          - {distro: centos, image: 'centos:7', name_extra: 'ruby 2.0.0'}
           # Fedora latest stable version
           # Allow failure due to the following test failures.
           # https://github.com/brianmario/mysql2/issues/965

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -7,11 +7,11 @@ jobs:
     name: >-
       ${{ matrix.distro }} ${{ matrix.image }}
     runs-on: ubuntu-20.04 # focal
-    continue-on-error: ${{ matrix.allow-failure }}
+    continue-on-error: ${{ matrix.allow-failure || false }}
     strategy:
       matrix:
         include:
-          - {distro: centos, image: 'centos:7', allow-failure: false}
+          - {distro: centos, image: 'centos:7'}
           # Fedora latest stable version
           # Allow failure due to the following test failures.
           # https://github.com/brianmario/mysql2/issues/965

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,3 @@
-sudo: required
 dist: trusty
 language: ruby
 bundler_args: --without development
@@ -9,17 +8,8 @@ before_install:
   - gem update bundler
   - gem --version
   - bash ci/setup.sh
-addons:
-  hosts:
-    - mysql2gem.example.com
-  apt:
-    packages:
-    - mysql-server-5.6
-    - mysql-client-core-5.6
-    - mysql-client-5.6
 matrix:
   include:
-    - rvm: 2.0.0
     - rvm: 2.4
       env: DB=mariadb10.0
       addons:


### PR DESCRIPTION
There are 3 commits on this PR to refactor the CI yaml files.

* Fix wrong comments.
* GitHub Actions: Set the default value to allow-failure.
* Migrate Ruby 2.0.0 case in Travis to GitHub Actions.

## Fix wrong comments.

The comments for the 2 cases were actually opposite.

## GitHub Actions: Set the default value to allow-failure.

There is a way to omit the `allow-failure` when the case passes setting the default value. The tip is inspired by [the rspec-core's GitHub Actions yaml file](https://github.com/rspec/rspec-core/blob/ea8554afd1a2b63677c6593059fa8f2476181deb/.github/workflows/ci.yml#L57).

## Migrate Ruby 2.0.0 case in Travis to GitHub Actions.

We have actually Ruby 2.0.0 case on CentOS 7 case. I know the system Ruby in CentOS 7 is 2.0.0 until the CentOS 7 will be end of life. The tip using `name_extra` also comes from [the rspec-core's GitHub Actions yaml file](https://github.com/rspec/rspec-core/blob/ea8554afd1a2b63677c6593059fa8f2476181deb/.github/workflows/ci.yml#L20).

I thought we could remove the Ruby 2.0.0 case in Travis CI. In other words, we may still want to keep the Ruby 2.0.0 in Travis for some reasons.

What do you think?

