### PR TITLE
Add a regression spec for the GC window inside the first #field_types call

### DIFF
--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -95,6 +95,31 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
     expect(result.field_types).to eql(before_types)
   end
 
+  it "should keep field_types valid when GC runs during the first call" do
+    # The array is stored on the C struct before the fill loop runs, and that
+    # loop allocates a String per column, so a GC inside it can collect the
+    # still-unmarked array between the store and the rb_ary_store that follows.
+    # That window is a write into a freed slot, and it is inside the very first
+    # #field_types call -- the spec above only covers a stale read on a later
+    # one. Ordinary GC is enough here; compaction is not part of the mechanism.
+    # Reproduction from @jeremy (#1453). Three fresh results give three
+    # independent first-call windows: whether the dying array temporary is
+    # conservatively pinned on the C stack is compiler/layout luck, so one
+    # window could theoretically survive unpatched where another aborts.
+    3.times do
+      result = @client.query "SELECT 1 AS a, 'x' AS b, 2.5 AS c, NOW() AS d"
+      begin
+        GC.stress = true
+        types = result.field_types # first-ever call on this Result
+      ensure
+        GC.stress = false
+      end
+      expect(types).to be_an_instance_of(Array)
+      expect(types.length).to eql(4)
+      expect(types).to all(be_an_instance_of(String))
+    end
+  end
+
   it "should raise a Mysql2::Error exception upon a bad query" do
     expect do
       @client.query "bad sql"


### PR DESCRIPTION
Follow-up to #1453, which was merged while this spec was being added to it — the push and the merge crossed, so the spec landed on the branch a few hours after the branch had already gone in. The fix itself is in master; this PR carries only the regression spec.

It covers the window @jeremy described in https://github.com/brianmario/mysql2/pull/1453#issuecomment-5201239179 (and in #1454): `rb_mysql_result_fetch_field_types` stores the new Array on the wrapper and then runs a fill loop that allocates a String per column, so a GC inside that loop could collect the still-unmarked array between the store and the `rb_ary_store` that follows — a write through a freed object slot, inside the very first `#field_types` call. The pre-existing spec only covers a stale read on a *later* call. The test runs three fresh first-call windows under `GC.stress`, since whether the dying array temporary happens to be conservatively pinned on the C stack is compiler/layout luck, and asserts the contents as well as the shape.

Verified it bites: with the two `fieldTypes` mark/compact lines removed from current master, this spec aborts 3/3 with `[BUG] try to mark T_NONE object`; with master as-is it passes 3/3.

Tested on Ruby 3.3.10, MySQL 9.6.0 (Homebrew, libmysqlclient.24), macOS arm64. The full suite there is 366 examples with 3 failures that are identical on unpatched current master (`client_spec.rb:101`, `:729`, `:740` — the reconnect group). No dependency or code changes — one spec only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
