### PR TITLE
Add Ruby 3.1 to the CI matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,35 +17,36 @@ jobs:
           - ubuntu-18.04 # bionic
           # - ubuntu-16.04 # xenial
         ruby:
+          - '3.1'
           - '3.0'
-          - 2.7
-          - 2.6
-          - 2.5
-          - 2.4
-          - 2.3
-          - 2.2
-          - 2.1
+          - '2.7'
+          - '2.6'
+          - '2.5'
+          - '2.4'
+          - '2.3'
+          - '2.2'
+          - '2.1'
         db: ['']
         include:
           # Allow failure due to Mysql2::Error: Unknown system variable 'session_track_system_variables'.
-          - {os: ubuntu-16.04, ruby: 2.4, db: mariadb10.0, allow-failure: true}
+          - {os: ubuntu-16.04, ruby: '2.4', db: mariadb10.0, allow-failure: true}
           # Comment out due to ci/setup.sh stucking.
           # - {os: ubuntu-18.04, ruby: 2.4, db: mariadb10.1}
           # Allow failure due to the issue #965, #1165.
-          - {os: ubuntu-20.04, ruby: 2.4, db: mariadb10.3, allow-failure: true}
-          - {os: ubuntu-18.04, ruby: 2.4, db: mysql57}
+          - {os: ubuntu-20.04, ruby: '2.4', db: mariadb10.3, allow-failure: true}
+          - {os: ubuntu-18.04, ruby: '2.4', db: mysql57}
           # Allow failure due to the issue #1165.
-          - {os: ubuntu-20.04, ruby: 2.4, db: mysql80, allow-failure: true}
+          - {os: ubuntu-20.04, ruby: '2.4', db: mysql80, allow-failure: true}
           - {os: ubuntu-18.04, ruby: 'head', db: '', allow-failure: true}
           # db: A DB's brew package name in macOS case.
           #     Set a name "db: 'name@X.Y'" when using an old version.
           # MariaDB lastet version
           # Allow failure due to the following test failures that rarely happens.
           # https://github.com/brianmario/mysql2/issues/1194
-          - {os: macos-latest, ruby: 2.4, db: mariadb, allow-failure: true}
+          - {os: macos-latest, ruby: '2.4', db: mariadb, allow-failure: true}
           # MySQL latest version
           # Allow failure due to the issue #1165.
-          - {os: macos-latest, ruby: 2.4, db: mysql, allow-failure: true}
+          - {os: macos-latest, ruby: '2.4', db: mysql, allow-failure: true}
       # On the fail-fast: true, it cancels all in-progress jobs
       # if any matrix job fails unlike Travis fast_finish.
       fail-fast: false


### PR DESCRIPTION
I quoted all the version numbers for consistency.