### PR TITLE
improve ConnectionError mapping

### DIFF
--- a/lib/mysql2/error.rb
+++ b/lib/mysql2/error.rb
@@ -24,6 +24,7 @@ module Mysql2
       1159 => ConnectionError, # ER_NET_READ_INTERRUPTED
       1160 => ConnectionError, # ER_NET_ERROR_ON_WRITE
       1161 => ConnectionError, # ER_NET_WRITE_INTERRUPTED
+      1927 => ConnectionError, # ER_CONNECTION_KILLED
 
       2001 => ConnectionError, # CR_SOCKET_CREATE_ERROR
       2002 => ConnectionError, # CR_CONNECTION_ERROR


### PR DESCRIPTION
During a mariadb outage, I had these application errors :
```
ActiveRecord::StatementInvalid: Mysql2::Error: Connection was killed: SELECT ... FROM ... WHERE ...
```

This patch aims at improving error mapping like this :
```
Mysql2::Error::ConnectionError: Connection was killed
```
