### PR TITLE
Suppress errors on RuboCop 0.50.0 & Ruby 3.1+

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -8,6 +8,9 @@ AllCops:
     - 'pkg/**/*'
     - 'tmp/**/*'
     - 'vendor/**/*'
+    # Suppress errors on RuboCop 0.50.0 & Ruby 3.1+
+    - 'lib/mysql2/console.rb'
+    - 'tasks/generate.rake'
 
 Layout/CaseIndentation:
   EnforcedStyle: end


### PR DESCRIPTION
This PR suppress errors on RuboCop 0.50.0 & Ruby 3.1+.

RuboCop raises errors in `fedora fedora:rawhide` workflow.
https://github.com/brianmario/mysql2/runs/6070946568?check_suite_focus=true

```
Running RuboCop...
Inspecting 36 files
...............An error occurred while Lint/BlockAlignment cop was inspecting /build/lib/mysql2/console.rb:3:20.
To see the complete backtrace run rubocop -d.
..................An error occurred while Lint/BlockAlignment cop was inspecting /build/tasks/generate.rake:1:0.
To see the complete backtrace run rubocop -d.
...

36 files inspected, no offenses detected

2 errors occurred:
An error occurred while Lint/BlockAlignment cop was inspecting /build/lib/mysql2/console.rb:3:20.
An error occurred while Lint/BlockAlignment cop was inspecting /build/tasks/generate.rake:1:0.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
Mention the following information in the issue report:
0.50.0 (using Parser 2.7.2.0, running on ruby 3.1.1 x86_64-linux)
RuboCop failed!
```

The latest RuboCop (v1.27.0) with Ruby 3.1 does not raise the error.
But this gem still supports Ruby 2.0, so we can't update RuboCop.
That's why I just excluded files that caused the error.