### PR TITLE
Dynamically set Homebrew-installed OpenSSL flag

### DIFF
--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -22,7 +22,12 @@ def add_ssl_defines(header)
 end
 
 # Homebrew openssl
-$LDFLAGS << ' -L/usr/local/opt/openssl/lib' if RUBY_PLATFORM =~ /darwin/
+if RUBY_PLATFORM =~ /darwin/ && system("command -v brew")
+  openssl_location = `brew --prefix openssl`.strip
+  if openssl_location
+    $LDFLAGS << " -L#{openssl_location}/lib" 
+  end
+end
 
 # 2.1+
 have_func('rb_absint_size')


### PR DESCRIPTION
This is a follow-up to #1135 which added the OpenSSL flag assuming that
if the `RUBY_PLATFORM` is `darwin` (macOS):
- Homebrew is installed
- OpenSSL is installed via Homebrew

This PR:
- no longer assumes Homebrew is installed if we're on macOS
- no longer assumes OpenSSL is installed via Homebrew
- asks Homebrew for the openssl location (which will also work with the
newer openssl@1.1 recipe)

Should prevent issues like these when running bundle install on the
rails codebase:

<details>
<summary>Bundle Install error due to: ld: warning: directory not found for option '-L/usr/local/opt/openssl/lib'</summary>
<pre>
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/olivierlacan/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/bundler/gems/mysql2-7f4e844fccf6/ext/mysql2
/Users/olivierlacan/.rbenv/versions/3.0.1/bin/ruby -I /Users/olivierlacan/.rbenv/versions/3.0.1/lib/ruby/site_ruby/3.0.0 -r ./siteconf20210816-60984-ogpmsf.rb extconf.rb
checking for rb_absint_size()... yes
checking for rb_absint_singlebit_p()... yes
checking for rb_wait_for_single_fd()... yes
checking for rb_enc_interned_str() in ruby.h... yes
-----
Using mysql_config at /opt/homebrew/bin/mysql_config
-----
checking for mysql.h... yes
checking for errmsg.h... yes
checking for SSL_MODE_DISABLED in mysql.h... yes
checking for SSL_MODE_PREFERRED in mysql.h... yes
checking for SSL_MODE_REQUIRED in mysql.h... yes
checking for SSL_MODE_VERIFY_CA in mysql.h... yes
checking for SSL_MODE_VERIFY_IDENTITY in mysql.h... yes
checking for MYSQL.net.vio in mysql.h... yes
checking for MYSQL.net.pvio in mysql.h... no
checking for MYSQL_ENABLE_CLEARTEXT_PLUGIN in mysql.h... yes
checking for SERVER_QUERY_NO_GOOD_INDEX_USED in mysql.h... yes
checking for SERVER_QUERY_NO_INDEX_USED in mysql.h... yes
checking for SERVER_QUERY_WAS_SLOW in mysql.h... yes
checking for MYSQL_OPTION_MULTI_STATEMENTS_ON in mysql.h... yes
checking for MYSQL_OPTION_MULTI_STATEMENTS_OFF in mysql.h... yes
checking for my_bool in mysql.h... no
-----
Don't know how to set rpath on your system, if MySQL libraries are not in path mysql2 may not load
-----
-----
Setting libpath to /opt/homebrew/Cellar/mysql/8.0.26/lib
-----
creating Makefile

current directory: /Users/olivierlacan/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/bundler/gems/mysql2-7f4e844fccf6/ext/mysql2
make DESTDIR\= clean

current directory: /Users/olivierlacan/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/bundler/gems/mysql2-7f4e844fccf6/ext/mysql2
make DESTDIR\=
compiling client.c
compiling infile.c
compiling mysql2_ext.c
compiling result.c
result.c:259:55: warning: format specifies type 'long' but the argument has type 'int' [-Wformat]
        rb_field_type = rb_sprintf("decimal(%ld,%d)", precision, field->decimals);
                                            ~~~       ^~~~~~~~~
                                            %d
result.c:258:35: warning: implicit conversion loses integer precision: 'unsigned long' to 'int' [-Wshorten-64-to-32]
        precision = field->length - (field->decimals > 0 ? 2 : 1);
                  ~ ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
2 warnings generated.
compiling statement.c
linking shared-object mysql2/mysql2.bundle
ld: warning: directory not found for option '-L/usr/local/opt/openssl/lib'
ld: library not found for -lzstd
clang-12: error: linker command failed with exit code 1 (use -v to see invocation)
make: *** [mysql2.bundle] Error 1

make failed, exit code 2

Gem files will remain installed in /Users/olivierlacan/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/bundler/gems/mysql2-7f4e844fccf6 for inspection.
Results logged to /Users/olivierlacan/.rbenv/versions/3.0.1/lib/ruby/gems/3.0.0/bundler/gems/extensions/arm64-darwin-20/3.0.0/mysql2-7f4e844fccf6/gem_make.out

An error occurred while installing mysql2 (0.5.3), and Bundler cannot continue.
</pre>
</details>