### PR TITLE
rb_mysql_result_free_result is now executed if the result is 0 rows.

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1015,7 +1015,7 @@ static VALUE rb_mysql_result_each_(VALUE self,
       rb_raise(cMysql2Error, "You have already fetched all the rows for this query and streaming is true. (to reiterate you must requery).");
     }
   } else {
-    if (args->cacheRows && wrapper->lastRowProcessed == wrapper->numberOfRows) {
+    if (args->cacheRows && wrapper->resultFreed) {
       /* we've already read the entire dataset from the C result into our */
       /* internal array. Lets hand that over to the user since it's ready to go */
       for (i = 0; i < wrapper->numberOfRows; i++) {


### PR DESCRIPTION
Fix #1398

When there are 0 rows in the result, the condition to load the cache from the beginning ( `lastRowProcessed == numberOfRows`) is met, and the else route is not entered. Because of this, `rb_mysql_result_free_result` is not called.
To resolve this, the else route is always entered first.