### PR TITLE
Mark Result's fieldTypes so the GC can see it

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -70,6 +70,7 @@ static void rb_mysql_result_mark(void * wrapper) {
   mysql2_result_wrapper * w = wrapper;
   if (w) {
     rb_gc_mark_movable(w->fields);
+    rb_gc_mark_movable(w->fieldTypes);
     rb_gc_mark_movable(w->rows);
     rb_gc_mark_movable(w->encoding);
     rb_gc_mark_movable(w->client);
@@ -152,6 +153,7 @@ static void rb_mysql_result_compact(void * wrapper) {
   mysql2_result_wrapper * w = wrapper;
   if (w) {
     rb_mysql2_gc_location(w->fields);
+    rb_mysql2_gc_location(w->fieldTypes);
     rb_mysql2_gc_location(w->rows);
     rb_mysql2_gc_location(w->encoding);
     rb_mysql2_gc_location(w->client);


### PR DESCRIPTION
`mysql2_result_wrapper` is xmalloc'd, so the collector neither scans it nor updates it — every `VALUE` in it has to be marked by hand. `fieldTypes` is declared in `result.h:9` but appears in neither `rb_mysql_result_mark` nor `rb_mysql_result_compact`, both of which handle exactly `fields`, `rows`, `encoding`, `client` and `statement`. Nothing else marks it, so nothing keeps the Array alive.

No compaction is involved — ordinary GC is enough.

## The window is inside the allocating call

This isn't "the Array is freed sometime later and a subsequent read is stale". It's freed during the call that creates it:

1. `rb_mysql_result_fetch_field_types` allocates the Array and stores it in `wrapper->fieldTypes`
2. the fill loop calls `rb_mysql_result_fetch_field_type` per column, which allocates Strings (`rb_sprintf` / `rb_str_new_cstr` / `rb_str_export_to_enc`) and can trigger a GC
3. `rb_ary_store(wrapper->fieldTypes, idx, ...)` then writes through a freed object slot

So the failure isn't only a bad read — step 3 is a write into whatever now occupies that slot.

## Reproducing

Public API only, no `Fiddle` and no raw memory access, so a crash can only come from the extension:

```ruby
require "mysql2"
client = Mysql2::Client.new(host: "127.0.0.1", username: "root")
res = client.query("select 1 as a, 'x' as b, 2.5 as c, now() as d")
GC.stress = true
types = res.field_types      # first-ever call on this Result
GC.stress = false
raise "not an Array: #{types.class}" unless types.is_a?(Array)
```

Built both trees inside the same step that ran the test, so the artifact can't drift from the source:

```
                     master     with this patch
GC.stress, 1 call    3/3 abort  3/3 pass
GC off (control)     3/3 pass   3/3 pass
```

`GC.stress` only makes it deterministic — it isn't required. Looping ordinary `field_types` calls with allocation churn between them and no stress, no `GC.start` and no compaction, master segfaults **within the first 25 calls, 5/5**, while the patched build completes 60,000 calls 3/3 (180,000 total). The exact rate depends on the surrounding allocation profile; a busy app supplies plenty.

## Affected

Present since `c3d1abc1e` (2020-03-16, #1068), which added `field_types` without extending the mark function. So 0.5.4, 0.5.5, 0.5.6, 0.5.7 and master. Tested against master `d4f8c13`, Ruby 4.0.6, MySQL 9.6.

## The patch

Two lines, matching the existing style in each function — `rb_gc_mark_movable` in the mark function and `rb_mysql2_gc_location` in the compact function, so `fieldTypes` stays movable like its five neighbours rather than being pinned.

Found while sweeping native gems for dangling `VALUE`s. Happy to add a regression test if you'd like one, though it needs `GC.stress` to be deterministic.