### PR TITLE
Update GitHub Actions workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -51,18 +51,17 @@ jobs:
       # if any matrix job fails unlike Travis fast_finish.
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
+      - name: Install openssl
+        if: matrix.os == 'macos-latest'
+        run: |
+          brew update
+          brew install openssl
       # https://github.com/ruby/setup-ruby
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-      - name: Install openssl
-        if: matrix.os == 'macos-latest'
-        run: |
-            brew update
-            brew install openssl
-      - run: ruby -v
-      - run: bundle install --without development
+          bundler-cache: true
       - if: matrix.db != ''
         run: echo 'DB=${{ matrix.db }}' >> $GITHUB_ENV
       - run: sudo echo "127.0.0.1 mysql2gem.example.com" | sudo tee -a /etc/hosts

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,6 +50,8 @@ jobs:
       # On the fail-fast: true, it cancels all in-progress jobs
       # if any matrix job fails unlike Travis fast_finish.
       fail-fast: false
+    env:
+      BUNDLE_WITHOUT: development
     steps:
       - uses: actions/checkout@v3
       - name: Install openssl

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -61,7 +61,7 @@ jobs:
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}
-          bundler-cache: true
+          bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - if: matrix.db != ''
         run: echo 'DB=${{ matrix.db }}' >> $GITHUB_ENV
       - run: sudo echo "127.0.0.1 mysql2gem.example.com" | sudo tee -a /etc/hosts

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -21,7 +21,7 @@ jobs:
       # if any matrix job fails unlike Travis fast_finish.
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
       - run: docker build -t mysql2 -f ci/Dockerfile_${{ matrix.distro }} --build-arg IMAGE=${{ matrix.image }} .
       # Add the "--cap-add=... --security-opt seccomp=..." options
       # as a temporary workaround to avoid the following issue

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -5,7 +5,8 @@ on: [push, pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-
+    env:
+      BUNDLE_WITHOUT: development
     steps:
     - uses: actions/checkout@v3
     - name: Set up Ruby 2.4

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -7,21 +7,11 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - name: Set up Ruby 2.4
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.4
-    - name: Cache gems
-      uses: actions/cache@v1
-      with:
-        path: vendor/bundle
-        key: ${{ runner.os }}-rubocop-${{ hashFiles('**/Gemfile.lock') }}
-        restore-keys: |
-          ${{ runner.os }}-rubocop-
-    - name: Install gems
-      run: |
-        bundle config path vendor/bundle
-        bundle install --jobs 4 --retry 3
+        bundler-cache: true
     - name: Run RuboCop
       run: bundle exec rubocop

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -12,6 +12,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: 2.4
-        bundler-cache: true
+        bundler-cache: true # runs 'bundle install' and caches installed gems automatically
     - name: Run RuboCop
       run: bundle exec rubocop


### PR DESCRIPTION
This PR does some minor enhancements for GitHub Actions workflows.
- Bump actions/checkout from v2 to v3
- Enable bundler-cache in ruby/setup-ruby

Some workflows fail, but I believe it has nothing to do with this change.