### PR TITLE
Fix faling CI

### DIFF
--- a/ci/Dockerfile_fedora
+++ b/ci/Dockerfile_fedora
@@ -14,6 +14,7 @@ RUN dnf -yq install \
   gcc \
   gcc-c++ \
   git \
+  libyaml-devel \
   make \
   mariadb-connector-c-devel \
   mariadb-server \

--- a/ci/mysql57.sh
+++ b/ci/mysql57.sh
@@ -7,6 +7,7 @@ rm -fr /etc/mysql
 rm -fr /var/lib/mysql
 apt-key add support/5072E1F5.asc # old signing key
 apt-key add support/3A79BD29.asc # 5.7.37 and higher
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C
 # Verify the repository as add-apt-repository does not.
 wget -q --spider http://repo.mysql.com/apt/ubuntu/dists/$(lsb_release -cs)/mysql-5.7
 add-apt-repository 'http://repo.mysql.com/apt/ubuntu mysql-5.7'

--- a/ci/mysql80.sh
+++ b/ci/mysql80.sh
@@ -7,6 +7,7 @@ rm -fr /etc/mysql
 rm -fr /var/lib/mysql
 apt-key add support/5072E1F5.asc # old signing key
 apt-key add support/3A79BD29.asc # 8.0.28 and higher
+apt-key adv --keyserver keyserver.ubuntu.com --recv-keys B7B3B788A8D3785C
 # Verify the repository as add-apt-repository does not.
 wget -q --spider http://repo.mysql.com/apt/ubuntu/dists/$(lsb_release -cs)/mysql-8.0
 add-apt-repository 'http://repo.mysql.com/apt/ubuntu mysql-8.0'


### PR DESCRIPTION
1. Ubuntu-based CI failing because of old keys
2. Fedora-based CI is failing because of missing dependency