### PR TITLE
Make Result#fields return interned strings in Ruby 3+

### DIFF
--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -31,6 +31,8 @@ have_func('rb_absint_singlebit_p')
 # Missing in RBX (https://github.com/rubinius/rubinius/issues/3771)
 have_func('rb_wait_for_single_fd')
 
+have_func("rb_enc_interned_str", "ruby.h")
+
 # borrowed from mysqlplus
 # http://github.com/oldmoe/mysqlplus/blob/master/ext/extconf.rb
 dirs = ENV.fetch('PATH').split(File::PATH_SEPARATOR) + %w[

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -118,6 +118,13 @@ RSpec.describe Mysql2::Result do
       result = @client.query "SELECT 'a', 'b', 'c'"
       expect(result.fields).to eql(%w[a b c])
     end
+
+    it "should return an array of frozen strings" do
+      result = @client.query "SELECT 'a', 'b', 'c'"
+      result.fields.each do |f|
+        expect(f).to be_frozen
+      end
+    end
   end
 
   context "#field_types" do


### PR DESCRIPTION
### Context

These strings are very likely to be used for hash keys. And when using a mutable string as a hash key, ruby will duplicate it and freeze the copy:

```ruby
>> k = "foo" + "bar"
=> "foobar"
>> k.object_id
=> 260
>> h = {k => 1}
=> {"foobar"=>1}
>> h.keys.first.object_id
=> 280
```

This leads to performance patches like this one: https://github.com/rails/rails/commit/a46dcb7454b56c979cded85f2f4f875dcd2cfdf0

Additionally, on recent rubies, when using a frozen string as a key, Ruby will intern the string to save on memory: https://github.com/msgpack/msgpack-ruby/commit/e8dedef58886578110887abba166632c08ee60c6

And finally, since Ruby 3.0, `rb_enc_interned_str` allow to directly retrieve an existing interned string without allocating any object. 

### This patch

Based on the three statements above, I believe that it would be preferable to directly intern the field string if possible, and if not to simply freeze them.

Of course this could cause some minor compatibility issues, but they quite unlikely and trivial to fix.