### PR TITLE
Print the mysql client version info in a SSL support warning.

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -122,7 +122,7 @@ static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
   unsigned long version = mysql_get_client_version();
 
   if (version < 50703) {
-    rb_warn( "Your mysql client library does not support setting ssl_mode; full support comes with 5.7.11." );
+    rb_warn("Your mysql client library version %lu does not support setting ssl_mode; full support comes with 5.7.11.", version);
     return Qnil;
   }
 #if defined(HAVE_CONST_MYSQL_OPT_SSL_VERIFY_SERVER_CERT) || defined(HAVE_CONST_MYSQL_OPT_SSL_ENFORCE)
@@ -163,7 +163,7 @@ static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
   return INT2NUM(result);
 #endif
 #ifdef NO_SSL_MODE_SUPPORT
-  rb_warn( "Your mysql client library does not support setting ssl_mode; full support comes with 5.7.11." );
+  rb_warn("Your mysql client library does not support setting ssl_mode; full support comes with 5.7.11.");
   return Qnil;
 #endif
 }

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -121,7 +121,7 @@ struct nogvl_select_db_args {
 static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
   unsigned long version = mysql_get_client_version();
 
-  if (version < 50703) {
+  if (version >= 50000 && version < 50703) {
     rb_warn("Your mysql client library version %lu does not support setting ssl_mode; full support comes with 5.7.11.", version);
     return Qnil;
   }


### PR DESCRIPTION
I am seeing interesting warnings in CI Fedora cases.


https://github.com/brianmario/mysql2/actions/runs/3758719509/jobs/6387395753#step:4:310

```
/build/lib/mysql2/client.rb:58: warning: Your mysql client library does not support setting ssl_mode; full support comes with 5.7.11.
```

There are 2 possibilities about where the warning comes from. Because the 2 lines below have the same warning message.

* https://github.com/brianmario/mysql2/blob/7f6f33a6e0bd652d5e7087edb6e5d00df248d35b/ext/mysql2/client.c#L125
* https://github.com/brianmario/mysql2/blob/7f6f33a6e0bd652d5e7087edb6e5d00df248d35b/ext/mysql2/client.c#L166


So, I printed the version in the warning. The result was "30207" was printed. 

https://github.com/junaruga/mysql2/actions/runs/3761039661/jobs/6392364841#step:4:401

```
/build/lib/mysql2/client.rb:58: warning: Your mysql client library version 30207 does not support setting ssl_mode; full support comes with 5.7.11.
```

Because the client library [mariadb-connector-c](https://github.com/mariadb-corporation/mariadb-connector-c) version 3.2.7 was used on the environment.

So, seeing the logic to print the warning. I think the condition `version < 50703` is only considered for MySQL and MariaDB (a client library bundled in MariaDB). But not for mariadb-connector-c. Maybe we can fix the condition in another PR.
https://github.com/brianmario/mysql2/blob/7f6f33a6e0bd652d5e7087edb6e5d00df248d35b/ext/mysql2/client.c#L122-L127

I think this PR is helpful to debug around this kind of issue.

## Coding style

Originally the `rb_warn` in line 125 and 166 has spaces inside the "()". However, checking other parts below, I removed the spaces to align other parts.

```
$ grep -r rb_warn ext/
ext/mysql2/client.c:    rb_warn( "Your mysql client library does not support setting ssl_mode; full support comes with 5.7.11." );
ext/mysql2/client.c:    rb_warn( "Your mysql client library does not support ssl_mode %d.", val );
ext/mysql2/client.c:    rb_warn( "Your mysql client library does not support ssl_mode as expected." );
ext/mysql2/client.c:  rb_warn( "Your mysql client library does not support setting ssl_mode; full support comes with 5.7.11." );
ext/mysql2/client.c:        rb_warn("mysql2 failed to invalidate FD safely, closing unsafely\n");
ext/mysql2/client.c:    rb_warn("%s\n", mysql_error(wrapper->client));
ext/mysql2/client.c:    rb_warn("Connections are always closed by garbage collector on Windows");
ext/mysql2/client.c:    rb_warn("%s\n", mysql_error(wrapper->client));
ext/mysql2/result.c:    rb_warn(":cache_rows is ignored if :stream is true");
ext/mysql2/result.c:    rb_warn(":cache_rows is forced for prepared statements (if not streaming)");
ext/mysql2/result.c:    rb_warn(":cast is forced for prepared statements");
ext/mysql2/result.c:      rb_warn(":database_timezone option must be :utc or :local - defaulting to :local");
```

## Commit message

The commit message is below.

It's to know the details of the warning, and to distinguish warnings between the client.c:125 and client.c:166, as these messages are the same. I wanted to know where the warning came from.