### PR TITLE
Add an option to use SSL certifications generated from specific host (Create certificaitons in CI)

### DIFF
--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -16,7 +16,7 @@ jobs:
           # Fedora latest stable version
           - {distro: fedora, image: 'fedora:latest'}
           # Fedora development version
-          - {distro: fedora, image: 'fedora:rawhide', ssl_cert_dir: '/tmp/mysql2'}
+          - {distro: fedora, image: 'fedora:rawhide', ssl_cert_dir: '/tmp/mysql2', ssl_cert_host: 'localhost'}
       # On the fail-fast: true, it cancels all in-progress jobs
       # if any matrix job fails unlike Travis fast_finish.
       fail-fast: false
@@ -29,8 +29,9 @@ jobs:
       # https://bugzilla.redhat.com/show_bug.cgi?id=1900021
       - run: |
           docker run \
-            --add-host=mysql2gem.example.com:127.0.0.1 \
+            --add-host=${{ matrix.ssl_cert_host || 'mysql2gem.example.com' }}:127.0.0.1 \
             -t \
             -e TEST_RUBY_MYSQL2_SSL_CERT_DIR="${{ matrix.ssl_cert_dir || '' }}" \
+            -e TEST_RUBY_MYSQL2_SSL_CERT_HOST="${{ matrix.ssl_cert_host || '' }}" \
             --cap-add=SYS_PTRACE --security-opt seccomp=unconfined \
             mysql2

--- a/ci/Dockerfile_fedora
+++ b/ci/Dockerfile_fedora
@@ -17,6 +17,7 @@ RUN dnf -yq install \
   make \
   mariadb-connector-c-devel \
   mariadb-server \
+  openssl \
   redhat-rpm-config \
   ruby-devel \
   rubygem-bigdecimal \

--- a/ci/container.sh
+++ b/ci/container.sh
@@ -5,6 +5,13 @@ set -eux
 ruby -v
 bundle install --path vendor/bundle --without development
 
+# Regenerate the SSL certification files from the specified host.
+if [ -n "${TEST_RUBY_MYSQL2_SSL_CERT_HOST}" ]; then
+  pushd spec/ssl
+  bash gen_certs.sh
+  popd
+fi
+
 # Start mysqld service.
 bash ci/setup_container.sh
 

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -153,7 +153,7 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
 
     let(:option_overrides) do
       {
-        'host'     => 'mysql2gem.example.com', # must match the certificates
+        'host'     => ssl_cert_host, # must match the certificates
         :sslkey    => "#{ssl_cert_dir}/client-key.pem",
         :sslcert   => "#{ssl_cert_dir}/client-cert.pem",
         :sslca     => "#{ssl_cert_dir}/ca-cert.pem",

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -73,6 +73,19 @@ RSpec.configure do |config|
     @ssl_cert_dir
   end
 
+  # A host used to create the certificates pem files.
+  def ssl_cert_host
+    return @ssl_cert_host if @ssl_cert_host
+
+    host = ENV['TEST_RUBY_MYSQL2_SSL_CERT_HOST']
+    @ssl_cert_host = if host && !host.empty?
+      host
+    else
+      'mysql2gem.example.com'
+    end
+    @ssl_cert_host
+  end
+
   config.before(:suite) do
     begin
       new_client

--- a/spec/ssl/gen_certs.sh
+++ b/spec/ssl/gen_certs.sh
@@ -2,6 +2,10 @@
 
 set -eux
 
+# TEST_RUBY_MYSQL2_SSL_CERT_HOST: custom host for the SSL certificates.
+SSL_CERT_HOST=${TEST_RUBY_MYSQL2_SSL_CERT_HOST:-mysql2gem.example.com}
+echo "Generating the SSL certifications from the host ${SSL_CERT_HOST}.."
+
 echo "
 [ ca ]
 # January 1, 2015
@@ -30,7 +34,7 @@ commonName_default             = ca_mysql2gem
 " >> ca.cnf
 
 echo "
-commonName_default             = mysql2gem.example.com
+commonName_default             = ${SSL_CERT_HOST}
 " >> cert.cnf
 
 # Generate a set of certificates


### PR DESCRIPTION
This PR is alternative for the <https://github.com/brianmario/mysql2/pull/1296> with less modification. What do you think? Is this PR better for you than the #1296?

---

In the Fedora project, we are running the mysql2 tests on the build environment with a user permission, without root permission and without `sudo`.

In this case, we couldn't set up the custom domain "mysql2gem.example.com" to run SSL tests. The feature to create a set of the SSL certifications from the localhost gives an option to run the SSL tests executed in the environment.

How to generate the certificaton files:

```
$ cd spec/ssl/
$ TEST_RUBY_MYSQL2_SSL_CERT_HOST=localhost bash gen_certs.sh
```

The files are generated in the `spec/ssl` directory.

How to use:

```
$ TEST_RUBY_MYSQL2_SSL_CERT_HOST=localhost \
bundle exec rake spec
```