### PR TITLE
Expose `db` attribute of `MYSQL` client struct

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1332,6 +1332,26 @@ static VALUE rb_mysql_client_encoding(VALUE self) {
 }
 
 /* call-seq:
+ *    client.database
+ *
+ * Returns the currently selected database.
+ *
+ * The result may be stale if `session_track_schema` is disabled.  Read
+ * https://dev.mysql.com/doc/refman/5.7/en/session-state-tracking.html for more
+ * information.
+ */
+static VALUE rb_mysql_client_database(VALUE self) {
+  GET_CLIENT(self);
+
+  char *db = wrapper->client->db;
+  if (!db) {
+    return Qnil;
+  }
+
+  return rb_str_new_cstr(wrapper->client->db);
+}
+
+/* call-seq:
  *    client.automatic_close?
  *
  * @return [Boolean]
@@ -1603,6 +1623,7 @@ void init_mysql2_client() {
   rb_define_method(cMysql2Client, "ssl_cipher", rb_mysql_get_ssl_cipher, 0);
   rb_define_method(cMysql2Client, "encoding", rb_mysql_client_encoding, 0);
   rb_define_method(cMysql2Client, "session_track", rb_mysql_client_session_track, 1);
+  rb_define_method(cMysql2Client, "database", rb_mysql_client_database, 0);
 
   rb_define_private_method(cMysql2Client, "connect_timeout=", set_connect_timeout, 1);
   rb_define_private_method(cMysql2Client, "read_timeout=", set_read_timeout, 1);


### PR DESCRIPTION
Adds an accessor method that returns the current value of the `MSYQL`
client struct's `db` attribute.

The `MYSQL` client struct includes a field `char *db`.  When the
`session_track_schema` setting is enabled, this field will be updated
using information from server-provided "OK" packets, keeping it in sync
as the client switches between databases.