### PR TITLE
Ruby 3.2 deprecates `double_heap` option to `GC.verify_compaction_references`

### DIFF
--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -9,7 +9,11 @@ DatabaseCredentials = YAML.load_file('spec/configuration.yml')
 if GC.respond_to?(:verify_compaction_references)
   # This method was added in Ruby 3.0.0. Calling it this way asks the GC to
   # move objects around, helping to find object movement bugs.
-  GC.verify_compaction_references(double_heap: true, toward: :empty)
+  if RUBY_VERSION >= "3.2"
+    GC.verify_compaction_references(expand_heap: true, toward: :empty)
+  else
+    GC.verify_compaction_references(double_heap: true, toward: :empty)
+  end
 end
 
 RSpec.configure do |config|


### PR DESCRIPTION
This commit uses newly supported `expand_heap` option if Ruby version is 3.2 or higher.

- Warning message fixed by this commit:
```ruby
$ bundle exec rake spec
... snip ...
<internal:gc>:286: warning: double_heap is deprecated, please use expand_heap instead
... snip ...
```

Refer to https://github.com/ruby/ruby/commit/a6dd859affc42b667279e513bb94fb75cfb133c1