### PR TITLE
Improve prepared statement ergonomics

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -17,7 +17,8 @@ group :test do
   gem 'rspec', '~> 3.2'
 
   # https://github.com/bbatsov/rubocop/pull/4789
-  gem 'rubocop', '~> 1.30', '>= 1.30.1' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6')
+  # 1.51 is the last version supporting Ruby 2.6
+  gem 'rubocop', '>= 1.30.1', '< 1.51' if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('2.6')
 end
 
 group :benchmarks, optional: true do

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -1,6 +1,6 @@
 require './spec/spec_helper'
 
-RSpec.describe Mysql2::Statement do
+RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
   before(:example) do
     @client = new_client(encoding: "utf8")
   end
@@ -319,8 +319,8 @@ RSpec.describe Mysql2::Statement do
     it "should throw an exception if we try to iterate twice when streaming is enabled" do
       result = @client.prepare("SELECT 1 UNION SELECT 2").execute(stream: true, cache_rows: false)
       expect do
-        result.each {}
-        result.each {}
+        result.to_a
+        result.to_a
       end.to raise_exception(Mysql2::Error)
     end
   end
@@ -719,6 +719,16 @@ RSpec.describe Mysql2::Statement do
       stmt = @client.prepare 'SELECT 1'
       stmt.close
       expect { stmt.execute }.to raise_error(Mysql2::Error, /Invalid statement handle/)
+    end
+
+    it 'should not raise if called multiple times' do
+      stmt = @client.prepare 'SELECT 1'
+      expect(stmt).to_not be_closed
+
+      3.times do
+        expect { stmt.close }.to_not raise_error
+        expect(stmt).to be_closed
+      end
     end
   end
 end


### PR DESCRIPTION
While working on Mysql2 prepared statement support in Rails, I found them very hard to use. Most notably we sometimes need to close them eagerly, but it's complicated by the fact that you can only call `close` once, any subsequent call raises an error instead of just nooping.

There's also no way to check if a statement was closed or not.

cc @sodabrew @tenderlove 