### PR TITLE
Travis: Remove the command to pin Rubygems.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,8 @@
 dist: trusty
 language: ruby
 bundler_args: --without development
-# Pin Rubygems to a working version. Sometimes it breaks upstream. Update now and then.
 before_install:
   - gem --version
-  - gem update --system --quiet || gem update --system 2.7.10 --quiet
   - gem update bundler
   - gem --version
   - bash ci/setup.sh


### PR DESCRIPTION
On the Travis log the command costs around 160 seconds.
If we see an issue, we can enable the command again.

I think especially old Ruby such as 2.0.0 affected the issue coming from not pined rubygems. And now we do not have the older Rubies in Travis.

Here is [the Travis log](https://travis-ci.org/github/junaruga/mysql2/builds/766760662) on my forked repo. 
It's much faster now!
