### PR TITLE
CI: fix defunct MariaDB package names and repo URLs

### DIFF
--- a/ci/mariadb1011.sh
+++ b/ci/mariadb1011.sh
@@ -6,5 +6,5 @@ rm -fr /etc/mysql
 rm -fr /var/lib/mysql
 
 apt-key add support/C74CD1D8.asc
-add-apt-repository "deb https://downloads.mariadb.com/MariaDB/mariadb-10.11/repo/ubuntu $(lsb_release -cs) main"
-apt install -y -o Dpkg::Options::='--force-confnew' mariadb-server-10.11 libmariadb-dev
+add-apt-repository "deb https://deb.mariadb.org/10.11/ubuntu $(lsb_release -cs) main"
+apt install -y -o Dpkg::Options::='--force-confnew' mariadb-server libmariadb-dev

--- a/ci/mariadb106.sh
+++ b/ci/mariadb106.sh
@@ -6,5 +6,5 @@ rm -fr /etc/mysql
 rm -fr /var/lib/mysql
 
 apt-key add support/C74CD1D8.asc
-add-apt-repository "deb https://downloads.mariadb.com/MariaDB/mariadb-10.6/repo/ubuntu $(lsb_release -cs) main"
-apt install -y -o Dpkg::Options::='--force-confnew' mariadb-server-10.6 libmariadb-dev
+add-apt-repository "deb https://deb.mariadb.org/10.6/ubuntu $(lsb_release -cs) main"
+apt install -y -o Dpkg::Options::='--force-confnew' mariadb-server libmariadb-dev


### PR DESCRIPTION
10.6 repo URL was moved. 10.11 package name no longer includes version suffix.

Switch both to deb.mariadb.org mirrors and use suffix-less package names.