### PR TITLE
Remove Appveyor CI badge from README [ci skip]

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,7 @@
 # Mysql2 - A modern, simple and very fast MySQL library for Ruby - binding to libmysql
 
-GitHub Actions
 [![GitHub Actions Status: Build](https://github.com/brianmario/mysql2/actions/workflows/build.yml/badge.svg)](https://github.com/brianmario/mysql2/actions/workflows/build.yml)
 [![GitHub Actions Status: Container](https://github.com/brianmario/mysql2/actions/workflows/container.yml/badge.svg)](https://github.com/brianmario/mysql2/actions/workflows/container.yml)
-Appveyor CI
-[![Appveyor CI Status](https://ci.appveyor.com/api/projects/status/github/sodabrew/mysql2)](https://ci.appveyor.com/project/sodabrew/mysql2)
 
 The Mysql2 gem is meant to serve the extremely common use-case of connecting, querying and iterating on results.
 Some database libraries out there serve as direct 1:1 mappings of the already complex C APIs available.


### PR DESCRIPTION
- appveyor.yml was deleted in 7be15fe ("No longer using this CI service.", Sep 2024), but the badge was left behind.
- The "GitHub Actions" label is dropped as well, since there is no longer a second CI service to distinguish it from.