### PR TITLE
Support get_server_public_key option 

### DIFF
--- a/README.md
+++ b/README.md
@@ -281,6 +281,7 @@ Mysql2::Client.new(
   :reconnect = true/false,
   :local_infile = true/false,
   :secure_auth = true/false,
+  :get_server_public_key = true/false,
   :default_file = '/path/to/my.cfg',
   :default_group = 'my.cfg section',
   :default_auth = 'authentication_windows_client'

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -996,6 +996,13 @@ static VALUE _mysql_client_options(VALUE self, int opt, VALUE value) {
       retval  = charval;
       break;
 
+#ifdef HAVE_CONST_MYSQL_OPT_GET_SERVER_PUBLIC_KEY
+    case MYSQL_OPT_GET_SERVER_PUBLIC_KEY:
+      boolval = (value == Qfalse ? 0 : 1);
+      retval = &boolval;
+      break;
+#endif
+
 #ifdef HAVE_MYSQL_DEFAULT_AUTH
     case MYSQL_DEFAULT_AUTH:
       charval = (const char *)StringValueCStr(value);
@@ -1485,6 +1492,14 @@ static VALUE set_init_command(VALUE self, VALUE value) {
   return _mysql_client_options(self, MYSQL_INIT_COMMAND, value);
 }
 
+static VALUE set_get_server_public_key(VALUE self, VALUE value) {
+#ifdef HAVE_CONST_MYSQL_OPT_GET_SERVER_PUBLIC_KEY
+  return _mysql_client_options(self, MYSQL_OPT_GET_SERVER_PUBLIC_KEY, value);
+#else
+  return Qfalse;
+#endif
+}
+
 static VALUE set_default_auth(VALUE self, VALUE value) {
 #ifdef HAVE_MYSQL_DEFAULT_AUTH
   return _mysql_client_options(self, MYSQL_DEFAULT_AUTH, value);
@@ -1596,6 +1611,7 @@ void init_mysql2_client() {
   rb_define_private_method(cMysql2Client, "default_file=", set_read_default_file, 1);
   rb_define_private_method(cMysql2Client, "default_group=", set_read_default_group, 1);
   rb_define_private_method(cMysql2Client, "init_command=", set_init_command, 1);
+  rb_define_private_method(cMysql2Client, "get_server_public_key=", set_get_server_public_key, 1);
   rb_define_private_method(cMysql2Client, "default_auth=", set_default_auth, 1);
   rb_define_private_method(cMysql2Client, "ssl_set", set_ssl_options, 5);
   rb_define_private_method(cMysql2Client, "ssl_mode=", rb_set_ssl_mode_option, 1);

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1496,7 +1496,7 @@ static VALUE set_get_server_public_key(VALUE self, VALUE value) {
 #ifdef HAVE_CONST_MYSQL_OPT_GET_SERVER_PUBLIC_KEY
   return _mysql_client_options(self, MYSQL_OPT_GET_SERVER_PUBLIC_KEY, value);
 #else
-  return Qfalse;
+  rb_raise(cMysql2Error, "get-server-public-key is not available, you may need a newer MySQL client library");
 #endif
 }
 

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -159,6 +159,7 @@ have_const('SERVER_QUERY_NO_INDEX_USED', mysql_h)
 have_const('SERVER_QUERY_WAS_SLOW', mysql_h)
 have_const('MYSQL_OPTION_MULTI_STATEMENTS_ON', mysql_h)
 have_const('MYSQL_OPTION_MULTI_STATEMENTS_OFF', mysql_h)
+have_const('MYSQL_OPT_GET_SERVER_PUBLIC_KEY', mysql_h)
 
 # my_bool is replaced by C99 bool in MySQL 8.0, but we want
 # to retain compatibility with the typedef in earlier MySQLs.

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -32,11 +32,11 @@ module Mysql2
       opts[:connect_timeout] = 120 unless opts.key?(:connect_timeout)
 
       # TODO: stricter validation rather than silent massaging
-      %i[reconnect connect_timeout local_infile read_timeout write_timeout default_file default_group secure_auth init_command automatic_close enable_cleartext_plugin default_auth].each do |key|
+      %i[reconnect connect_timeout local_infile read_timeout write_timeout default_file default_group secure_auth init_command automatic_close enable_cleartext_plugin default_auth get_server_public_key].each do |key|
         next unless opts.key?(key)
 
         case key
-        when :reconnect, :local_infile, :secure_auth, :automatic_close, :enable_cleartext_plugin
+        when :reconnect, :local_infile, :secure_auth, :automatic_close, :enable_cleartext_plugin, :get_server_public_key
           send(:"#{key}=", !!opts[key]) # rubocop:disable Style/DoubleNegation
         when :connect_timeout, :read_timeout, :write_timeout
           send(:"#{key}=", Integer(opts[key])) unless opts[key].nil?


### PR DESCRIPTION
# What

This PR fixes below MySQL authentication error with SSL-disabled connection.
```
Mysql2::Error: Authentication plugin 'caching_sha2_password' reported error: 
Authentication requires secure connection.
```

# Background

This error only happen in case of first authentication under cleartext TCP connection. `caching_sha2_password` authentication requires a secure connection at first authentication for each users. The first authentication means that the cache is not ready yet at server-side. The reason why secure connection is required is that MySQL server need to know user password to create cache.  After the cache is created, MySQL server does not request secure connection anymore. Please refer to the MySQL manual to know details.

> For each user account, the first client connection for the user after any of the following operations must use a secure connection (made using TCP using TLS credentials, a Unix socket file, or shared memory) or RSA key pair-based password exchange: 
https://dev.mysql.com/doc/refman/8.0/en/caching-sha2-pluggable-authentication.html

`libmysqlclient` provides MYSQL_OPT_GET_SERVER_PUBLIC_KEY option which enables clients to create a requested secure connection automatically during authentication. This PR carries it to mysql2.

# Sample code


```
require 'mysql2'

port     = 3306
hostname = 'hostname'
username = 'user'
password = 'password'

# connect with SSL to issue FLUSH PRIVILEGES
client = Mysql2::Client.new(:host => hostname, :port => port, :username => username, :password => password, :ssl_mode => :required)

# force clear cache
client.query("FLUSH PRIVILEGES")

print "# without get_server_public_key\n"
# this returns Authentication requires secure connection.
begin
  client = Mysql2::Client.new(:host => hostname, :port => port, :username => username, :password => password, :ssl_mode => :disabled)
rescue => e
  printf("connect ng %s\n", e)
end

print "# with get_server_public_key\n"
begin
  client = Mysql2::Client.new(:host => hostname, :port => port, :username => username, :password => password, :ssl_mode => :disabled, :get_server_public_key => true)
  print "connect ok\n"
rescue => e
  printf("connect ng %s\n", e)
end
```

```
$ ruby ../test2.rb
# without get_server_public_key
connect ng Authentication plugin 'caching_sha2_password' reported error: Authentication requires secure connection.
# with get_server_public_key
connect ok
```