### PR TITLE
CI: GitHub dropped Ubuntu 18.04 runners; switch to 20.04 for MySQL 5.7 test

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -33,7 +33,6 @@ jobs:
           - {os: ubuntu-22.04, ruby: '3.0', db: mariadb10.6}
           - {os: ubuntu-20.04, ruby: '2.7', db: mariadb10.6}
           - {os: ubuntu-20.04, ruby: '2.7', db: mysql80}
-          - {os: ubuntu-18.04, ruby: '2.7', db: mysql57}
 
           # TODO - Windows CI
           # - {os: windows-2022, ruby: '3.2', db: mysql80}


### PR DESCRIPTION
https://github.blog/changelog/2022-08-09-github-actions-the-ubuntu-18-04-actions-runner-image-is-being-deprecated-and-will-be-removed-by-12-1-22/

We'll need to switch to running MySQL in Docker to restore 5.7 test coverage. (Maybe be simpler than doing package installs, anyway?)