### PR TITLE
Update Mysql2::Result spec for Ruby 3.1

### DIFF
--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -6,12 +6,17 @@ RSpec.describe Mysql2::Result do
   end
 
   it "should raise a TypeError exception when it doesn't wrap a result set" do
-    r = Mysql2::Result.new
-    expect { r.count }.to raise_error(TypeError)
-    expect { r.fields }.to raise_error(TypeError)
-    expect { r.field_types }.to raise_error(TypeError)
-    expect { r.size }.to raise_error(TypeError)
-    expect { r.each }.to raise_error(TypeError)
+    if RUBY_VERSION >= "3.1"
+      expect { Mysql2::Result.new }.to raise_error(TypeError)
+      expect { Mysql2::Result.allocate }.to raise_error(TypeError)
+    else
+      r = Mysql2::Result.new
+      expect { r.count }.to raise_error(TypeError)
+      expect { r.fields }.to raise_error(TypeError)
+      expect { r.field_types }.to raise_error(TypeError)
+      expect { r.size }.to raise_error(TypeError)
+      expect { r.each }.to raise_error(TypeError)
+    end
   end
 
   it "should have included Enumerable" do


### PR DESCRIPTION
Ref: https://github.com/brianmario/mysql2/issues/1179

Ruby 3.1 immediately raise a TypeError if you try to instantiate a class that doesn't have an allocator, which is what we want anyways.

This should fix ruby-head CI.

I'm actually tempted to undefine `Result.new` and `Result.allocate`, but chose to stick to the minimum change.

cc @simi @listerino