### PR TITLE
MacOS: Add a Homebrew OpenSSL directory configuration option.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -27,6 +27,7 @@ jobs:
           - '2.2'
           - '2.1'
         db: ['']
+        ssl: ['']
         include:
           # Comment out due to ci/setup.sh stucking.
           # - {os: ubuntu-18.04, ruby: 2.4, db: mariadb10.1}
@@ -39,10 +40,10 @@ jobs:
           # MariaDB lastet version
           # Allow failure due to the following test failures that rarely happens.
           # https://github.com/brianmario/mysql2/issues/1194
-          - {os: macos-latest, ruby: '2.6', db: mariadb, allow-failure: true}
+          - {os: macos-latest, ruby: '2.6', db: mariadb, ssl: openssl@1.1, allow-failure: true}
           # MySQL latest version
           # Allow failure due to the issue #1194.
-          - {os: macos-latest, ruby: '2.6', db: mysql, allow-failure: true}
+          - {os: macos-latest, ruby: '2.6', db: mysql, ssl: openssl@1.1, allow-failure: true}
       # On the fail-fast: true, it cancels all in-progress jobs
       # if any matrix job fails unlike Travis fast_finish.
       fail-fast: false
@@ -60,6 +61,8 @@ jobs:
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
       - if: matrix.db != ''
         run: echo 'DB=${{ matrix.db }}' >> $GITHUB_ENV
+      - if: startsWith(matrix.os, 'macos') && matrix.ssl != ''
+        run: echo "RUBY_MYSQL2_SSL_DIR=$(brew --prefix ${{ matrix.ssl }})" >> $GITHUB_ENV
       - run: sudo echo "127.0.0.1 mysql2gem.example.com" | sudo tee -a /etc/hosts
       - run: bash ci/setup.sh
       - run: bundle exec rake spec

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -50,11 +50,6 @@ jobs:
       BUNDLE_WITHOUT: development
     steps:
       - uses: actions/checkout@v3
-      - name: Install openssl
-        if: matrix.os == 'macos-latest'
-        run: |
-          brew update
-          brew install openssl
       # https://github.com/ruby/setup-ruby
       - uses: ruby/setup-ruby@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -48,6 +48,9 @@ jobs:
       fail-fast: false
     env:
       BUNDLE_WITHOUT: development
+      # reduce MacOS CI time, don't need to clean a runtime that isn't saved
+      HOMEBREW_NO_INSTALL_CLEANUP: 1
+      HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
     steps:
       - uses: actions/checkout@v3
       # https://github.com/ruby/setup-ruby

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -28,8 +28,16 @@ end
 
 # Homebrew openssl
 if RUBY_PLATFORM =~ /darwin/ && system("command -v brew")
-  openssl_location = `brew --prefix openssl`.strip
-  $LDFLAGS << " -L#{openssl_location}/lib" if openssl_location
+  _, lib = dir_config('ssl')
+  unless lib
+    openssl_location = `brew --prefix openssl`.strip
+    lib = "#{openssl_location}/lib" if openssl_location
+  end
+
+  if lib
+    abort "-----\nCannot find library dir(s) #{lib}\n-----" unless lib && lib.split(File::PATH_SEPARATOR).any? { |dir| File.directory?(dir) }
+    $LDFLAGS << " -L#{lib}"
+  end
 end
 
 # 2.1+

--- a/tasks/compile.rake
+++ b/tasks/compile.rake
@@ -51,6 +51,9 @@ Rake::ExtensionTask.new("mysql2", Mysql2::GEMSPEC) do |ext|
       POST_INSTALL_MESSAGE
     end
   end
+
+  ssl_dir = ENV['RUBY_MYSQL2_SSL_DIR']
+  ext.config_options << "--with-ssl-dir=#{ssl_dir}" if ssl_dir
 end
 Rake::Task[:spec].prerequisites << :compile
 


### PR DESCRIPTION
This PR is to add Homebrew OpenSSL directory configuration option in MacOS environment. This fixes #1300. It is related to and #1297, as this PR passes CI MacOS cases.

There are 3 commits. The first 2 commits come from another PR:  https://github.com/brianmario/mysql2/pull/1299. The third commit is the main one of this PR.

What do you think? If the PR will be merged, then we need to add this option to the README.md - Configuration options section, and I am happy to help. Note I don't have MacOS environment. I appreciate if someone can help to test this PR on MacOS environment.

I confirmed the CI passed on my forked repository. ([CI link](https://github.com/junaruga/mysql2/actions/runs/3912453010/jobs/6687116518)), and the error case by directory existing check ([CI link](https://github.com/junaruga/mysql2/actions/runs/3911886706/jobs/6685806468#step:7:17)).

In the GitHub Actions build.yml, the way of how to set the matrix environment variables is used in ruby/ruby. You can see [this](https://github.com/ruby/ruby/blob/fc7f8520337be9513d984f67c9ef98ef85d03d0f/.github/workflows/compilers.yml#L220).

## Commit message

MacOS: Add a Homebrew OpenSSL directory configuration option.

This commit is to enable users to set a custom Homebrew openssl directory
configuration option to set the openssl library path on MacOS.

Previously we got the openssl library path by `brew --prefix openssl` on MacOS.
However, there is a case where the directory actually doesn't exist. And this
option enables users to build mysql2 in the case.

```
+ brew --prefix openssl
/usr/local/opt/openssl@3

+ ls -ld /usr/local/opt/openssl*
lrwxr-xr-x  1 runner  admin  36 Dec 16 01:28 /usr/local/opt/openssl -> /usr/local/Cellar/openssl@1.1/1.1.1s
lrwxr-xr-x  1 runner  admin  28 Dec 16 01:19 /usr/local/opt/openssl@1.1 -> ../Cellar/openssl@1.1/1.1.1s
/usr/local/opt/openssl@1.1
```

== How to use ==

In the development, you can run like this.

```
$ RUBY_MYSQL2_BREW_SSL_DIR=/usr/local/opt/openssl@1.1 rake
```

In the installation, you can run like this.

```
$ gem install mysql2 -- --with-brew-ssl-dir=/usr/local/opt/openssl@1.1
```

== Note ==

In this commit, the directory existing check is added in the `extconf.rb`. If
the openssl directory doesn't exist, the build fails with the error message
below.

```
Cannot find library dir(s) /usr/local/opt/openssl@3/lib
```

