### PR TITLE
Setup default CA path if not provided

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -17,7 +17,7 @@ Layout/IndentHeredoc:
 
 # Offense count: 2
 Metrics/AbcSize:
-  Max: 90
+  Max: 91
 
 # Offense count: 31
 # Configuration parameters: CountComments, ExcludedMethods.
@@ -32,11 +32,11 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments.
 Metrics/ClassLength:
-  Max: 125
+  Max: 135
 
 # Offense count: 3
 Metrics/CyclomaticComplexity:
-  Max: 30
+  Max: 32
 
 # Offense count: 313
 # Configuration parameters: AllowHeredoc, AllowURI, URISchemes, IgnoreCopDirectives, IgnoredPatterns.
@@ -51,7 +51,7 @@ Metrics/MethodLength:
 
 # Offense count: 2
 Metrics/PerceivedComplexity:
-  Max: 27
+  Max: 29
 
 # Offense count: 3
 # Configuration parameters: Blacklist.


### PR DESCRIPTION
This adds setup of a default CA path if there's no path provided by the user. This enables easier configuration of system level CA validation if the MySQL server has a certificate signed by a system root.

On more and more cloud based MySQL platforms system signed CA certificates are used and this hides the issue of selecting the appropriate path from the user.

The real longer term answer here is that this is a default that changes in libmysqlclient itself. The current situation here is mixed. When using MariaDB (including the changes in #1205), the default system roots are already loaded and used if no CA is provided.

On MySQL itself on the other hand, a CA path is required today. I have also opened a PR to improve that, see
https://github.com/mysql/mysql-server/pull/358 & https://bugs.mysql.com/bug.php?id=104649.