### PR TITLE
CI: Set the verbose option in the Makefile to print compiling commands.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,6 +63,8 @@ jobs:
         run: echo "127.0.0.1 mysql2gem.example.com" | tee -a C:/Windows/System32/drivers/etc/hosts
       - run: echo 'DB=${{ matrix.db }}' >> $GITHUB_ENV
       - run: bash ci/setup.sh
+      # Set the verbose option in the Makefile to print compiling command lines.
+      - run: echo "MAKEFLAGS=V=1" >> $GITHUB_ENV
       - if: matrix.ssl
         run: echo "rake_spec_opts=--with-openssl-dir=$(brew --prefix ${{ matrix.ssl }})" >> $GITHUB_ENV
       - run: bundle exec rake spec -- $rake_spec_opts


### PR DESCRIPTION
This PR is to see the compiling command lines including the used compiler, compiler flags and macros in the CI logs.

For example on this ticket https://github.com/brianmario/mysql2/issues/1182#issuecomment-817171322 , I think we want to know which CI case  has the defined `HAVE_CONST_MYSQL_OPT_SSL_ENFORCE` to check if  the logic `warning: Your mysql client library does not support ssl_mode as expected.` is tested.

Set the environment variable `MAKE="make V=1"` to print command lines to compile on CI.
For the `MAKE` environment, See https://github.com/rake-compiler/rake-compiler/blob/v1.1.1/lib/rake/extensiontask.rb#L477

After following my PR is merged, we can set this logic in `tasks/compile.rake`.
https://github.com/rake-compiler/rake-compiler/pull/192
