### PR TITLE
Use openssl@3 for the macOS Ruby 2.6 CI job

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
           # https://github.com/brianmario/mysql2/issues/1194
           - {os: macos-latest, ruby: '4.0', db: mariadb@11.4, ssl: openssl@3, allow-failure: true}
           - {os: macos-latest, ruby: '4.0', db: mysql@8.4, ssl: openssl@3, allow-failure: true}
-          - {os: macos-latest, ruby: '2.6', db: mysql@8.0, ssl: openssl@1.1, allow-failure: true}
+          - {os: macos-latest, ruby: '2.6', db: mysql@8.0, ssl: openssl@3, allow-failure: true}
 
       # On the fail-fast: true, it cancels all in-progress jobs
       # if any matrix job fails, which we don't want.


### PR DESCRIPTION
The `macos-latest ruby 2.6 mysql@8.0` job currently fails at `extconf.rb` because Homebrew has removed the `openssl@1.1` formula (OpenSSL 1.1.1 reached end of life in September 2023):

```
##[error]No available formula with the name "openssl@1.1". Did you mean openssl@3.5, openssl@3.0, openssl@4 or openssl@3?
```

Example failure: https://github.com/brianmario/mysql2/actions/runs/28774101830/job/85314025678 (also fails on master; the last green master build predates the formula removal).

The `mysql@8.0` Homebrew package itself links against `openssl@3` now, so build mysql2 against the same formula, matching the other two macOS jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)