### PR TITLE
Fix prepared statements + 0 rows + fields segfault

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1015,7 +1015,7 @@ static VALUE rb_mysql_result_each_(VALUE self,
       rb_raise(cMysql2Error, "You have already fetched all the rows for this query and streaming is true. (to reiterate you must requery).");
     }
   } else {
-    if (args->cacheRows && wrapper->resultFreed) {
+    if (args->cacheRows && wrapper->lastRowProcessed == wrapper->numberOfRows) {
       /* we've already read the entire dataset from the C result into our */
       /* internal array. Lets hand that over to the user since it's ready to go */
       for (i = 0; i < wrapper->numberOfRows; i++) {

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -192,6 +192,13 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
     expect(list[1]).to eq('2')
   end
 
+  it "should give us fields when no rows" do
+    statement = @client.prepare 'SELECT 1 FROM mysql2_test WHERE 1=0'
+    r = statement.execute
+    list = r.fields
+    expect(list.length).to eq(1)
+  end
+
   it "should handle as a decimal binding a BigDecimal" do
     stmt = @client.prepare('SELECT ? AS decimal_test')
     test_result = stmt.execute(BigDecimal("123.45")).first


### PR DESCRIPTION
Ref https://github.com/rails/rails/issues/55745

```
require "mysql2"

c = ::Mysql2::Client.new(database: "activerecord_unittest", username: "rails")
ps = c.prepare("SELECT * FROM products WHERE 1=0")
r = ps.execute
puts r.fields
```

This script (connection configured for the Rails repo, but unimportant) segfaults consistently on 0.5.7 but runs fine on 0.5.6. 

Reverting #1399 with no other changes fixes the segfault. I'm not sure if this is fully correct, but it doesn't crash.