### PR TITLE
Fix session tracking tests

### DIFF
--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -1078,19 +1078,24 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     end
 
     it "returns multiple session track type values when available" do
-      @client.query("SET @@SESSION.session_track_transaction_info='CHARACTERISTICS'")
+      @client.query("SET @@SESSION.session_track_transaction_info='CHARACTERISTICS';")
 
-      res = @client.session_track(Mysql2::Client::SESSION_TRACK_TRANSACTION_STATE)
-      expect(res).to eq(["________"])
-
-      res = @client.session_track(Mysql2::Client::SESSION_TRACK_TRANSACTION_CHARACTERISTICS)
-      expect(res).to eq([""])
+      res = @client.session_track(Mysql2::Client::SESSION_TRACK_SYSTEM_VARIABLES)
+      expect(res).to eq(%w[session_track_transaction_info CHARACTERISTICS])
 
       res = @client.session_track(Mysql2::Client::SESSION_TRACK_STATE_CHANGE)
       expect(res).to be_nil
 
-      res = @client.session_track(Mysql2::Client::SESSION_TRACK_SYSTEM_VARIABLES)
-      expect(res).to eq(%w[session_track_transaction_info CHARACTERISTICS])
+      res = @client.session_track(Mysql2::Client::SESSION_TRACK_TRANSACTION_CHARACTERISTICS)
+      expect(res).to eq([""])
+    end
+
+    it "returns valid transaction state inside a transaction" do
+      @client.query("SET @@SESSION.session_track_transaction_info='CHARACTERISTICS';")
+      @client.query("START TRANSACTION;")
+
+      res = @client.session_track(Mysql2::Client::SESSION_TRACK_TRANSACTION_STATE)
+      expect(res).to eq(["T_______"])
     end
 
     it "returns empty array if session track type not found" do


### PR DESCRIPTION
closes https://github.com/brianmario/mysql2/issues/1220

I didn't write the original tests, but looking at them I think that they relied on undefined behaviour.

I've broken the check for transaction state tracking into its own test, and followed the tests that MySQL itself performs in its test suite:

https://github.com/mysql/mysql-server/blob/3290a66c89eb1625a7058e0ef732432b6952b435/mysql-test/r/session_tracker_trx_state.result#L154L159

The original test (which checks that multiple client state updates can be read) is still valid.

Arguably this new test isn't testing my original library changes anyway, it's testing MySQL client behaviour, but I don't want to just remove a failing test to make things pass 😬

There are unrelated failures to #1220 which I haven't addressed.