### PR TITLE
Add bigdecimal to runtime dependencies

### DIFF
--- a/mysql2.gemspec
+++ b/mysql2.gemspec
@@ -22,4 +22,6 @@ Mysql2::GEMSPEC = Gem::Specification.new do |s|
   s.files = `git ls-files README.md CHANGELOG.md LICENSE ext lib support`.split
 
   s.metadata['msys2_mingw_dependencies'] = 'libmariadbclient'
+
+  s.add_runtime_dependency 'bigdecimal'
 end


### PR DESCRIPTION
Ruby 3.4 will promote bigdecimal gem to a bundled gem in order to improve maintenancebility. To migrate to Ruby 3.4 easily, Ruby 3.3 warns a use of bigdecimal if it's not added to dependencies.

> /build/lib/mysql2.rb:2: warning: bigdecimal was loaded from the standard library, but will no longer be part of the default gems since Ruby 3.4.0. Add bigdecimal to your Gemfile or gemspec.

https://github.com/brianmario/mysql2/actions/runs/8972155446/job/24639503831#step:4:238

So this patch adds bigdecimal to runtime dependencies.

I know bigdecimal is not always necessary, but I'd like to prevent a lot of users from adding the gem to their Gemfile manually.

Ref. https://bugs.ruby-lang.org/issues/20187
Slides from RubyKaigi 2024: https://speakerdeck.com/andpad/long-journey-of-ruby-standard-library-rubykaigi-2024