### PR TITLE
Fix a mismatching size warning

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -256,7 +256,7 @@ static VALUE rb_mysql_result_fetch_field_type(VALUE self, unsigned int idx) {
           https://github.com/mysql/mysql-server/blob/ea7d2e2d16ac03afdd9cb72a972a95981107bf51/sql/field.cc#L2246
         */
         precision = field->length - (field->decimals > 0 ? 2 : 1);
-        rb_field_type = rb_sprintf("decimal(%ld,%d)", precision, field->decimals);
+        rb_field_type = rb_sprintf("decimal(%d,%d)", precision, field->decimals);
         break;
       case MYSQL_TYPE_STRING:       // char[]
         if (field->flags & ENUM_FLAG) {


### PR DESCRIPTION
```
ext/mysql2/result.c:259:55: warning: format specifies type 'long' but the argument has type 'int' [-Wformat]
        rb_field_type = rb_sprintf("decimal(%ld,%d)", precision, field->decimals);
```

cc @tenderlove 