### PR TITLE
update README for MacOS installation with linker failure

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,12 +89,28 @@ the library file `libmysqlclient.so` but is missing the header file `mysql.h`
 
 ### Mac OS X
 
+``` sh
+  brew install openssl
+  gem install mysql2 -- --with-opt-dir="$(brew --prefix openssl)"
+```
+
+You may hit this issue `ld: library not found for -lssl`, because [MacOS is pointing to
+LibreSSL instead of OpenSSL](https://stackoverflow.com/questions/62195898/openssl-still-pointing-to-libressl-2-8-3).
+
 You may use MacPorts, Homebrew, or a native MySQL installer package. The most
 common paths will be automatically searched. If you want to select a specific
 MySQL directory, use the `--with-mysql-dir` or `--with-mysql-config` options above.
 
 If you have not done so already, you will need to install the XCode select tools by running
 `xcode-select --install`.
+
+If you are using `bundle install` to manage dependencies in project, you might need to set
+`bundle config`.
+``` sh
+  brew install openssl
+  bundle config --local build.mysql2 --with-opt-dir="$(brew --prefix openssl)"
+  bundle install
+```
 
 ### Windows
 


### PR DESCRIPTION
Reference to https://github.com/brianmario/mysql2/issues/1005#issuecomment-433219580 .

This PR was created after spending time on figuring out the issue, but later found that there are similar pending PR as well. Please help to close them too.
- If https://github.com/brianmario/mysql2/pull/1204 is merged, this PR and https://github.com/brianmario/mysql2/pull/1051 could be avoided.
- Relevant issues that could potentially be resolved: https://github.com/brianmario/mysql2/issues/1005, and the bunches of issues here: https://github.com/brianmario/mysql2/issues/795

References for context:
https://stackoverflow.com/questions/62195898/openssl-still-pointing-to-libressl-2-8-3 .