### PR TITLE
Lock on the current Fiber rather than current Thread

### DIFF
--- a/ext/mysql2/client.h
+++ b/ext/mysql2/client.h
@@ -3,7 +3,7 @@
 
 typedef struct {
   VALUE encoding;
-  VALUE active_thread; /* rb_thread_current() or Qnil */
+  VALUE active_fiber; /* rb_fiber_current() or Qnil */
   long server_version;
   int reconnect_enabled;
   unsigned int connect_timeout;
@@ -15,7 +15,6 @@ typedef struct {
   MYSQL *client;
 } mysql_client_wrapper;
 
-void rb_mysql_client_set_active_thread(VALUE self);
 void rb_mysql_set_server_query_flags(MYSQL *client, VALUE result);
 
 #define GET_CLIENT(self) \

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -448,7 +448,7 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
   if (metadata == NULL) {
     if (mysql_stmt_errno(stmt) != 0) {
       // either CR_OUT_OF_MEMORY or CR_UNKNOWN_ERROR. both fatal.
-      wrapper->active_thread = Qnil;
+      wrapper->active_fiber = Qnil;
       rb_raise_mysql2_stmt_error(stmt_wrapper);
     }
     // no data and no error, so query was not a SELECT
@@ -461,7 +461,7 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
       mysql_free_result(metadata);
       rb_raise_mysql2_stmt_error(stmt_wrapper);
     }
-    wrapper->active_thread = Qnil;
+    wrapper->active_fiber = Qnil;
   }
 
   resultObj = rb_mysql_result_to_obj(stmt_wrapper->client, wrapper->encoding, current, metadata, self);
@@ -502,7 +502,7 @@ static VALUE rb_mysql_stmt_fields(VALUE self) {
   if (metadata == NULL) {
     if (mysql_stmt_errno(stmt) != 0) {
       // either CR_OUT_OF_MEMORY or CR_UNKNOWN_ERROR. both fatal.
-      wrapper->active_thread = Qnil;
+      wrapper->active_fiber = Qnil;
       rb_raise_mysql2_stmt_error(stmt_wrapper);
     }
     // no data and no error, so query was not a SELECT

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -2,6 +2,8 @@ require 'rspec'
 require 'mysql2'
 require 'timeout'
 require 'yaml'
+require 'fiber'
+
 DatabaseCredentials = YAML.load_file('spec/configuration.yml')
 
 if GC.respond_to?(:verify_compaction_references)


### PR DESCRIPTION
Applications using fiber are able to do concurrent queries from the same thread.

Ref: https://github.com/rails/rails/pull/46519#issuecomment-1321730478

~~NB: I'm not sure when `rb_fiber_current()` was introduced, so I'm waiting for CI to see.~~