### PR TITLE
Fix use-after-free crash when close races with ping or query

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1,34 +1,3 @@
-/*
- * Thread safety in mysql2
- *
- * Three mechanisms protect against concurrent access to a MYSQL connection.
- * They guard against different failure modes at different layers and are
- * not interchangeable:
- *
- * 1. active_fiber (Ruby level, GVL held)
- *    Prevents two fibers or threads from starting operations on the same
- *    connection concurrently.  Checked before rb_thread_call_without_gvl.
- *    Raises a clear Ruby error ("This connection is in use by: ...") so
- *    users can fix connection pool misuse.  ping and close intentionally
- *    skip this check — ping is a lightweight health check and close must
- *    work regardless of connection state.
- *
- * 2. mutex (C level, no GVL — rb_nativethread_lock_t)
- *    Serializes nogvl_close with other nogvl_* functions that touch the
- *    MYSQL struct.  Prevents use-after-free when close races with an
- *    in-flight operation that has already released the GVL.  The
- *    active_fiber check cannot help here because it runs before the GVL
- *    is released, leaving a window between the check and the actual
- *    libmysql call.
- *
- * 3. refcount (GC lifecycle)
- *    Tracks how many Ruby objects (Client + its Result objects) reference
- *    the mysql_client_wrapper.  A Result increments the count; GC of the
- *    Result decrements it.  The wrapper (and MYSQL struct) is only freed
- *    when the count reaches zero, preventing a GC ordering issue where
- *    Client is collected before an outstanding Result.
- */
-
 #include <mysql2_ext.h>
 
 #include <time.h>
@@ -150,7 +119,6 @@ struct nogvl_send_query_args {
 struct nogvl_select_db_args {
   MYSQL *mysql;
   char *db;
-  mysql_client_wrapper *wrapper;
 };
 
 static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
@@ -391,14 +359,12 @@ static VALUE invalidate_fd(int clientfd)
 static void *nogvl_close(void *ptr) {
   mysql_client_wrapper *wrapper = ptr;
 
-  rb_native_mutex_lock(&wrapper->mutex);
   if (wrapper->initialized && !wrapper->closed) {
     mysql_close(wrapper->client);
     wrapper->closed = 1;
     wrapper->reconnect_enabled = 0;
     wrapper->active_fiber = Qnil;
   }
-  rb_native_mutex_unlock(&wrapper->mutex);
 
   return NULL;
 }
@@ -426,7 +392,6 @@ void decr_mysql2_client(mysql_client_wrapper *wrapper)
 #endif
 
     nogvl_close(wrapper);
-    rb_native_mutex_destroy(&wrapper->mutex);
     xfree(wrapper->client);
     xfree(wrapper);
   }
@@ -451,7 +416,6 @@ static VALUE allocate(VALUE klass) {
   wrapper->refcount = 1;
   wrapper->affected_rows = -1;
   wrapper->client = (MYSQL*)xmalloc(sizeof(MYSQL));
-  rb_native_mutex_initialize(&wrapper->mutex);
 
   return obj;
 }
@@ -634,13 +598,7 @@ static void *nogvl_send_query(void *ptr) {
   struct nogvl_send_query_args *args = ptr;
   int rv;
 
-  rb_native_mutex_lock(&args->wrapper->mutex);
-  if (args->wrapper->closed) {
-    rb_native_mutex_unlock(&args->wrapper->mutex);
-    return (void *)Qfalse;
-  }
   rv = mysql_send_query(args->mysql, args->sql_ptr, args->sql_len);
-  rb_native_mutex_unlock(&args->wrapper->mutex);
 
   return (void*)(rv == 0 ? Qtrue : Qfalse);
 }
@@ -662,16 +620,8 @@ static VALUE do_send_query(VALUE args) {
  * block while calling mysql_read_query_result
  */
 static void *nogvl_read_query_result(void *ptr) {
-  mysql_client_wrapper *wrapper = ptr;
-  my_bool res;
-
-  rb_native_mutex_lock(&wrapper->mutex);
-  if (wrapper->closed) {
-    rb_native_mutex_unlock(&wrapper->mutex);
-    return (void *)Qfalse;
-  }
-  res = mysql_read_query_result(wrapper->client);
-  rb_native_mutex_unlock(&wrapper->mutex);
+  MYSQL * client = ptr;
+  my_bool res = mysql_read_query_result(client);
 
   return (void *)(res == 0 ? Qtrue : Qfalse);
 }
@@ -679,13 +629,6 @@ static void *nogvl_read_query_result(void *ptr) {
 static void *nogvl_do_result(void *ptr, char use_result) {
   mysql_client_wrapper *wrapper = ptr;
   MYSQL_RES *result;
-
-  rb_native_mutex_lock(&wrapper->mutex);
-  if (wrapper->closed) {
-    wrapper->active_fiber = Qnil;
-    rb_native_mutex_unlock(&wrapper->mutex);
-    return NULL;
-  }
 
   if (use_result) {
     result = mysql_use_result(wrapper->client);
@@ -696,7 +639,6 @@ static void *nogvl_do_result(void *ptr, char use_result) {
   /* once our result is stored off, this connection is
      ready for another command to be issued */
   wrapper->active_fiber = Qnil;
-  rb_native_mutex_unlock(&wrapper->mutex);
 
   return result;
 }
@@ -726,7 +668,7 @@ static VALUE rb_mysql_client_async_result(VALUE self) {
     return Qnil;
 
   REQUIRE_CONNECTED(wrapper);
-  if ((VALUE)rb_thread_call_without_gvl(nogvl_read_query_result, wrapper, RUBY_UBF_IO, 0) == Qfalse) {
+  if ((VALUE)rb_thread_call_without_gvl(nogvl_read_query_result, wrapper->client, RUBY_UBF_IO, 0) == Qfalse) {
     /* an error occurred, mark this connection inactive */
     wrapper->active_fiber = Qnil;
     rb_raise_mysql2_error(wrapper);
@@ -1246,17 +1188,11 @@ static VALUE rb_mysql_client_thread_id(VALUE self) {
 
 static void *nogvl_select_db(void *ptr) {
   struct nogvl_select_db_args *args = ptr;
-  void *result;
 
-  rb_native_mutex_lock(&args->wrapper->mutex);
-  if (args->wrapper->closed) {
-    rb_native_mutex_unlock(&args->wrapper->mutex);
+  if (mysql_select_db(args->mysql, args->db) == 0)
+    return (void *)Qtrue;
+  else
     return (void *)Qfalse;
-  }
-  result = (mysql_select_db(args->mysql, args->db) == 0 ? (void *)Qtrue : (void *)Qfalse);
-  rb_native_mutex_unlock(&args->wrapper->mutex);
-
-  return result;
 }
 
 /* call-seq:
@@ -1274,7 +1210,6 @@ static VALUE rb_mysql_client_select_db(VALUE self, VALUE db)
 
   args.mysql = wrapper->client;
   args.db = StringValueCStr(db);
-  args.wrapper = wrapper;
 
   if (rb_thread_call_without_gvl(nogvl_select_db, &args, RUBY_UBF_IO, 0) == Qfalse)
     rb_raise_mysql2_error(wrapper);
@@ -1283,18 +1218,9 @@ static VALUE rb_mysql_client_select_db(VALUE self, VALUE db)
 }
 
 static void *nogvl_ping(void *ptr) {
-  mysql_client_wrapper *wrapper = ptr;
-  void *result;
+  MYSQL *client = ptr;
 
-  rb_native_mutex_lock(&wrapper->mutex);
-  if (wrapper->closed) {
-    rb_native_mutex_unlock(&wrapper->mutex);
-    return (void *)Qfalse;
-  }
-  result = (void *)(mysql_ping(wrapper->client) == 0 ? Qtrue : Qfalse);
-  rb_native_mutex_unlock(&wrapper->mutex);
-
-  return result;
+  return (void *)(mysql_ping(client) == 0 ? Qtrue : Qfalse);
 }
 
 /* call-seq:
@@ -1311,7 +1237,7 @@ static VALUE rb_mysql_client_ping(VALUE self) {
   if (!CONNECTED(wrapper)) {
     return Qfalse;
   } else {
-    return (VALUE)rb_thread_call_without_gvl(nogvl_ping, wrapper, RUBY_UBF_IO, 0);
+    return (VALUE)rb_thread_call_without_gvl(nogvl_ping, wrapper->client, RUBY_UBF_IO, 0);
   }
 }
 

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1,3 +1,48 @@
+/*
+ * Thread safety in mysql2
+ *
+ * Three mechanisms protect against concurrent access to a MYSQL connection.
+ * They guard against different failure modes at different layers and are
+ * not interchangeable:
+ *
+ * 1. active_fiber (Ruby level, GVL held)
+ *    Prevents two fibers or threads from starting operations on the same
+ *    connection concurrently.  Checked before rb_thread_call_without_gvl.
+ *    Raises a clear Ruby error ("This connection is in use by: ...") so
+ *    users can fix connection pool misuse.  ping returns false instead of
+ *    raising.  close intentionally skips this check — it must work
+ *    regardless of connection state.
+ *
+ * 2. closed flag + socket shutdown (C level)
+ *    rb_mysql_client_close checks active_fiber while holding the GVL.
+ *    If no operation is in-flight, it calls mysql_close directly for a
+ *    clean disconnect (COM_QUIT + free).  If an operation IS in-flight,
+ *    it calls nogvl_close which sets wrapper->closed and calls
+ *    shutdown(SHUT_RDWR) to interrupt the blocked I/O, deferring
+ *    mysql_close to decr_mysql2_client (refcount == 0).
+ *
+ *    If an in-flight nogvl_* function misses the closed flag (race),
+ *    the shutdown causes its I/O to fail with a socket error rather
+ *    than use-after-free.  REQUIRE_CONNECTED and closed? also check
+ *    the flag at Ruby level.
+ *
+ *    decr_mysql2_client does NOT call nogvl_close — it sets the closed
+ *    flag directly and lets mysql_close handle cleanup, so COM_QUIT can
+ *    be sent through the still-open socket during GC.
+ *
+ *    A native mutex is intentionally avoided here: if a thread holds such
+ *    a mutex at fork() time, the child inherits a permanently-locked mutex
+ *    (the owning thread does not survive fork), and any subsequent close
+ *    or GC in the child deadlocks.
+ *
+ * 3. refcount (GC lifecycle)
+ *    Tracks how many Ruby objects (Client + its Result objects) reference
+ *    the mysql_client_wrapper.  A Result increments the count; GC of the
+ *    Result decrements it.  The wrapper (and MYSQL struct) is only freed
+ *    when the count reaches zero, preventing a GC ordering issue where
+ *    Client is collected before an outstanding Result.
+ */
+
 #include <mysql2_ext.h>
 
 #include <time.h>
@@ -34,7 +79,7 @@ static ID intern_brackets, intern_merge, intern_merge_bang, intern_new_with_args
 
 #define REQUIRE_CONNECTED(wrapper) \
   REQUIRE_INITIALIZED(wrapper) \
-  if (!CONNECTED(wrapper) && !wrapper->reconnect_enabled) { \
+  if (wrapper->closed || (!CONNECTED(wrapper) && !wrapper->reconnect_enabled)) { \
     rb_raise(cMysql2Error, "MySQL client is not connected"); \
   }
 
@@ -360,10 +405,27 @@ static void *nogvl_close(void *ptr) {
   mysql_client_wrapper *wrapper = ptr;
 
   if (wrapper->initialized && !wrapper->closed) {
-    mysql_close(wrapper->client);
     wrapper->closed = 1;
     wrapper->reconnect_enabled = 0;
     wrapper->active_fiber = Qnil;
+
+    /* Shut down the socket to interrupt any in-flight operations on other
+     * threads.  shutdown() is thread-safe with concurrent send()/recv() —
+     * it causes them to fail with a socket error rather than risk
+     * use-after-free.  We intentionally do NOT call mysql_close() here
+     * because it frees the MYSQL struct internals; an in-flight libmysql
+     * call on another thread may still be reading them.  The actual
+     * mysql_close() is deferred to decr_mysql2_client (refcount == 0),
+     * where no concurrent access is possible.
+     */
+#ifndef _WIN32
+    {
+      int fd = wrapper->client->net.fd;
+      if (fd >= 0) {
+        shutdown(fd, SHUT_RDWR);
+      }
+    }
+#endif
   }
 
   return NULL;
@@ -391,7 +453,20 @@ void decr_mysql2_client(mysql_client_wrapper *wrapper)
     }
 #endif
 
-    nogvl_close(wrapper);
+    /* Set closed state directly — don't call nogvl_close (which would
+     * shutdown the socket before mysql_close can send COM_QUIT).
+     * Refcount == 0 guarantees no concurrent access.
+     */
+    if (!wrapper->closed) {
+      wrapper->closed = 1;
+      wrapper->reconnect_enabled = 0;
+      wrapper->active_fiber = Qnil;
+    }
+
+    if (wrapper->initialized) {
+      mysql_close(wrapper->client);
+    }
+
     xfree(wrapper->client);
     xfree(wrapper);
   }
@@ -572,8 +647,25 @@ static VALUE rb_mysql_connect(VALUE self, VALUE user, VALUE pass, VALUE host, VA
 static VALUE rb_mysql_client_close(VALUE self) {
   GET_CLIENT(self);
 
-  if (wrapper->client) {
-    rb_thread_call_without_gvl(nogvl_close, wrapper, RUBY_UBF_IO, 0);
+  if (wrapper->client && !wrapper->closed) {
+    if (NIL_P(wrapper->active_fiber)) {
+      /* No operation in-flight.  We hold the GVL so no new operation can
+       * start (REQUIRE_CONNECTED / set_active_fiber both need the GVL).
+       * It is safe to call mysql_close which sends COM_QUIT and frees
+       * the connection cleanly.  Mark initialized=0 so decr_mysql2_client
+       * won't call mysql_close a second time. */
+      wrapper->closed = 1;
+      wrapper->reconnect_enabled = 0;
+      wrapper->active_fiber = Qnil;
+      mysql_close(wrapper->client);
+      wrapper->initialized = 0;
+    } else {
+      /* An operation is in-flight on another thread (without the GVL).
+       * Use nogvl_close to set the closed flag and shutdown the socket,
+       * interrupting the in-flight operation.  mysql_close is deferred
+       * to decr_mysql2_client (refcount == 0). */
+      rb_thread_call_without_gvl(nogvl_close, wrapper, RUBY_UBF_IO, 0);
+    }
   }
 
   return Qnil;
@@ -586,7 +678,7 @@ static VALUE rb_mysql_client_close(VALUE self) {
  */
 static VALUE rb_mysql_client_closed(VALUE self) {
   GET_CLIENT(self);
-  return CONNECTED(wrapper) ? Qfalse : Qtrue;
+  return (wrapper->closed || !CONNECTED(wrapper)) ? Qtrue : Qfalse;
 }
 
 /*
@@ -1234,11 +1326,18 @@ static void *nogvl_ping(void *ptr) {
 static VALUE rb_mysql_client_ping(VALUE self) {
   GET_CLIENT(self);
 
-  if (!CONNECTED(wrapper)) {
+  if (wrapper->closed || !CONNECTED(wrapper)) {
     return Qfalse;
-  } else {
-    return (VALUE)rb_thread_call_without_gvl(nogvl_ping, wrapper->client, RUBY_UBF_IO, 0);
   }
+  if (!NIL_P(wrapper->active_fiber)) {
+    return Qfalse;
+  }
+
+  wrapper->active_fiber = rb_fiber_current();
+  VALUE result = (VALUE)rb_thread_call_without_gvl(nogvl_ping, wrapper->client, RUBY_UBF_IO, 0);
+  wrapper->active_fiber = Qnil;
+
+  return result;
 }
 
 /* call-seq:

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1,3 +1,34 @@
+/*
+ * Thread safety in mysql2
+ *
+ * Three mechanisms protect against concurrent access to a MYSQL connection.
+ * They guard against different failure modes at different layers and are
+ * not interchangeable:
+ *
+ * 1. active_fiber (Ruby level, GVL held)
+ *    Prevents two fibers or threads from starting operations on the same
+ *    connection concurrently.  Checked before rb_thread_call_without_gvl.
+ *    Raises a clear Ruby error ("This connection is in use by: ...") so
+ *    users can fix connection pool misuse.  ping and close intentionally
+ *    skip this check — ping is a lightweight health check and close must
+ *    work regardless of connection state.
+ *
+ * 2. mutex (C level, no GVL — rb_nativethread_lock_t)
+ *    Serializes nogvl_close with other nogvl_* functions that touch the
+ *    MYSQL struct.  Prevents use-after-free when close races with an
+ *    in-flight operation that has already released the GVL.  The
+ *    active_fiber check cannot help here because it runs before the GVL
+ *    is released, leaving a window between the check and the actual
+ *    libmysql call.
+ *
+ * 3. refcount (GC lifecycle)
+ *    Tracks how many Ruby objects (Client + its Result objects) reference
+ *    the mysql_client_wrapper.  A Result increments the count; GC of the
+ *    Result decrements it.  The wrapper (and MYSQL struct) is only freed
+ *    when the count reaches zero, preventing a GC ordering issue where
+ *    Client is collected before an outstanding Result.
+ */
+
 #include <mysql2_ext.h>
 
 #include <time.h>

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -119,6 +119,7 @@ struct nogvl_send_query_args {
 struct nogvl_select_db_args {
   MYSQL *mysql;
   char *db;
+  mysql_client_wrapper *wrapper;
 };
 
 static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
@@ -359,12 +360,14 @@ static VALUE invalidate_fd(int clientfd)
 static void *nogvl_close(void *ptr) {
   mysql_client_wrapper *wrapper = ptr;
 
+  rb_native_mutex_lock(&wrapper->mutex);
   if (wrapper->initialized && !wrapper->closed) {
     mysql_close(wrapper->client);
     wrapper->closed = 1;
     wrapper->reconnect_enabled = 0;
     wrapper->active_fiber = Qnil;
   }
+  rb_native_mutex_unlock(&wrapper->mutex);
 
   return NULL;
 }
@@ -392,6 +395,7 @@ void decr_mysql2_client(mysql_client_wrapper *wrapper)
 #endif
 
     nogvl_close(wrapper);
+    rb_native_mutex_destroy(&wrapper->mutex);
     xfree(wrapper->client);
     xfree(wrapper);
   }
@@ -416,6 +420,7 @@ static VALUE allocate(VALUE klass) {
   wrapper->refcount = 1;
   wrapper->affected_rows = -1;
   wrapper->client = (MYSQL*)xmalloc(sizeof(MYSQL));
+  rb_native_mutex_initialize(&wrapper->mutex);
 
   return obj;
 }
@@ -598,7 +603,13 @@ static void *nogvl_send_query(void *ptr) {
   struct nogvl_send_query_args *args = ptr;
   int rv;
 
+  rb_native_mutex_lock(&args->wrapper->mutex);
+  if (args->wrapper->closed) {
+    rb_native_mutex_unlock(&args->wrapper->mutex);
+    return (void *)Qfalse;
+  }
   rv = mysql_send_query(args->mysql, args->sql_ptr, args->sql_len);
+  rb_native_mutex_unlock(&args->wrapper->mutex);
 
   return (void*)(rv == 0 ? Qtrue : Qfalse);
 }
@@ -620,8 +631,16 @@ static VALUE do_send_query(VALUE args) {
  * block while calling mysql_read_query_result
  */
 static void *nogvl_read_query_result(void *ptr) {
-  MYSQL * client = ptr;
-  my_bool res = mysql_read_query_result(client);
+  mysql_client_wrapper *wrapper = ptr;
+  my_bool res;
+
+  rb_native_mutex_lock(&wrapper->mutex);
+  if (wrapper->closed) {
+    rb_native_mutex_unlock(&wrapper->mutex);
+    return (void *)Qfalse;
+  }
+  res = mysql_read_query_result(wrapper->client);
+  rb_native_mutex_unlock(&wrapper->mutex);
 
   return (void *)(res == 0 ? Qtrue : Qfalse);
 }
@@ -629,6 +648,13 @@ static void *nogvl_read_query_result(void *ptr) {
 static void *nogvl_do_result(void *ptr, char use_result) {
   mysql_client_wrapper *wrapper = ptr;
   MYSQL_RES *result;
+
+  rb_native_mutex_lock(&wrapper->mutex);
+  if (wrapper->closed) {
+    wrapper->active_fiber = Qnil;
+    rb_native_mutex_unlock(&wrapper->mutex);
+    return NULL;
+  }
 
   if (use_result) {
     result = mysql_use_result(wrapper->client);
@@ -639,6 +665,7 @@ static void *nogvl_do_result(void *ptr, char use_result) {
   /* once our result is stored off, this connection is
      ready for another command to be issued */
   wrapper->active_fiber = Qnil;
+  rb_native_mutex_unlock(&wrapper->mutex);
 
   return result;
 }
@@ -668,7 +695,7 @@ static VALUE rb_mysql_client_async_result(VALUE self) {
     return Qnil;
 
   REQUIRE_CONNECTED(wrapper);
-  if ((VALUE)rb_thread_call_without_gvl(nogvl_read_query_result, wrapper->client, RUBY_UBF_IO, 0) == Qfalse) {
+  if ((VALUE)rb_thread_call_without_gvl(nogvl_read_query_result, wrapper, RUBY_UBF_IO, 0) == Qfalse) {
     /* an error occurred, mark this connection inactive */
     wrapper->active_fiber = Qnil;
     rb_raise_mysql2_error(wrapper);
@@ -1188,11 +1215,17 @@ static VALUE rb_mysql_client_thread_id(VALUE self) {
 
 static void *nogvl_select_db(void *ptr) {
   struct nogvl_select_db_args *args = ptr;
+  void *result;
 
-  if (mysql_select_db(args->mysql, args->db) == 0)
-    return (void *)Qtrue;
-  else
+  rb_native_mutex_lock(&args->wrapper->mutex);
+  if (args->wrapper->closed) {
+    rb_native_mutex_unlock(&args->wrapper->mutex);
     return (void *)Qfalse;
+  }
+  result = (mysql_select_db(args->mysql, args->db) == 0 ? (void *)Qtrue : (void *)Qfalse);
+  rb_native_mutex_unlock(&args->wrapper->mutex);
+
+  return result;
 }
 
 /* call-seq:
@@ -1210,6 +1243,7 @@ static VALUE rb_mysql_client_select_db(VALUE self, VALUE db)
 
   args.mysql = wrapper->client;
   args.db = StringValueCStr(db);
+  args.wrapper = wrapper;
 
   if (rb_thread_call_without_gvl(nogvl_select_db, &args, RUBY_UBF_IO, 0) == Qfalse)
     rb_raise_mysql2_error(wrapper);
@@ -1218,9 +1252,18 @@ static VALUE rb_mysql_client_select_db(VALUE self, VALUE db)
 }
 
 static void *nogvl_ping(void *ptr) {
-  MYSQL *client = ptr;
+  mysql_client_wrapper *wrapper = ptr;
+  void *result;
 
-  return (void *)(mysql_ping(client) == 0 ? Qtrue : Qfalse);
+  rb_native_mutex_lock(&wrapper->mutex);
+  if (wrapper->closed) {
+    rb_native_mutex_unlock(&wrapper->mutex);
+    return (void *)Qfalse;
+  }
+  result = (void *)(mysql_ping(wrapper->client) == 0 ? Qtrue : Qfalse);
+  rb_native_mutex_unlock(&wrapper->mutex);
+
+  return result;
 }
 
 /* call-seq:
@@ -1237,7 +1280,7 @@ static VALUE rb_mysql_client_ping(VALUE self) {
   if (!CONNECTED(wrapper)) {
     return Qfalse;
   } else {
-    return (VALUE)rb_thread_call_without_gvl(nogvl_ping, wrapper->client, RUBY_UBF_IO, 0);
+    return (VALUE)rb_thread_call_without_gvl(nogvl_ping, wrapper, RUBY_UBF_IO, 0);
   }
 }
 

--- a/ext/mysql2/client.h
+++ b/ext/mysql2/client.h
@@ -1,6 +1,8 @@
 #ifndef MYSQL2_CLIENT_H
 #define MYSQL2_CLIENT_H
 
+#include <ruby/thread_native.h>
+
 typedef struct {
   VALUE encoding;
   VALUE active_fiber; /* rb_fiber_current() or Qnil */
@@ -14,6 +16,7 @@ typedef struct {
   int closed;
   uint64_t affected_rows;
   MYSQL *client;
+  rb_nativethread_lock_t mutex;
 } mysql_client_wrapper;
 
 void rb_mysql_set_server_query_flags(MYSQL *client, VALUE result);

--- a/ext/mysql2/client.h
+++ b/ext/mysql2/client.h
@@ -1,8 +1,6 @@
 #ifndef MYSQL2_CLIENT_H
 #define MYSQL2_CLIENT_H
 
-#include <ruby/thread_native.h>
-
 typedef struct {
   VALUE encoding;
   VALUE active_fiber; /* rb_fiber_current() or Qnil */
@@ -16,7 +14,6 @@ typedef struct {
   int closed;
   uint64_t affected_rows;
   MYSQL *client;
-  rb_nativethread_lock_t mutex;
 } mysql_client_wrapper;
 
 void rb_mysql_set_server_query_flags(MYSQL *client, VALUE result);

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -385,6 +385,24 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     end
   end
 
+  it "should not crash when ping and close are called concurrently" do
+    100.times do
+      client = new_client
+      thread = Thread.new { client.ping }
+      client.close
+      thread.join
+    end
+  end
+
+  it "should not crash when query and close are called concurrently" do
+    100.times do
+      client = new_client
+      thread = Thread.new { client.query("SELECT 1") rescue nil }
+      client.close
+      thread.join
+    end
+  end
+
   it "should not try to query closed mysql connection" do
     client = new_client(reconnect: true)
     expect(client.close).to be_nil

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -385,24 +385,6 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     end
   end
 
-  it "should not crash when ping and close are called concurrently" do
-    100.times do
-      client = new_client
-      thread = Thread.new { client.ping }
-      client.close
-      thread.join
-    end
-  end
-
-  it "should not crash when query and close are called concurrently" do
-    100.times do
-      client = new_client
-      thread = Thread.new { client.query("SELECT 1") rescue nil }
-      client.close
-      thread.join
-    end
-  end
-
   it "should not try to query closed mysql connection" do
     client = new_client(reconnect: true)
     expect(client.close).to be_nil

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -385,6 +385,77 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     end
   end
 
+  it "should not crash when ping and close are called concurrently" do
+    100.times do
+      client = new_client
+      thread = Thread.new { client.ping }
+      client.close
+      thread.join
+    end
+  end
+
+  it "should not crash when query and close are called concurrently" do
+    100.times do
+      client = new_client
+      thread = Thread.new { client.query("SELECT 1") rescue nil }
+      client.close
+      thread.join
+    end
+  end
+
+  it "should not deadlock when forking while a query is in-flight" do
+    skip "Fork not available" unless Process.respond_to?(:fork)
+
+    # The C extension must remain fork-safe. A naive approach using a native
+    # mutex (pthread_mutex_t) would deadlock in the child if the mutex was
+    # held at fork() time — the owning thread does not survive fork, leaving
+    # the mutex permanently locked. Instead the extension uses a closed flag
+    # + socket shutdown, which is safe across fork.
+    #
+    # A large result set keeps the connection busy during
+    # mysql_store_result for several milliseconds, making the race
+    # catchable. The sleep is varied each iteration so that fork() samples
+    # different phases of the query lifecycle.
+    large_result = "WITH RECURSIVE nums AS (SELECT 1 n UNION ALL SELECT n+1 FROM nums WHERE n < 1000) " \
+                   "SELECT REPEAT('x', 10000) AS data FROM nums"
+
+    50.times do |i|
+      client = Mysql2::Client.new(DatabaseCredentials['root'])
+
+      thread = Thread.new do
+        client.query(large_result) rescue nil
+      end
+
+      # Vary the timing so fork() lands in different phases of the query.
+      sleep(0.001 * (i % 5))
+
+      pid = fork do
+        client.close rescue nil
+        exit!(0)
+      end
+
+      # Deadlock means the child never exits. Poll with a timeout.
+      deadline = Process.clock_gettime(Process::CLOCK_MONOTONIC) + 5
+      status = nil
+      loop do
+        _, status = Process.waitpid2(pid, Process::WNOHANG)
+        break if status
+        if Process.clock_gettime(Process::CLOCK_MONOTONIC) > deadline
+          Process.kill(:KILL, pid)
+          Process.waitpid2(pid)
+          thread.join rescue nil
+          client.close rescue nil
+          raise "Child process deadlocked — likely mutex held at fork time"
+        end
+        sleep 0.05
+      end
+
+      thread.join rescue nil
+      client.close rescue nil
+      expect(status.exitstatus).to eq(0)
+    end
+  end
+
   it "should not try to query closed mysql connection" do
     client = new_client(reconnect: true)
     expect(client.close).to be_nil


### PR DESCRIPTION
## Summary

Fix a use-after-free crash when `close` is called from one thread while another thread is executing `ping`, `query`, or another operation without the GVL. Instead of calling `mysql_close` immediately (which frees the `MYSQL` struct while another thread is still using it), `close` now detects whether an operation is in-flight and takes one of two paths:

- **Idle** (no in-flight operation): call `mysql_close` directly while holding the GVL for a clean `COM_QUIT` disconnect.
- **Busy** (operation in-flight): set a `closed` flag and call `shutdown(SHUT_RDWR)` on the socket to interrupt the blocked I/O, then defer `mysql_close` to `decr_mysql2_client` (refcount == 0) where no concurrent access is possible.

**Reproducer:**
```ruby
client = Mysql2::Client.new(host: "127.0.0.1", port: 3306, username: "root")
Thread.new { client.ping }
client.close
```

This crashes with a segfault because both `nogvl_close` and `nogvl_ping` release Ruby's GVL via `rb_thread_call_without_gvl` and then call libmysql functions concurrently on the same `MYSQL *` connection. `mysql_close` frees internal state while `mysql_ping` is still accessing it.

## Why not a native mutex

A native mutex was considered but intentionally avoided: if a thread holds such a mutex at `fork()` time, the child inherits a permanently-locked mutex and any subsequent `close` or GC deadlocks. The flag + `shutdown()` approach avoids this problem entirely.

A Ruby-level `Mutex` was also [discussed and dismissed in #1284](https://github.com/brianmario/mysql2/pull/1284#issuecomment-1285657443) by @casperisfine, with valid arguments about method dispatch overhead, `Thread.handle_interrupt` handling, and behavioral changes.

## Why the connection pool cannot prevent this

The pool serializes *starting* operations at the Ruby level, but once two threads have each passed the Ruby-level checks (one doing `ping`, the other doing `close`), they are inside `rb_thread_call_without_gvl` concurrently. The pool has no visibility into that window.

## Changes

- Split `close` into idle/busy paths as described above
- Set `active_fiber` around `ping`'s `nogvl` call so `close` can detect in-flight pings
- Check `wrapper->closed` in `REQUIRE_CONNECTED`, `closed?`, and `ping` since `mysql_close` is now deferred and `CONNECTED()` remains true after `close`
- Add a doc comment to `client.c` explaining the three thread safety mechanisms (`active_fiber`, closed flag + shutdown, refcount)
- Add tests for concurrent close+ping, close+query, and fork safety

## Related issues

- #461 — "mysql2 doesn't seem to be threadsafe" — shows the exact crash pattern.
- #777 — `mysql_ping` crash with thread contention in Passenger.
- #983, #1019, #1282 — segfault reports likely caused by the same family of races.

## Test plan

- [x] Added specs for concurrent `ping`+`close`, `query`+`close`, and fork safety
- [ ] Existing test suite passes
- [ ] `rake spec:valgrind` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)