### PR TITLE
Correct MariaDB runtime library verison check

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -48,9 +48,12 @@ static ID intern_brackets, intern_merge, intern_merge_bang, intern_new_with_args
  * compatibility with mysql-connector-c, where LIBMYSQL_VERSION is the correct
  * variable to use, but MYSQL_SERVER_VERSION gives the correct numbers when
  * linking against the server itself
+ *
+ * MariaDB exposes its client version independently to the server version as
+ * MARIADB_PACKAGE_VERSION.
  */
-#if defined(MARIADB_CLIENT_VERSION_STR)
-  #define MYSQL_LINK_VERSION MARIADB_CLIENT_VERSION_STR
+#if defined(MARIADB_PACKAGE_VERSION)
+  #define MYSQL_LINK_VERSION MARIADB_PACKAGE_VERSION
 #elif defined(LIBMYSQL_VERSION)
   #define MYSQL_LINK_VERSION LIBMYSQL_VERSION
 #else


### PR DESCRIPTION
The MariaDB C/C version used by mysql_get_client_info() version is different from the server version exposed as MARIADB_CLIENT_VERSION_STR. The correct C/C version will be MARIADB_PACKAGE_VERSION.

Fixes #1391.