### PR TITLE
Fix zero and partial-zero dates over the binary protocol

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -741,7 +741,16 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
         case MYSQL_TYPE_DATE:         // MYSQL_TIME
         case MYSQL_TYPE_NEWDATE:      // MYSQL_TIME
           ts = (MYSQL_TIME*)result_buffer->buffer;
-          val = rb_funcall(cDate, intern_new, 3, INT2NUM(ts->year), INT2NUM(ts->month), INT2NUM(ts->day));
+          /* Mirror the text-protocol semantics for zero and partial-zero
+           * dates: all-zero is nil, partial-zero raises Mysql2::Error. */
+          if (ts->year + ts->month + ts->day == 0) {
+            val = Qnil;
+          } else if (ts->month < 1 || ts->day < 1) {
+            rb_raise(cMysql2Error, "Invalid date in field '%.*s': %04u-%02u-%02u",
+                     (int)fields[i].name_length, fields[i].name, ts->year, ts->month, ts->day);
+          } else {
+            val = rb_funcall(cDate, intern_new, 3, INT2NUM(ts->year), INT2NUM(ts->month), INT2NUM(ts->day));
+          }
           break;
         case MYSQL_TYPE_TIME:         // MYSQL_TIME
           ts = (MYSQL_TIME*)result_buffer->buffer;
@@ -760,6 +769,17 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
 
           ts = (MYSQL_TIME*)result_buffer->buffer;
           seconds = (ts->year*31557600ULL) + (ts->month*2592000ULL) + (ts->day*86400ULL) + (ts->hour*3600ULL) + (ts->minute*60ULL) + ts->second;
+
+          /* Mirror the text-protocol semantics for zero and partial-zero
+           * datetimes (the text path computes the same seconds value and
+           * returns nil when it is 0, raises when month or day is 0). */
+          if (seconds == 0) {
+            val = Qnil;
+            break;
+          } else if (ts->month < 1 || ts->day < 1) {
+            rb_raise(cMysql2Error, "Invalid date in field '%.*s': %04u-%02u-%02u %02u:%02u:%02u",
+                     (int)fields[i].name_length, fields[i].name, ts->year, ts->month, ts->day, ts->hour, ts->minute, ts->second);
+          }
 
           if (seconds < MYSQL2_MIN_TIME || seconds > MYSQL2_MAX_TIME) { // use DateTime instead
             VALUE offset = INT2NUM(0);

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -509,6 +509,62 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
       expect(test_result['enum_test']).to eql('val1')
     end
 
+    context "zero and partial-zero dates" do
+      before do
+        @client.query("SET SESSION sql_mode = ''")
+        @client.query("DROP TABLE IF EXISTS mysql2_zero_dates")
+        @client.query("CREATE TABLE mysql2_zero_dates (d DATE, dt DATETIME, ts_test TIMESTAMP NULL)")
+        @client.query("INSERT INTO mysql2_zero_dates VALUES ('0000-00-00', '0000-00-00 00:00:00', '0000-00-00 00:00:00')")
+      end
+
+      after do
+        @client.query("DROP TABLE IF EXISTS mysql2_zero_dates")
+      end
+
+      it "returns nil for zero dates over the binary protocol, matching the text protocol" do
+        text_row = @client.query("SELECT * FROM mysql2_zero_dates").first
+        stmt_row = @client.prepare("SELECT * FROM mysql2_zero_dates").execute.first
+        expect(text_row).to eql("d" => nil, "dt" => nil, "ts_test" => nil)
+        expect(stmt_row).to eql(text_row)
+      end
+
+      it "raises Mysql2::Error for partial-zero DATETIME values over both protocols" do
+        @client.query("UPDATE mysql2_zero_dates SET dt = '1972-00-27 00:00:00'")
+        expect { @client.query("SELECT dt FROM mysql2_zero_dates").to_a }.to \
+          raise_error(Mysql2::Error, /Invalid date in field 'dt': 1972-00-27 00:00:00/)
+        expect { @client.prepare("SELECT dt FROM mysql2_zero_dates").execute.to_a }.to \
+          raise_error(Mysql2::Error, /Invalid date in field 'dt': 1972-00-27 00:00:00/)
+        # The binary path reports the same (aliased) field name the text path does.
+        expect { @client.prepare("SELECT dt AS aliased_dt FROM mysql2_zero_dates").execute.to_a }.to \
+          raise_error(Mysql2::Error, /Invalid date in field 'aliased_dt'/)
+      end
+
+      it "raises Mysql2::Error for partial-zero DATE values over both protocols" do
+        @client.query("UPDATE mysql2_zero_dates SET d = '1972-00-27'")
+        expect { @client.query("SELECT d FROM mysql2_zero_dates").to_a }.to \
+          raise_error(Mysql2::Error, /Invalid date in field 'd': 1972-00-27/)
+        expect { @client.prepare("SELECT d FROM mysql2_zero_dates").execute.to_a }.to \
+          raise_error(Mysql2::Error, /Invalid date in field 'd': 1972-00-27/)
+      end
+
+      it "keeps both protocols identical for invalid-but-storable dates under ALLOW_INVALID_DATES" do
+        @client.query("SET SESSION sql_mode = 'ALLOW_INVALID_DATES'")
+        @client.query("UPDATE mysql2_zero_dates SET d = '2004-04-31', dt = '2004-04-31 12:00:00'")
+        # DATE: Date.new rejects the invalid civil date on both paths. Matched
+        # as ArgumentError/"invalid date" rather than Date::Error, which is
+        # Ruby 3.0+ only; it subclasses ArgumentError and carries the same
+        # message, so this is exact on 3.x and still correct on 2.6.
+        expect { @client.query("SELECT d FROM mysql2_zero_dates").to_a }.to \
+          raise_error(ArgumentError, /invalid date/)
+        expect { @client.prepare("SELECT d FROM mysql2_zero_dates").execute.to_a }.to \
+          raise_error(ArgumentError, /invalid date/)
+        # DATETIME: Time normalizes the overflow identically on both paths.
+        text_val = @client.query("SELECT dt FROM mysql2_zero_dates").first["dt"]
+        stmt_val = @client.prepare("SELECT dt FROM mysql2_zero_dates").execute.first["dt"]
+        expect(stmt_val).to eql(text_val)
+      end
+    end
+
     it "should raise an error given an invalid DATETIME" do
       server_info = @client.server_info
       if server_info[:version].include?('MariaDB') || server_info[:id] < 80000


### PR DESCRIPTION
## Summary

A zero date (`'0000-00-00'` / `'0000-00-00 00:00:00'`, storable under permissive `sql_mode`) returns `nil` from `Client#query`, but raised `Date::Error` (`ArgumentError` on older Rubies) from `Statement#execute`, because the binary-protocol casting passed the zeroed `MYSQL_TIME` components straight to `Date.new` / `DateTime.civil`. Partial-zero values (`'1972-00-27'`) likewise raised `Date::Error` instead of the `Mysql2::Error` the text protocol raises.

This makes the prepared-statement path mirror the text-protocol semantics for zero and partial-zero values (other invalid-but-storable values already behave identically on both paths, since both construct through the same Ruby classes — verified and locked in by a spec for `ALLOW_INVALID_DATES` dates like `'2004-04-31'`, where both protocols raise `Date::Error` for DATE and both normalize identically for DATETIME):

| value | `Client#query` (unchanged) | `Statement#execute` before | `Statement#execute` after |
|---|---|---|---|
| `0000-00-00` (DATE) | `nil` | raises `Date::Error` | `nil` |
| `0000-00-00 00:00:00` (DATETIME/TIMESTAMP) | `nil` | raises `Date::Error` | `nil` |
| `1972-00-27` (partial zero) | raises `Mysql2::Error` | raises `Date::Error` | raises `Mysql2::Error`, same message format |

## Repro (against master)

```ruby
client.query("SET SESSION sql_mode = ''")
client.query("CREATE TABLE zd (dt DATETIME)")
client.query("INSERT INTO zd VALUES ('0000-00-00 00:00:00')")
client.query("SELECT * FROM zd").first          # => { "dt" => nil }
client.prepare("SELECT * FROM zd").execute.first # => Date::Error: invalid date
```

## Related issues and PRs

- Supersedes #1054 (credit @gentlawk for the original `seconds == 0` approach): this PR additionally covers `DATE`/`NEWDATE`, adds the partial-zero `Mysql2::Error` parity, and uses specs that still exercise on MySQL 8+ — `CAST('0000-00-00' AS DATETIME)` returns `NULL` on modern servers, so #1054's CAST-based specs no longer test the code path; these specs store real zero-date rows under `sql_mode=''`.
- Related to #963 (same `invalid date` error class from `Statement#execute`): I could not reproduce #963's exact UNION-of-valid-dates shape on MySQL 9.6.0 with a current client (it returns correct dates on unpatched master — that repro appears to have been client-era-specific). The zero-date case in this PR is the reproducible remaining instance of the error class.

A note on `MYSQL_TYPE_NEWDATE`: the C change covers it alongside `MYSQL_TYPE_DATE` for parity with the surrounding code, but current servers do not send `NEWDATE` in result metadata (it is an internal server type), so the specs exercise `DATE`/`DATETIME`/`TIMESTAMP`.

## Behavior change note

Code that relied on rescuing `Date::Error` from prepared-statement zero dates will now receive `nil` (matching `Client#query`) — that divergence is the bug being fixed.

## Testing

- Tested on: macOS 15 (Darwin 25.5.0), Apple Silicon (arm64), Ruby 3.3.11, MySQL Server 9.6.0, Oracle libmysqlclient 9.6 (Homebrew `mysql-client`).
- Full suite: 357 examples; the only 2 failures are the ones already present on master (the `symbolize_keys` / `field_types` pair that #1450 addresses) — none related to this change.
- Not tested here: Linux, Windows, MariaDB client/server, non-current Rubies. The change is pure C logic on `MYSQL_TIME` scalar fields with no new API usage, so the existing CI matrix should cover those.
- No new dependencies, no public API changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## CI note

All spec-job failures on this PR are the two failures already present on master (the `symbolize_keys` / `field_types` pair that #1450 addresses) — this PR's specs pass on every matrix platform (Ubuntu 22.04/24.04, macOS, Fedora, MySQL 8.0/8.4, MariaDB 10.11/11.4, Ruby 2.6 through 4.0/head). The build-job rubocop failure was a master-latent `Metrics/BlockLength` offense in `result_spec.rb` (a file this PR otherwise does not touch); the second commit silences it with the same inline-disable convention `statement_spec.rb` uses.