### PR TITLE
Add an option to set a custom SSL pem files directory in test.

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -16,7 +16,7 @@ jobs:
           # Fedora latest stable version
           - {distro: fedora, image: 'fedora:latest'}
           # Fedora development version
-          - {distro: fedora, image: 'fedora:rawhide'}
+          - {distro: fedora, image: 'fedora:rawhide', ssl_cert_dir: '/tmp/mysql2'}
       # On the fail-fast: true, it cancels all in-progress jobs
       # if any matrix job fails unlike Travis fast_finish.
       fail-fast: false
@@ -27,4 +27,10 @@ jobs:
       # as a temporary workaround to avoid the following issue
       # in the Fedora >= 34 containers.
       # https://bugzilla.redhat.com/show_bug.cgi?id=1900021
-      - run: docker run --add-host=mysql2gem.example.com:127.0.0.1 -t --cap-add=SYS_PTRACE --security-opt seccomp=unconfined mysql2
+      - run: |
+          docker run \
+            --add-host=mysql2gem.example.com:127.0.0.1 \
+            -t \
+            -e TEST_RUBY_MYSQL2_SSL_CERT_DIR="${{ matrix.ssl_cert_dir || '' }}" \
+            --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
+            mysql2

--- a/ci/ssl.sh
+++ b/ci/ssl.sh
@@ -2,11 +2,14 @@
 
 set -eux
 
+# TEST_RUBY_MYSQL2_SSL_CERT_DIR: custom SSL certs directory.
+SSL_CERT_DIR=${TEST_RUBY_MYSQL2_SSL_CERT_DIR:-/etc/mysql}
+
 # Make sure there is an /etc/mysql
-mkdir -p /etc/mysql
+mkdir -p "${SSL_CERT_DIR}"
 
 # Copy the local certs to /etc/mysql
-cp spec/ssl/*pem /etc/mysql/
+cp spec/ssl/*pem "${SSL_CERT_DIR}"
 
 # Wherever MySQL configs live, go there (this is for cross-platform)
 cd $(my_print_defaults --help | grep my.cnf | xargs find 2>/dev/null | xargs dirname)
@@ -14,7 +17,7 @@ cd $(my_print_defaults --help | grep my.cnf | xargs find 2>/dev/null | xargs dir
 # Put the configs into the server
 echo "
 [mysqld]
-ssl-ca=/etc/mysql/ca-cert.pem
-ssl-cert=/etc/mysql/server-cert.pem
-ssl-key=/etc/mysql/server-key.pem
+ssl-ca=${SSL_CERT_DIR}/ca-cert.pem
+ssl-cert=${SSL_CERT_DIR}/server-cert.pem
+ssl-key=${SSL_CERT_DIR}/server-key.pem
 " >> my.cnf

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -154,9 +154,9 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     let(:option_overrides) do
       {
         'host'     => 'mysql2gem.example.com', # must match the certificates
-        :sslkey    => '/etc/mysql/client-key.pem',
-        :sslcert   => '/etc/mysql/client-cert.pem',
-        :sslca     => '/etc/mysql/ca-cert.pem',
+        :sslkey    => "#{ssl_cert_dir}/client-key.pem",
+        :sslcert   => "#{ssl_cert_dir}/client-cert.pem",
+        :sslca     => "#{ssl_cert_dir}/ca-cert.pem",
         :sslcipher => 'DHE-RSA-AES256-SHA',
         :sslverify => true,
       }

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -60,6 +60,19 @@ RSpec.configure do |config|
     end
   end
 
+  # A directory where SSL certificates pem files exist.
+  def ssl_cert_dir
+    return @ssl_cert_dir if @ssl_cert_dir
+
+    dir = ENV['TEST_RUBY_MYSQL2_SSL_CERT_DIR']
+    @ssl_cert_dir = if dir && !dir.empty?
+      dir
+    else
+      '/etc/mysql'
+    end
+    @ssl_cert_dir
+  end
+
   config.before(:suite) do
     begin
       new_client


### PR DESCRIPTION
In the Fedora project, we are running the mysql2 tests on the build environment with a user permission, without root permission and without `sudo`.

For [the change](https://github.com/brianmario/mysql2/pull/1290) in MariaDB 10.5.18 on Fedora, we need to set up the SSL pem files manually to run the SSL tests.

In this case, we couldn't set up the pem files required to run SSL tests in the `/etc/mysql`. This custom SSL directory option gives an option to run the SSL tests executed in the environment.

How to use:

```
$ TEST_RUBY_MYSQL2_SSL_DIR=/tmp/mysql2 \
  bundle exec rake spec
```
