### PR TITLE
Update `affected_rows` after calling `mysql_next_result`

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1282,6 +1282,7 @@ static VALUE rb_mysql_client_next_result(VALUE self)
     int ret;
     GET_CLIENT(self);
     ret = mysql_next_result(wrapper->client);
+    wrapper->affected_rows = mysql_affected_rows(wrapper->client);
     if (ret > 0) {
       rb_raise_mysql2_error(wrapper);
       return Qfalse;


### PR DESCRIPTION
Fix: https://github.com/brianmario/mysql2/issues/1411
Followup: https://github.com/brianmario/mysql2/pull/1383

When using multi statement, we need to update the affected rows after each call to `mysql_next_result`.