### PR TITLE
Undefine T_DATA allocators for Ruby 3.2 compatibility

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1174,6 +1174,7 @@ void init_mysql2_result() {
   rb_global_variable(&cDateTime);
 
   cMysql2Result = rb_define_class_under(mMysql2, "Result", rb_cObject);
+  rb_undef_alloc_func(cMysql2Result);
   rb_global_variable(&cMysql2Result);
   
   rb_define_method(cMysql2Result, "each", rb_mysql_result_each, -1);

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -581,6 +581,7 @@ void init_mysql2_statement() {
   rb_global_variable(&cBigDecimal);
 
   cMysql2Statement = rb_define_class_under(mMysql2, "Statement", rb_cObject);
+  rb_undef_alloc_func(cMysql2Statement);
   rb_global_variable(&cMysql2Statement);
 
   rb_define_method(cMysql2Statement, "param_count", rb_mysql_stmt_param_count, 0);

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -6,17 +6,8 @@ RSpec.describe Mysql2::Result do
   end
 
   it "should raise a TypeError exception when it doesn't wrap a result set" do
-    if RUBY_VERSION >= "3.1"
-      expect { Mysql2::Result.new }.to raise_error(TypeError)
-      expect { Mysql2::Result.allocate }.to raise_error(TypeError)
-    else
-      r = Mysql2::Result.new
-      expect { r.count }.to raise_error(TypeError)
-      expect { r.fields }.to raise_error(TypeError)
-      expect { r.field_types }.to raise_error(TypeError)
-      expect { r.size }.to raise_error(TypeError)
-      expect { r.each }.to raise_error(TypeError)
-    end
+    expect { Mysql2::Result.new }.to raise_error(TypeError)
+    expect { Mysql2::Result.allocate }.to raise_error(TypeError)
   end
 
   it "should have included Enumerable" do


### PR DESCRIPTION
Ref: https://bugs.ruby-lang.org/issues/18007

cc @tenderlove 

```
lib/mysql2/em.rb:17: warning: undefining the allocator of T_DATA class Mysql2::Result
spec/mysql2/statement_spec.rb:56: warning: undefining the allocator of T_DATA class Mysql2::Statement
```