### PR TITLE
Add path to support homebrew on arm based macbook

### DIFF
--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -48,6 +48,7 @@ dirs = ENV.fetch('PATH').split(File::PATH_SEPARATOR) + %w[
   /opt/local
   /opt/local/mysql
   /opt/local/lib/mysql5*
+  /opt/homebrew/opt/mysql*
   /usr
   /usr/mysql
   /usr/local


### PR DESCRIPTION
The default homebrew path on my Apple M1 Pro is `/opt/homebrew` (as [described here](https://github.com/Homebrew/brew/pull/9117)).  I've added an additional path that should mean I don't have to manually configure mysql2.