### PR TITLE
Avoid modifying frozen string literals

### DIFF
--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -86,7 +86,7 @@ dirs = ENV.fetch('PATH').split(File::PATH_SEPARATOR) + %w[
   /usr/local/opt/mysql@*
   /usr/local/opt/mysql-client
   /usr/local/opt/mysql-client@*
-].map { |dir| dir << '/bin' }
+].map { |dir| "#{dir}/bin" }
 
 # For those without HOMEBREW_ROOT in PATH
 dirs << "#{ENV['HOMEBREW_ROOT']}/bin" if ENV['HOMEBREW_ROOT']

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -886,7 +886,7 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     end
 
     it "should carry over the original string's encoding" do
-      str = "abc'def\"ghi\0jkl%mno"
+      str = "abc'def\"ghi\0jkl%mno".dup
       escaped = Mysql2::Client.escape(str)
       expect(escaped.encoding).to eql(str.encoding)
 


### PR DESCRIPTION
Given MRI 3.4 will have a warning whenever frozen string literals are edited, this PR fixes up the two situations where I expect that to happen.

I've tried to modify the CI workflows to have frozen string literals enforced, but the relevant RUBYOPT flags (`--enable-frozen-string-literal --debug-frozen-string-literal`) can't be used in old Ruby versions (<= 2.3) and so setting it globally is not an option - though it did turn up the frozen string in the client spec.

Annoyingly, setting RUBYOPT conditionally (like is done with other variables) doesn't work either - I think it gets stuck somewhere within rake-compiler, but given that it works in modern Ruby versions when the env is set globally, this inconsistency is especially odd. 

Anyway: I figure it's worth having this PR around for now, and the CI wrangling can be sorted another time.