### PR TITLE
Remove ubuntu-16.04 from workflows

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -15,7 +15,6 @@ jobs:
           # https://github.com/brianmario/mysql2/issues/1165
           # - ubuntu-20.04 # focal
           - ubuntu-18.04 # bionic
-          # - ubuntu-16.04 # xenial
         ruby:
           - '3.1'
           - '3.0'
@@ -28,8 +27,6 @@ jobs:
           - '2.1'
         db: ['']
         include:
-          # Allow failure due to Mysql2::Error: Unknown system variable 'session_track_system_variables'.
-          - {os: ubuntu-16.04, ruby: '2.4', db: mariadb10.0, allow-failure: true}
           # Comment out due to ci/setup.sh stucking.
           # - {os: ubuntu-18.04, ruby: 2.4, db: mariadb10.1}
           # Allow failure due to the issue #965, #1165.


### PR DESCRIPTION
This PR removes ubuntu-16.04 from GitHub Actions workflows.

A workflow with ubuntu-16.04 is not running forever.
https://github.com/brianmario/mysql2/runs/6066060698?check_suite_focus=true

```
Requested labels: ubuntu-16.04
Job defined at: brianmario/mysql2/.github/workflows/build.yml@refs/pull/1254/merge
Waiting for a runner to pick up this job...
```

This is because GitHub Actions no longer supports Ubuntu 16.04.
https://github.blog/changelog/2021-04-29-github-actions-ubuntu-16-04-lts-virtual-environment-will-be-removed-on-september-20-2021/
- Currently available environments:
 https://docs.github.com/en/actions/using-github-hosted-runners/about-github-hosted-runners#supported-runners-and-hardware-resources

But it seems that Ubuntu 16.04 LTS is supported until 2026.
So should we still run the CI on Ubuntu 16.04 like CentOS and Fedora listed in `.github/workflows/container.yml`?
