### PR TITLE
Fix to build with MySQL 5.1

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -922,10 +922,12 @@ static VALUE _mysql_client_options(VALUE self, int opt, VALUE value) {
       retval  = charval;
       break;
 
+#ifdef HAVE_MYSQL_DEFAULT_AUTH
     case MYSQL_DEFAULT_AUTH:
       charval = (const char *)StringValueCStr(value);
       retval  = charval;
       break;
+#endif
 
 #ifdef HAVE_CONST_MYSQL_ENABLE_CLEARTEXT_PLUGIN
     case MYSQL_ENABLE_CLEARTEXT_PLUGIN:
@@ -1391,7 +1393,11 @@ static VALUE set_init_command(VALUE self, VALUE value) {
 }
 
 static VALUE set_default_auth(VALUE self, VALUE value) {
+#ifdef HAVE_MYSQL_DEFAULT_AUTH
   return _mysql_client_options(self, MYSQL_DEFAULT_AUTH, value);
+#else
+  rb_raise(cMysql2Error, "pluggable authentication is not available, you may need a newer MySQL client library");
+#endif
 }
 
 static VALUE set_enable_cleartext_plugin(VALUE self, VALUE value) {

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -116,6 +116,7 @@ have_struct_member('MYSQL', 'net.vio', mysql_h)
 have_struct_member('MYSQL', 'net.pvio', mysql_h)
 
 # These constants are actually enums, so they cannot be detected by #ifdef in C code.
+have_const('MYSQL_DEFAULT_AUTH', mysql_h)
 have_const('MYSQL_ENABLE_CLEARTEXT_PLUGIN', mysql_h)
 have_const('SERVER_QUERY_NO_GOOD_INDEX_USED', mysql_h)
 have_const('SERVER_QUERY_NO_INDEX_USED', mysql_h)


### PR DESCRIPTION
mysql2 0.5.3 can't build with MySQL 5.1.

```
$ rake compile -- --with-mysql-dir=$(pwd)/mysql-5.1.73-linux-x86_64-glibc23
cd tmp/x86_64-linux/mysql2/2.6.7
/usr/local/bin/ruby -I. ../../../../ext/mysql2/extconf.rb -- --with-mysql-dir=/mysql2/mysql-5.1.73-linux-x86_64-glibc23
checking for rb_absint_size()... yes
checking for rb_absint_singlebit_p()... yes
checking for rb_wait_for_single_fd()... yes
checking for rb_enc_interned_str() in ruby.h... no
-----
Using --with-mysql-dir=/mysql2/mysql-5.1.73-linux-x86_64-glibc23
-----
checking for -lmysqlclient... yes
checking for mysql.h... yes
checking for errmsg.h... yes
checking for SSL_MODE_DISABLED in mysql.h... no
checking for MYSQL_OPT_SSL_ENFORCE in mysql.h... no
checking for MYSQL.net.vio in mysql.h... yes
checking for MYSQL.net.pvio in mysql.h... no
checking for MYSQL_ENABLE_CLEARTEXT_PLUGIN in mysql.h... no
checking for SERVER_QUERY_NO_GOOD_INDEX_USED in mysql.h... yes
checking for SERVER_QUERY_NO_INDEX_USED in mysql.h... yes
checking for SERVER_QUERY_WAS_SLOW in mysql.h... no
checking for MYSQL_OPTION_MULTI_STATEMENTS_ON in mysql.h... yes
checking for MYSQL_OPTION_MULTI_STATEMENTS_OFF in mysql.h... yes
checking for my_bool in mysql.h... yes
-----
Setting libpath to /mysql2/mysql-5.1.73-linux-x86_64-glibc23/lib
-----
creating Makefile
cd -
cd tmp/x86_64-linux/mysql2/2.6.7
/usr/bin/make
compiling ../../../../ext/mysql2/client.c
../../../../ext/mysql2/client.c: In function ‘_mysql_client_options’:
../../../../ext/mysql2/client.c:925:10: error: ‘MYSQL_DEFAULT_AUTH’ undeclared (first use in this function); did you mean ‘MYSQL_SECURE_AUTH’?
     case MYSQL_DEFAULT_AUTH:
          ^~~~~~~~~~~~~~~~~~
          MYSQL_SECURE_AUTH
../../../../ext/mysql2/client.c:925:10: note: each undeclared identifier is reported only once for each function it appears in
../../../../ext/mysql2/client.c: In function ‘set_default_auth’:
../../../../ext/mysql2/client.c:1394:38: error: ‘MYSQL_DEFAULT_AUTH’ undeclared (first use in this function); did you mean ‘MYSQL_SECURE_AUTH’?
   return _mysql_client_options(self, MYSQL_DEFAULT_AUTH, value);
                                      ^~~~~~~~~~~~~~~~~~
                                      MYSQL_SECURE_AUTH
../../../../ext/mysql2/client.c:1395:1: warning: control reaches end of non-void function [-Wreturn-type]
 }
 ^
../../../../ext/mysql2/client.c: At top level:
cc1: warning: unrecognized command line option ‘-Wno-used-but-marked-unused’
cc1: warning: unrecognized command line option ‘-Wno-static-in-inline’
cc1: warning: unrecognized command line option ‘-Wno-reserved-id-macro’
cc1: warning: unrecognized command line option ‘-Wno-missing-variable-declarations’
cc1: warning: unrecognized command line option ‘-Wno-documentation-unknown-command’
cc1: warning: unrecognized command line option ‘-Wno-disabled-macro-expansion’
cc1: warning: unrecognized command line option ‘-Wno-covered-switch-default’
cc1: warning: unrecognized command line option ‘-Wno-conditional-uninitialized’
cc1: warning: unrecognized command line option ‘-Wno-self-assign’
cc1: warning: unrecognized command line option ‘-Wno-parentheses-equality’
cc1: warning: unrecognized command line option ‘-Wno-constant-logical-operand’
make: *** [Makefile:245: client.o] Error 1
rake aborted!
```