### PR TITLE
Remove rcov configuration and rake task

### DIFF
--- a/spec/rcov.opts
+++ b/spec/rcov.opts
@@ -1,3 +1,0 @@
---exclude spec,gem
---text-summary
---sort coverage --sort-reverse

--- a/tasks/rspec.rake
+++ b/tasks/rspec.rake
@@ -18,11 +18,6 @@ begin
     end
   end
 
-  desc "Run all examples with RCov"
-  RSpec::Core::RakeTask.new('spec:rcov') do |t|
-    t.rcov = true
-  end
-
   RSpec::Core::RakeTask.new('spec') do |t|
     t.verbose = true
   end


### PR DESCRIPTION
Remove `spec/rcov.opts` and the `spec:rcov` rake task.

`RSpec::Core::RakeTask#rcov=` was deprecated in RSpec 2.99 and removed in RSpec 3.
RCov itself is not listed in the Gemfile or gemspec, so these files have been unused.