### PR TITLE
rubocop: Style/Documentation: Exclude lib/mysql2/result.rb.

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -87,6 +87,7 @@ Style/Documentation:
     - 'lib/mysql2/client.rb'
     - 'lib/mysql2/em.rb'
     - 'lib/mysql2/error.rb'
+    - 'lib/mysql2/result.rb'
     - 'lib/mysql2/statement.rb'
 
 # Offense count: 6


### PR DESCRIPTION
The issue was detected at https://github.com/brianmario/mysql2/pull/1293#issuecomment-1362928978 .

The rubocop 1.41.1 complained with the message below. This commit suppresses the message, and makes the CI pass.

https://github.com/brianmario/mysql2/actions/runs/3758719510/jobs/6387395566#step:4:12
```
 lib/mysql2/result.rb:2:3: C: Style/Documentation: Missing top-level documentation comment for class Mysql2::Result.
  class Result
  ^^^^^^^^^^^^
```