### PR TITLE
CI: upgrade actions/checkout to v6

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -62,7 +62,7 @@ jobs:
       HOMEBREW_NO_INSTALL_CLEANUP: 1
       HOMEBREW_NO_INSTALLED_DEPENDENTS_CHECK: 1
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - uses: ruby/setup-ruby@v1
         with:
           ruby-version: ${{ matrix.ruby }}

--- a/.github/workflows/container.yml
+++ b/.github/workflows/container.yml
@@ -21,7 +21,7 @@ jobs:
       # if any matrix job fails unlike Travis fast_finish.
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v6
       - run: docker build -t mysql2 -f ci/Dockerfile_${{ matrix.distro }} --build-arg IMAGE=${{ matrix.image }} .
       # Add the "--cap-add=... --security-opt seccomp=..." options
       # as a temporary workaround to avoid the following issue

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -8,7 +8,7 @@ jobs:
     env:
       BUNDLE_WITHOUT: development
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@v6
     - name: Set up Ruby 3.4
       uses: ruby/setup-ruby@v1
       with:


### PR DESCRIPTION
## Background
`actions/checkout@v3` runs on the Node.js 16 runtime, which has been deprecated by GitHub Actions. Newer versions use Node.js 20 (v4) and Node.js 24 (v5+). Bumping to v6 keeps the workflows on a supported runtime.

## Changes
- `.github/workflows/build.yml`: v3 → v6
- `.github/workflows/container.yml`: v3 → v6
- `.github/workflows/rubocop.yml`: v5 → v6