### PR TITLE
Rename the before/after hooks's symbol on RSpec 2 to the one on RSpec 3.

### DIFF
--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -407,7 +407,7 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
   end
 
   context ":local_infile" do
-    before(:all) do
+    before(:context) do
       new_client(local_infile: true) do |client|
         local = client.query "SHOW VARIABLES LIKE 'local_infile'"
         local_enabled = local.any? { |x| x['Value'] == 'ON' }
@@ -423,7 +423,7 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       end
     end
 
-    after(:all) do
+    after(:context) do
       new_client do |client|
         client.query "DROP TABLE IF EXISTS infileTest"
       end
@@ -730,7 +730,7 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     end
 
     context "Multiple results sets" do
-      before(:each) do
+      before(:example) do
         @multi_client = new_client(flags: Mysql2::Client::MULTI_STATEMENTS)
       end
 
@@ -974,12 +974,12 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
   end
 
   context 'write operations api' do
-    before(:each) do
+    before(:example) do
       @client.query "USE test"
       @client.query "CREATE TABLE IF NOT EXISTS lastIdTest (`id` BIGINT NOT NULL AUTO_INCREMENT, blah INT(11), PRIMARY KEY (`id`))"
     end
 
-    after(:each) do
+    after(:example) do
       @client.query "DROP TABLE lastIdTest"
     end
 
@@ -1027,7 +1027,7 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
   end
 
   context "session_track" do
-    before(:each) do
+    before(:example) do
       unless Mysql2::Client.const_defined?(:SESSION_TRACK)
         skip('Server versions must be MySQL 5.7 later.')
       end
@@ -1070,7 +1070,7 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
   end
 
   context "select_db" do
-    before(:each) do
+    before(:example) do
       2.times do |i|
         @client.query("CREATE DATABASE test_selectdb_#{i}")
         @client.query("USE test_selectdb_#{i}")
@@ -1078,7 +1078,7 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       end
     end
 
-    after(:each) do
+    after(:example) do
       2.times do |i|
         @client.query("DROP DATABASE test_selectdb_#{i}")
       end

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -1,7 +1,7 @@
 require 'spec_helper'
 
 RSpec.describe Mysql2::Result do
-  before(:each) do
+  before(:example) do
     @result = @client.query "SELECT 1"
   end
 

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -1,7 +1,7 @@
 require './spec/spec_helper.rb'
 
 RSpec.describe Mysql2::Statement do
-  before :each do
+  before(:example) do
     @client = new_client(encoding: "utf8")
   end
 
@@ -211,7 +211,7 @@ RSpec.describe Mysql2::Statement do
   end
 
   context "utf8_db" do
-    before(:each) do
+    before(:example) do
       @client.query("DROP DATABASE IF EXISTS test_mysql2_stmt_utf8")
       @client.query("CREATE DATABASE test_mysql2_stmt_utf8")
       @client.query("USE test_mysql2_stmt_utf8")
@@ -219,7 +219,7 @@ RSpec.describe Mysql2::Statement do
       @client.query("INSERT INTO テーブル (整数, 文字列) VALUES (1, 'イチ'), (2, '弐'), (3, 'さん')")
     end
 
-    after(:each) do
+    after(:example) do
       @client.query("DROP DATABASE test_mysql2_stmt_utf8")
     end
 
@@ -627,12 +627,12 @@ RSpec.describe Mysql2::Statement do
   end
 
   context 'last_id' do
-    before(:each) do
+    before(:example) do
       @client.query 'USE test'
       @client.query 'CREATE TABLE IF NOT EXISTS lastIdTest (`id` BIGINT NOT NULL AUTO_INCREMENT, blah INT(11), PRIMARY KEY (`id`))'
     end
 
-    after(:each) do
+    after(:example) do
       @client.query 'DROP TABLE lastIdTest'
     end
 
@@ -655,12 +655,12 @@ RSpec.describe Mysql2::Statement do
   end
 
   context 'affected_rows' do
-    before :each do
+    before(:example) do
       @client.query 'USE test'
       @client.query 'CREATE TABLE IF NOT EXISTS lastIdTest (`id` BIGINT NOT NULL AUTO_INCREMENT, blah INT(11), PRIMARY KEY (`id`))'
     end
 
-    after :each do
+    after(:example) do
       @client.query 'DROP TABLE lastIdTest'
     end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -74,7 +74,7 @@ Make sure that the testing database '#{database}' exists. If it does not exist, 
     end
   end
 
-  config.before(:all) do
+  config.before(:context) do
     new_client do |client|
       client.query %[
         CREATE TABLE IF NOT EXISTS mysql2_test (
@@ -136,11 +136,11 @@ Make sure that the testing database '#{database}' exists. If it does not exist, 
     end
   end
 
-  config.before(:each) do
+  config.before(:example) do
     @client = new_client
   end
 
-  config.after(:each) do
+  config.after(:example) do
     @clients.each(&:close)
   end
 end


### PR DESCRIPTION
Rename the old symbol names.

Rename :all to :context .
Rename :each to :example .

As a note, there is no used around hook.

Reference:
https://relishapp.com/rspec/rspec-core/v/2-99/docs/hooks/before-and-after-hooks
https://relishapp.com/rspec/rspec-core/v/3-10/docs/hooks/before-and-after-hooks
