### PR TITLE
Use numeric server version in invalid DATETIME specs

### DIFF
--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -404,7 +404,8 @@ RSpec.describe Mysql2::Result do
     end
 
     it "should raise an error given an invalid DATETIME" do
-      if @client.info[:version] < "8.0"
+      server_info = @client.server_info
+      if server_info[:version].include?('MariaDB') || server_info[:id] < 80000
         expect { @client.query("SELECT CAST('1972-00-27 00:00:00' AS DATETIME) as bad_datetime").each }.to \
           raise_error(Mysql2::Error, "Invalid date in field 'bad_datetime': 1972-00-27 00:00:00")
       else

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -482,7 +482,8 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
     end
 
     it "should raise an error given an invalid DATETIME" do
-      if @client.info[:version] < "8.0"
+      server_info = @client.server_info
+      if server_info[:version].include?('MariaDB') || server_info[:id] < 80000
         expect { @client.query("SELECT CAST('1972-00-27 00:00:00' AS DATETIME) as bad_datetime").each }.to \
           raise_error(Mysql2::Error, "Invalid date in field 'bad_datetime': 1972-00-27 00:00:00")
       else


### PR DESCRIPTION
Fix #1446

The "should raise an error given an invalid DATETIME" specs branched on `@client.info[:version] < "8.0"`, which is wrong in two ways:

1. **MySQL version schema change**: MySQL now uses calendar versioning (YY.M), so `"26.7.0"` compares lexicographically less than `"8.0"` and the specs take the pre-8.0 branch, expecting `Mysql2::Error` to be raised — but servers with 8.0+ behavior convert the invalid CAST to `NULL` instead, so nothing is raised. Comparing the numeric `server_info[:id]` (`8.0.0` => `80000`, `26.7.0` => `260700`) keeps the comparison correct for calendar versions.

2. **Server version, not client version**: whether the invalid CAST returns the invalid value (which makes mysql2 raise) or `NULL` (8.0+ behavior) is decided by the server, but `@client.info` is `mysql_get_client_info()` — the linked client library's version. It only worked because CI installs matching client and server versions. `server_info` reflects the actually connected server.

MariaDB (verified through 12.3) still returns the invalid value, so it stays in the raise branch regardless of its numeric version.

### References

- [A More Predictable MySQL Release Model: Calendar Versions, LTS, and Innovation](https://blogs.oracle.com/mysql/a-more-predictable-mysql-release-model-calendar-versions-lts-and-innovation)
- [MySQL Community Server 26.7 Early Access Release](https://blogs.oracle.com/mysql/mysql-community-server-26-7-early-access-release)

🤖 Generated with [Claude Code](https://claude.com/claude-code)