### PR TITLE
GitHub Actions: Comment out mariadb server 10.3 case on Ubuntu.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,7 +32,8 @@ jobs:
           # Comment out due to ci/setup.sh stucking.
           # - {os: ubuntu-18.04, ruby: 2.4, db: mariadb10.1}
           # `service mysql restart` fails.
-          - {os: ubuntu-20.04, ruby: 2.4, db: mariadb10.3, allow-failure: true}
+          # https://github.com/brianmario/mysql2/issues/1184
+          # - {os: ubuntu-20.04, ruby: 2.4, db: mariadb10.3}
           - {os: ubuntu-18.04, ruby: 2.4, db: mysql57}
           # Allow failure due to the issue #1165.
           - {os: ubuntu-20.04, ruby: 2.4, db: mysql80, allow-failure: true}


### PR DESCRIPTION
Shall we comment out the case for now?
Even the mariadb 10.3 server does not start on the environment.

I debugged it today related to #1184 . But it still does not work. 
