### PR TITLE
Support ruby GC compaction

### DIFF
--- a/ext/mysql2/client.h
+++ b/ext/mysql2/client.h
@@ -17,9 +17,17 @@ typedef struct {
 
 void rb_mysql_set_server_query_flags(MYSQL *client, VALUE result);
 
+extern const rb_data_type_t rb_mysql_client_type;
+
+#ifdef NEW_TYPEDDATA_WRAPPER
+#define GET_CLIENT(self) \
+  mysql_client_wrapper *wrapper; \
+  TypedData_Get_Struct(self, mysql_client_wrapper, &rb_mysql_client_type, wrapper);
+#else
 #define GET_CLIENT(self) \
   mysql_client_wrapper *wrapper; \
   Data_Get_Struct(self, mysql_client_wrapper, wrapper);
+#endif
 
 void init_mysql2_client(void);
 void decr_mysql2_client(mysql_client_wrapper *wrapper);

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -36,6 +36,9 @@ end
 have_func('rb_absint_size')
 have_func('rb_absint_singlebit_p')
 
+# 2.7+
+have_func('rb_gc_mark_movable')
+
 # Missing in RBX (https://github.com/rubinius/rubinius/issues/3771)
 have_func('rb_wait_for_single_fd')
 

--- a/ext/mysql2/mysql2_ext.h
+++ b/ext/mysql2/mysql2_ext.h
@@ -36,6 +36,19 @@ void Init_mysql2(void);
 typedef bool my_bool;
 #endif
 
+// ruby 2.7+
+#ifdef HAVE_RB_GC_MARK_MOVABLE
+#define rb_mysql2_gc_location(ptr) ptr = rb_gc_location(ptr)
+#else
+#define rb_gc_mark_movable(ptr) rb_gc_mark(ptr)
+#define rb_mysql2_gc_location(ptr)
+#endif
+
+// ruby 2.2+
+#ifdef TypedData_Make_Struct
+#define NEW_TYPEDDATA_WRAPPER 1
+#endif
+
 #include <client.h>
 #include <statement.h>
 #include <result.h>


### PR DESCRIPTION
ruby 2.7+ introduced GC compaction via `GC.compact`. This PR helps this gem to be compaction friendly.