### PR TITLE
Fix SSL errors on the container Fedora cases.

### DIFF
--- a/ci/setup_container.sh
+++ b/ci/setup_container.sh
@@ -4,6 +4,8 @@ set -eux
 
 MYSQL_TEST_LOG="$(pwd)/mysql.log"
 
+bash ci/ssl.sh
+
 mysql_install_db \
   --log-error="${MYSQL_TEST_LOG}"
 /usr/libexec/mysqld \
@@ -14,4 +16,12 @@ sleep 3
 cat ${MYSQL_TEST_LOG}
 
 /usr/libexec/mysqld --version
+
+mysql -u root <<SQL
+DROP USER 'root'@'localhost';
+CREATE USER 'root'@'localhost' IDENTIFIED BY '';
+GRANT ALL PRIVILEGES ON *.* TO 'root'@'localhost' WITH GRANT OPTION;
+FLUSH PRIVILEGES;
+SQL
+
 mysql -u root -e 'CREATE DATABASE IF NOT EXISTS test'


### PR DESCRIPTION
This PR fixes https://github.com/brianmario/mysql2/issues/1289 . Could you review this PR? Note I wrote the context in the commit message. Thanks.

---

This commit fixes the SSL related failures in the CI container Fedora cases.

The MariaDB 10.5.18 mysqld failed to start in the CI, container "fedora:rawhide" (Fedora 38) and "fedora:latest" (Fedora 37) cases with the SSL error below. So, we set the SSL configurations manually as well as MacOSX case.

```
 + /usr/libexec/mysqld --user=root --log-error=/build/mysql.log --ssl
2022-12-16 17:49:58 0 [Note] /usr/libexec/mysqld (mysqld 10.5.18-MariaDB) starting as process 724 ...
+ cat /build/mysql.log
2022-12-16 17:49:58 0 [Note] InnoDB: Uses event mutexes
2022-12-16 17:49:58 0 [Note] InnoDB: Compressed tables use zlib 1.2.12
2022-12-16 17:49:58 0 [Note] InnoDB: Number of pools: 1
2022-12-16 17:49:58 0 [Note] InnoDB: Using crc32 + pclmulqdq instructions
2022-12-16 17:49:58 0 [Note] mysqld: O_TMPFILE is not supported on /var/tmp (disabling future attempts)
2022-12-16 17:49:58 0 [Note] InnoDB: Using Linux native AIO
2022-12-16 17:49:58 0 [Note] InnoDB: Initializing buffer pool, total size = 134217728, chunk size = 134217728
2022-12-16 17:49:58 0 [Note] InnoDB: Completed initialization of buffer pool
2022-12-16 17:49:58 0 [Note] InnoDB: 128 rollback segments are active.
2022-12-16 17:49:58 0 [Note] InnoDB: Creating shared tablespace for temporary tables
2022-12-16 17:49:58 0 [Note] InnoDB: Setting file './ibtmp1' size to 12 MB. Physically writing the file full; Please wait ...
2022-12-16 17:49:58 0 [Note] InnoDB: File './ibtmp1' size is now 12 MB.
2022-12-16 17:49:58 0 [Note] InnoDB: 10.5.18 started; log sequence number 45079; transaction id 20
2022-12-16 17:49:58 0 [Note] Plugin 'FEEDBACK' is disabled.
2022-12-16 17:49:58 0 [Note] InnoDB: Loading buffer pool(s) from /var/lib/mysql/ib_buffer_pool
2022-12-16 17:49:58 0 [Note] InnoDB: Buffer pool(s) load completed at 221216 17:49:58
SSL error: Private key does not match the certificate public key
Error: -16 17:49:58 0 [ERROR] Failed to setup SSL
Error: -16 17:49:58 0 [ERROR] SSL error: Private key does not match the certificate public key
Error: -16 17:49:58 0 [ERROR] Aborting
```

After fixing the issue, we also saw the following failing tests with the error below. So, we recreated the db user.

```
expected no Exception, got #<Mysql2::Error: Access denied for user 'root'@'localhost'> with backtrace:
```

Note this issue didn't happened on the container CentOS case. But as we applied the fix to all the container cases to simplify the logic.