### PR TITLE
CI: Drop allow-failure option in some Ubuntu cases.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,12 +29,10 @@ jobs:
         include:
           # Comment out due to ci/setup.sh stucking.
           # - {os: ubuntu-18.04, ruby: 2.4, db: mariadb10.1}
-          # Allow failure due to the issue #965, #1165.
-          - {os: ubuntu-20.04, ruby: '2.4', db: mariadb10.3, allow-failure: true}
+          - {os: ubuntu-20.04, ruby: '2.4', db: mariadb10.3}
           - {os: ubuntu-18.04, ruby: '2.4', db: mysql57}
-          # Allow failure due to the issue #1165.
-          - {os: ubuntu-20.04, ruby: '2.4', db: mysql80, allow-failure: true}
-          - {os: ubuntu-18.04, ruby: 'head', db: '', allow-failure: true}
+          - {os: ubuntu-20.04, ruby: '2.4', db: mysql80}
+          - {os: ubuntu-18.04, ruby: 'head', db: ''}
           # db: A DB's brew package name in macOS case.
           #     Set a name "db: 'name@X.Y'" when using an old version.
           # MariaDB lastet version
@@ -42,7 +40,7 @@ jobs:
           # https://github.com/brianmario/mysql2/issues/1194
           - {os: macos-latest, ruby: '2.6', db: mariadb, allow-failure: true}
           # MySQL latest version
-          # Allow failure due to the issue #1165.
+          # Allow failure due to the issue #1194.
           - {os: macos-latest, ruby: '2.6', db: mysql, allow-failure: true}
       # On the fail-fast: true, it cancels all in-progress jobs
       # if any matrix job fails unlike Travis fast_finish.


### PR DESCRIPTION
As we fixed some of the issues, I think that we can drop the allow-failure option in some cases.

I saw the issue #1194 happened on the latest master's MacOS mysql case too. So, I chnaged the issue number from 1165 to 1194.
https://github.com/brianmario/mysql2/issues/1194#issuecomment-1361760742