### PR TITLE
Fix more builds

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,11 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
+      - name: Install openssl
+        if: matrix.os == 'macos-latest'
+        run: |
+            brew update
+            brew install openssl
       - run: ruby -v
       - run: bundle install --without development
       - if: matrix.db != ''

--- a/Gemfile
+++ b/Gemfile
@@ -15,6 +15,9 @@ gem 'irb', require: false
 group :test do
   gem 'eventmachine' unless RUBY_PLATFORM =~ /mswin|mingw/
   gem 'rspec', '~> 3.2'
+
+  # Downgrade psych because old RuboCop can't use new Psych
+  gem 'psych', '~> 3.3.2'
   # https://github.com/bbatsov/rubocop/pull/4789
   gem 'rubocop', '~> 0.50.0'
 end

--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,7 @@ group :test do
   gem 'rspec', '~> 3.2'
 
   # Downgrade psych because old RuboCop can't use new Psych
-  gem 'psych', '~> 3.3.2'
+  gem 'psych', '< 4.0.0'
   # https://github.com/bbatsov/rubocop/pull/4789
   gem 'rubocop', '~> 0.50.0'
 end

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -604,7 +604,7 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       end
       expect do
         @client.query("SELECT SLEEP(1)")
-      end.to raise_error(Mysql2::Error, /Lost connection to MySQL server/)
+      end.to raise_error(Mysql2::Error, /Lost connection/)
 
       if RUBY_PLATFORM !~ /mingw|mswin/
         expect do


### PR DESCRIPTION
I think this fixes most of the builds.  It looks like we're actually encountering a RuboCop bug in the `ruby-head` build.

I have to be quite honest, upgrading RuboCop seems like a daunting task.  I think we would gain more by removing RuboCop and making all builds required.