### PR TITLE
Do not run RuboCop in Container CI

### DIFF
--- a/ci/container.sh
+++ b/ci/container.sh
@@ -8,4 +8,4 @@ bundle install --path vendor/bundle --without development
 # Start mysqld service.
 bash ci/setup_container.sh
 
-bundle exec rake
+bundle exec rake spec


### PR DESCRIPTION
This PR stops running RuboCop in Container CI.
It's intended to suppress errors in `fedora fedora:rawhide` workflow.
https://github.com/brianmario/mysql2/runs/6182290369?check_suite_focus=true
```
Running RuboCop...
Inspecting 36 files
...............An error occurred while Lint/BlockAlignment cop was inspecting /build/lib/mysql2/console.rb:3:20.
To see the complete backtrace run rubocop -d.
..................An error occurred while Lint/BlockAlignment cop was inspecting /build/tasks/generate.rake:1:0.
To see the complete backtrace run rubocop -d.
...

36 files inspected, no offenses detected

2 errors occurred:
An error occurred while Lint/BlockAlignment cop was inspecting /build/lib/mysql2/console.rb:3:20.
An error occurred while Lint/BlockAlignment cop was inspecting /build/tasks/generate.rake:1:0.
Errors are usually caused by RuboCop bugs.
Please, report your problems to RuboCop's issue tracker.
Mention the following information in the issue report:
0.50.0 (using Parser 2.7.2.0, running on ruby 3.1.2 x86_64-linux)
RuboCop failed!
```

Since there is already [a workflow for RuboCop](https://github.com/brianmario/mysql2/blob/master/.github/workflows/rubocop.yml),
there is no need to run it in Container CI as well.

This is an alternative to #1256.
Once this PR is merged, #1256 can be closed.