### PR TITLE
Update DATETIME casting tests for mysql 8.0

### DIFF
--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -410,8 +410,13 @@ RSpec.describe Mysql2::Result do
     end
 
     it "should raise an error given an invalid DATETIME" do
-      expect { @client.query("SELECT CAST('1972-00-27 00:00:00' AS DATETIME) as bad_datetime").each }.to \
-        raise_error(Mysql2::Error, "Invalid date in field 'bad_datetime': 1972-00-27 00:00:00")
+      if @client.info[:version] < "8.0"
+        expect { @client.query("SELECT CAST('1972-00-27 00:00:00' AS DATETIME) as bad_datetime").each }.to \
+          raise_error(Mysql2::Error, "Invalid date in field 'bad_datetime': 1972-00-27 00:00:00")
+      else
+        expect(@client.query("SELECT CAST('1972-00-27 00:00:00' AS DATETIME) as bad_datetime").to_a.first).to \
+          eql("bad_datetime" => nil)
+      end
     end
 
     context "string encoding for ENUM values" do

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -482,8 +482,13 @@ RSpec.describe Mysql2::Statement do
     end
 
     it "should raise an error given an invalid DATETIME" do
-      expect { @client.query("SELECT CAST('1972-00-27 00:00:00' AS DATETIME) as bad_datetime").each }.to \
-        raise_error(Mysql2::Error, "Invalid date in field 'bad_datetime': 1972-00-27 00:00:00")
+      if @client.info[:version] < "8.0"
+        expect { @client.query("SELECT CAST('1972-00-27 00:00:00' AS DATETIME) as bad_datetime").each }.to \
+          raise_error(Mysql2::Error, "Invalid date in field 'bad_datetime': 1972-00-27 00:00:00")
+      else
+        expect(@client.query("SELECT CAST('1972-00-27 00:00:00' AS DATETIME) as bad_datetime").to_a.first).to \
+          eql("bad_datetime" => nil)
+      end
     end
 
     context "string encoding for ENUM values" do


### PR DESCRIPTION
Fix: https://github.com/brianmario/mysql2/issues/1208

With Mysql 5, the invalid datetime was returned.

However with 8.0 the returned row is `NULL`, so we can no longer detect this case and raise.

NB: I chose not to change the behavior on 5.x, but we could also chose to change it to match 8.0 behavior. However I don't see any way to bring back that behavior on 8.0 because it's impossible to distinguish between a `NULL` datetime and an invalid one.