### PR TITLE
use mysql_options if mysql_ssl_set isn't available (mysql client 8.3 support)

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1435,12 +1435,31 @@ static VALUE set_charset_name(VALUE self, VALUE value) {
 static VALUE set_ssl_options(VALUE self, VALUE key, VALUE cert, VALUE ca, VALUE capath, VALUE cipher) {
   GET_CLIENT(self);
 
+#ifdef HAVE_MYSQL_SSL_SET
   mysql_ssl_set(wrapper->client,
       NIL_P(key)    ? NULL : StringValueCStr(key),
       NIL_P(cert)   ? NULL : StringValueCStr(cert),
       NIL_P(ca)     ? NULL : StringValueCStr(ca),
       NIL_P(capath) ? NULL : StringValueCStr(capath),
       NIL_P(cipher) ? NULL : StringValueCStr(cipher));
+#else
+  /* mysql 8.3 does not provide mysql_ssl_set */
+  if (NIL_P(key)) {
+    mysql_options(wrapper->client, MYSQL_OPT_SSL_KEY, StringValueCStr(key));
+  }
+  if (NIL_P(cert)) {
+    mysql_options(wrapper->client, MYSQL_OPT_SSL_CERT, StringValueCStr(cert));
+  }
+  if (NIL_P(ca)) {
+    mysql_options(wrapper->client, MYSQL_OPT_SSL_CA, StringValueCStr(ca));
+  }
+  if (NIL_P(capath)) {
+    mysql_options(wrapper->client, MYSQL_OPT_SSL_CAPATH, StringValueCStr(capath));
+  }
+  if (NIL_P(cipher)) {
+    mysql_options(wrapper->client, MYSQL_OPT_SSL_CIPHER, StringValueCStr(cipher));
+  }
+#endif
 
   return self;
 }

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -164,6 +164,9 @@ have_const('MYSQL_OPTION_MULTI_STATEMENTS_OFF', mysql_h)
 # to retain compatibility with the typedef in earlier MySQLs.
 have_type('my_bool', mysql_h)
 
+# detect mysql functions
+have_func('mysql_ssl_set', mysql_h)
+
 ### Compiler flags to help catch errors
 
 # This is our wishlist. We use whichever flags work on the host.


### PR DESCRIPTION
for mysql client 8.3 support.

This is based on #1347 by @xjunior (who is credited in the commit log), but is backwards-compatible with all other client versions.

Fixes #1346
