### PR TITLE
Fix compilation on macOS CI

### DIFF
--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -99,9 +99,14 @@ if [[ x$OSTYPE =~ ^xdarwin ]]; then
 
   mysql.server start
   CHANGED_PASSWORD_BY_RECREATE=true
+
+  # the mysql & mariadb formulas depend on an older openssl and leave
+  # `brew --prefix openssl` pointing to an empty directory.
+  # So we install it again.
+  brew install openssl
 fi
 
-# TODO: get SSL working on OS X in Travis
+# TODO: get SSL working on OS X
 if ! [[ x$OSTYPE =~ ^xdarwin ]]; then
   sudo bash ci/ssl.sh
   sudo service mysql restart

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -604,7 +604,7 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       end
       expect do
         @client.query("SELECT SLEEP(1)")
-      end.to raise_error(Mysql2::Error, /Lost connection to MySQL server/)
+      end.to raise_error(Mysql2::Error, /Lost connection to (MySQL )?server/)
 
       if RUBY_PLATFORM !~ /mingw|mswin/
         expect do


### PR DESCRIPTION
Ref: https://github.com/brianmario/mysql2/issues/1179

The mysql & mariadb formulas depend on an older openssl and leave
`brew --prefix openssl` pointing to an empty directory.

This fixes the `ld: library not found for -lssl` error on CI.

NB: There's one test failing afterward, but I'll start digging into it too.

cc @tenderlove 