### PR TITLE
Fix segfault when accessing fields/field_types on freed result

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -939,6 +939,9 @@ static VALUE rb_mysql_result_fetch_fields(VALUE self) {
   }
 
   if (wrapper->fields == Qnil) {
+    if (wrapper->resultFreed) {
+      rb_raise(cMysql2Error, "Result set has already been freed");
+    }
     wrapper->numberOfFields = mysql_num_fields(wrapper->result);
     wrapper->fields = rb_ary_new2(wrapper->numberOfFields);
   }
@@ -958,6 +961,9 @@ static VALUE rb_mysql_result_fetch_field_types(VALUE self) {
   GET_RESULT(self);
 
   if (wrapper->fieldTypes == Qnil) {
+    if (wrapper->resultFreed) {
+      rb_raise(cMysql2Error, "Result set has already been freed");
+    }
     wrapper->numberOfFields = mysql_num_fields(wrapper->result);
     wrapper->fieldTypes = rb_ary_new2(wrapper->numberOfFields);
   }
@@ -1192,6 +1198,7 @@ VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_
   wrapper->lastRowProcessed = 0;
   wrapper->resultFreed = 0;
   wrapper->result = r;
+  wrapper->numberOfFields = 0;
   wrapper->fields = Qnil;
   wrapper->fieldTypes = Qnil;
   wrapper->rows = Qnil;
@@ -1220,6 +1227,14 @@ VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_
   /* Options that cannot be changed in results.each(...) { |row| }
    * should be processed here. */
   wrapper->is_streaming = (rb_hash_aref(options, sym_stream) == Qtrue ? 1 : 0);
+
+  /* Eagerly populate fields for non-streaming results to prevent
+   * segfault/error when accessing .fields on 0-row results that get freed
+   * after iteration completes but before .fields is accessed.
+   * See: https://github.com/brianmario/mysql2/issues/1426 */
+  if (r != NULL && !wrapper->is_streaming) {
+    rb_mysql_result_fetch_fields(obj);
+  }
 
   return obj;
 }

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1198,7 +1198,6 @@ VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_
   wrapper->lastRowProcessed = 0;
   wrapper->resultFreed = 0;
   wrapper->result = r;
-  wrapper->numberOfFields = 0;
   wrapper->fields = Qnil;
   wrapper->fieldTypes = Qnil;
   wrapper->rows = Qnil;


### PR DESCRIPTION
## Summary

Fixes segfault when accessing `.fields` or `.field_types` on a Result object after the internal result has been freed. This is particularly common with 0-row query results.

## Problem

A segfault occurs in the following sequence:
1. Query returns 0 rows
2. Internal row caching iterates (0 iterations), never populating `wrapper->fields`
3. Result is freed after iteration completes (0 processed == 0 total)
4. `.fields` is called, `wrapper->fields` is `Qnil`
5. `mysql_num_fields(wrapper->result)` accesses freed memory
6. **SEGFAULT**

## Fix

This PR includes two improvements:

### 1. Eager field population (primary fix)
Fields are now populated immediately when a result is created, before any iteration can free the result:

```c
// In rb_mysql_result_to_obj
if (r != NULL && !wrapper->is_streaming) {
  rb_mysql_result_fetch_fields(obj);
}
```

This prevents the problematic scenario from occurring at all.

### 2. Safety check (fallback)
The `resultFreed` check (which already exists in other functions like `rb_mysql_result_each_`) is now added to the fields accessor functions:

```c
if (wrapper->resultFreed) {
  rb_raise(cMysql2Error, "Result set has already been freed");
}
```

If an edge case still occurs, this raises a catchable Ruby exception instead of crashing the process.

## Testing

This fix has been tested in a production Rails 8.0 application where the segfault was occurring ~9 times per month during queries that return 0 rows. With the eager field population, the issue no longer occurs.

Fixes #1426