### PR TITLE
Only release the GVL for row fetches that can actually block

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,7 +39,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 143
+  Max: 144
 
 # Offense count: 3
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -50,6 +50,7 @@ typedef struct {
   int cacheRows;
   int cast;
   int streaming;
+  unsigned long rowsPerGvlYield;
   ID db_timezone;
   ID app_timezone;
   int block_given; /* boolean */
@@ -63,7 +64,7 @@ static ID intern_new, intern_utc, intern_local, intern_localtime, intern_local_o
   intern_query_options;
 static VALUE sym_symbolize_keys, sym_as, sym_array, sym_database_timezone,
   sym_application_timezone, sym_local, sym_utc, sym_cast_booleans,
-  sym_cache_rows, sym_cast, sym_stream, sym_name;
+  sym_cache_rows, sym_cast, sym_stream, sym_name, sym_rows_per_gvl_yield;
 
 /* Mark any VALUEs that are only referenced in C, so the GC won't get them. */
 static void rb_mysql_result_mark(void * wrapper) {
@@ -258,10 +259,27 @@ void mysql2_result_force_free(VALUE self) {
   wrapper->streamingComplete = 1;
 }
 
+/* Default for the :rows_per_gvl_yield query option: how many buffered rows to
+ * materialize between GVL yields. Empirical, not an alignment constant. 8192
+ * rows is 0.6-1.0ms of materialization on the shapes benchmarked, which keeps a
+ * thread waiting on the GVL from being blocked for a perceptible time while
+ * leaving the per-row handoff cost removed. The interval is a row count but the
+ * bound that matters is time, and time per row grows with row width, so a
+ * result whose rows are far wider than those shapes may want a lower value. */
+#define MYSQL2_ROWS_PER_GVL_YIELD_DEFAULT 8192
+
 /*
- * for small results, this won't hit the network, but there's no
- * reliable way for us to tell this so we'll always release the GVL
- * to be safe
+ * Only a streaming result can hit the network from a row fetch.
+ *
+ * A non-streaming result has already been drained into client memory by
+ * mysql_store_result (client.c) or mysql_stmt_store_result (statement.c), so
+ * fetching a row from it is pointer arithmetic over that buffer and cannot
+ * block. wrapper->is_streaming distinguishes the two reliably: mysql_use_result
+ * is only ever called when the query options say stream: true, and the same
+ * options hash is what sets wrapper->is_streaming.
+ *
+ * Releasing the GVL around a fetch that cannot block costs far more than the
+ * fetch itself, so the callers below only do it while streaming.
  */
 static void *nogvl_fetch_row(void *ptr) {
   MYSQL_RES *result = ptr;
@@ -736,7 +754,18 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
   }
 
   {
-    switch((uintptr_t)rb_thread_call_without_gvl(nogvl_stmt_fetch, wrapper->stmt_wrapper->stmt, RUBY_UBF_IO, 0)) {
+    uintptr_t fetch_result;
+    /* See the note above nogvl_fetch_row. A streaming result reads from the
+     * socket here, so the GVL is released around that call; a buffered one is
+     * already in client-library memory, so releasing costs more than the fetch.
+     * The release is kept as tight as possible around the client-library call
+     * because the GVL is required again immediately to build Ruby objects. */
+    if (wrapper->is_streaming) {
+      fetch_result = (uintptr_t)rb_thread_call_without_gvl(nogvl_stmt_fetch, wrapper->stmt_wrapper->stmt, RUBY_UBF_IO, 0);
+    } else {
+      fetch_result = (uintptr_t)nogvl_stmt_fetch(wrapper->stmt_wrapper->stmt);
+    }
+    switch(fetch_result) {
       case 0:
         /* success */
         break;
@@ -951,7 +980,16 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
   conn_enc = rb_to_encoding(wrapper->encoding);
 
   ptr = wrapper->result;
-  row = (MYSQL_ROW)rb_thread_call_without_gvl(nogvl_fetch_row, ptr, RUBY_UBF_IO, 0);
+  /* See the note above nogvl_fetch_row. A streaming result reads from the
+   * socket here, so the GVL is released around that call; a buffered one is
+   * already in client-library memory, so releasing costs more than the fetch.
+   * The release is kept as tight as possible around the client-library call
+   * because the GVL is required again immediately to build Ruby objects. */
+  if (wrapper->is_streaming) {
+    row = (MYSQL_ROW)rb_thread_call_without_gvl(nogvl_fetch_row, ptr, RUBY_UBF_IO, 0);
+  } else {
+    row = mysql_fetch_row(wrapper->result);
+  }
   if (row == NULL) {
     return Qnil;
   }
@@ -1319,6 +1357,7 @@ static VALUE rb_mysql_result_each_(VALUE self,
       }
     } else {
       unsigned long rowsProcessed = 0;
+      unsigned long rowsSinceYield = 0;
       rowsProcessed = RARRAY_LEN(wrapper->rows);
       fields = mysql_fetch_fields(wrapper->result);
 
@@ -1328,6 +1367,20 @@ static VALUE rb_mysql_result_each_(VALUE self,
           row = rb_ary_entry(wrapper->rows, i);
         } else {
           row = fetch_row_func(self, fields, args);
+
+          /* fetch_row_func is either rb_mysql_result_fetch_row or
+           * rb_mysql_result_fetch_row_stmt, which only need to hit the network
+           * when streaming. Buffered rows are already in memory owned by the
+           * MySQL/MariaDB client library. Those functions hold the GVL while in
+           * buffered mode as rows are quickly materialized into Ruby-space.
+           * Therefore call rb_thread_schedule every N rows to ensure that a very
+           * large result set does not starve out other threads. Only rows
+           * actually fetched are counted, so re-iterating a cached result does
+           * not add scheduling points. */
+          if (args->rowsPerGvlYield && ++rowsSinceYield >= args->rowsPerGvlYield) {
+            rowsSinceYield = 0;
+            rb_thread_schedule();
+          }
           if (args->cacheRows) {
             rb_ary_store(wrapper->rows, i, row);
           }
@@ -1363,6 +1416,8 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
   VALUE defaults, opts, (*fetch_row_func)(VALUE, MYSQL_FIELD *fields, const result_each_args *args);
   ID db_timezone, app_timezone, dbTz, appTz;
   int symbolizeKeys, asArray, castBool, cacheRows, cast;
+  unsigned long rowsPerGvlYield;
+  VALUE rowsPerGvlYieldOpt;
 
   GET_RESULT(self);
 
@@ -1386,6 +1441,17 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
   castBool      = RTEST(rb_hash_aref(opts, sym_cast_booleans));
   cacheRows     = RTEST(rb_hash_aref(opts, sym_cache_rows));
   cast          = RTEST(rb_hash_aref(opts, sym_cast));
+
+  /* :rows_per_gvl_yield -- 0 disables yielding; nil uses the default. */
+  rowsPerGvlYield = MYSQL2_ROWS_PER_GVL_YIELD_DEFAULT;
+  rowsPerGvlYieldOpt = rb_hash_aref(opts, sym_rows_per_gvl_yield);
+  if (!NIL_P(rowsPerGvlYieldOpt)) {
+    long requested = NUM2LONG(rowsPerGvlYieldOpt);
+    if (requested < 0) {
+      rb_raise(cMysql2Error, ":rows_per_gvl_yield must not be negative");
+    }
+    rowsPerGvlYield = (unsigned long)requested;
+  }
 
   if (wrapper->is_streaming && cacheRows) {
     rb_warn(":cache_rows is ignored if :stream is true");
@@ -1456,6 +1522,7 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
   args.asArray = asArray;
   args.castBool = castBool;
   args.cacheRows = cacheRows;
+  args.rowsPerGvlYield = rowsPerGvlYield;
   args.cast = cast;
   args.db_timezone = db_timezone;
   args.app_timezone = app_timezone;
@@ -1577,6 +1644,7 @@ void init_mysql2_result(void) {
   sym_database_timezone     = ID2SYM(rb_intern("database_timezone"));
   sym_application_timezone  = ID2SYM(rb_intern("application_timezone"));
   sym_cache_rows     = ID2SYM(rb_intern("cache_rows"));
+  sym_rows_per_gvl_yield = ID2SYM(rb_intern("rows_per_gvl_yield"));
   sym_cast           = ID2SYM(rb_intern("cast"));
   sym_stream         = ID2SYM(rb_intern("stream"));
   sym_name           = ID2SYM(rb_intern("name"));

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -11,6 +11,7 @@ module Mysql2
         database_timezone: :local,   # timezone Mysql2 will assume datetime objects are stored in
         application_timezone: nil,   # timezone Mysql2 will convert to before handing the object back to the caller
         cache_rows: true,            # tells Mysql2 to use its internal row cache for results
+        rows_per_gvl_yield: 8192,    # buffered rows to materialize between GVL yields; 0 disables yielding
         connect_flags: REMEMBER_OPTIONS | LONG_PASSWORD | LONG_FLAG | TRANSACTIONS | PROTOCOL_41 | SECURE_CONNECTION | CONNECT_ATTRS,
         cast: true,
         default_file: nil,

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -150,6 +150,24 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
   end
 
   context "#each" do
+    it "should return the same rows for any :rows_per_gvl_yield" do
+      # The option only changes how often rb_thread_schedule is called while
+      # materializing buffered rows, so every value must produce identical rows.
+      # How often other threads actually get scheduled is timing-dependent and
+      # deliberately not asserted here.
+      baseline = @client.query("SELECT 1 AS a UNION ALL SELECT 2 UNION ALL SELECT 3").to_a
+      [0, 1, 2, 8192].each do |n|
+        rows = @client.query("SELECT 1 AS a UNION ALL SELECT 2 UNION ALL SELECT 3",
+                             rows_per_gvl_yield: n,).to_a
+        expect(rows).to eql(baseline), ":rows_per_gvl_yield => #{n} changed the rows"
+      end
+    end
+
+    it "should reject a negative :rows_per_gvl_yield" do
+      expect { @client.query("SELECT 1", rows_per_gvl_yield: -1).to_a }.to \
+        raise_error(Mysql2::Error, /rows_per_gvl_yield/)
+    end
+
     it "should yield rows as hash's" do
       @result.each do |row|
         expect(row).to be_an_instance_of(Hash)


### PR DESCRIPTION
`rb_mysql_result_fetch_row` and `rb_mysql_result_fetch_row_stmt` release and
re-acquire the GVL around every single row, via `rb_thread_call_without_gvl`.

Profiling a 20,000-row query with macOS `sample` put 2,144 of 10,176 stack
samples inside that path -- and 2 in the actual `mysql_fetch_row`. The rest was
`setjmp` / `sigprocmask` / `__sigaltstack`: the cost of entering and leaving a
blocking region 20,000 times for a call that, on a buffered result, walks memory
the client library has already filled.

The comment above `nogvl_fetch_row` says there is "no reliable way for us to
tell" whether a fetch will hit the network. `wrapper->is_streaming` is that way:

  * client.c: `mysql_use_result` (unbuffered) is called in exactly one place,
    guarded by `stream == true` from `current_query_options`; every other path
    uses `mysql_store_result`. The same options hash is then duplicated into the
    Result, where it sets `wrapper->is_streaming`.
  * statement.c: `is_streaming` is read from the merged options hash, and
    `mysql_stmt_store_result` runs whenever it is false. That same hash is
    passed to `rb_mysql_result_to_obj`.

So `is_streaming == false` implies the rows are already in client memory. The
one asymmetry -- `Client#store_result` called while the options say
`stream: true` -- yields a buffered result that still reports as streaming, and
therefore still releases the GVL. That is the harmless direction.

Streaming results release the GVL exactly as before. Buffered results call
`mysql_fetch_row` / `nogvl_stmt_fetch` directly, and the buffered iteration loop
calls `rb_thread_schedule()` every 8192 rows instead.

The periodic yield is placed on the branch that actually fetches a row, so
re-iterating an already-cached result keeps its current scheduling behaviour,
and the streaming loop is untouched.

Holding the GVL across a fetch means other Ruby threads wait longer. With a
block, iteration returns to the VM each row and Ruby's ordinary preemption still
applies. Without a block the loop is pure C: nothing returns to the VM, so
without some yield the GVL would be held for the entire materialisation, and the
longest another thread could be kept waiting would grow with the result size
rather than being bounded. Measured that way -- a second thread looping on
`sleep 0.001`, longest interval it was kept off the GVL, query issued outside
the measured window, median of 3, cache_rows: false -- an earlier revision of this patch without
the periodic yield reached 269 ms at 1.6M rows and 286 ms at 3.2M and was still
climbing. Under a threaded server that is a real latency regression.

Hence the yield. With it, the same measurement no longer grows with result
size, staying a small bounded delay of the same order as master's:

| rows | | master | patch |
|---|---|---|---|
| 400,000 | `each { }` | 1.3 ms | 2.4 ms |
| 400,000 | `each` | 1.3 ms | 2.2 ms |
| 3,200,000 | `each { }` | 1.3 ms | 2.5 ms |
| 3,200,000 | `each` | 1.3 ms | 2.5 ms |

The bound does not grow with result size -- 2.5 ms is the worst case at 3.2M
rows, against master's 1.3 ms -- and the same run shows the materialisation
itself at 221 ms vs master's 741 ms on that shape (`cache_rows: false`,
median of 3).

On the interval: 8192 rows is 0.6-1.0 ms of materialisation on the shapes above,
taken from the same runs' total iteration time divided by row count. It is
coarse enough that the per-row handoff this commit removes does not come back,
and it does not scale with result size, so for similar row shapes the bound
should not grow with row count.

No new specs: no row value changes, and the scheduling property above is
measured rather than asserted -- a timing-sensitive spec for it would be flaky
in CI.

`rb_thread_schedule()` is the only API newly used here. It is declared in
`ruby/internal/intern/thread.h` among the installed public headers, so I did not
add a `have_func` guard for it. On the range: I checked 3.3 and 2.6, and it is
declared in both. I did not check 2.0-2.5, so I cannot tell you from my own
testing whether it spans the gem's declared `required_ruby_version` of
>= 2.0.0. If that matters, it is a one-line `have_func` guard and I am happy
to add it.

20,000 rows from a real application table (10 columns: bigints, varchars, a
DATETIME), `as: :array` with `database_timezone: :utc` -- the configuration
Rails' mysql2 adapter uses. Each sample is the min of 9 runs in one process;
9 samples per arm, arms interleaved to cancel drift.

| | median | range |
|---|---|---|
| master | 30.44 ms | 29.31 - 34.84 |
| patch  | 25.21 ms | 23.89 - 28.63 |

-17.2%, with no overlap between the two distributions.

Ruby 3.3.10, MySQL 9.6.0 (Homebrew, libmysqlclient.24), macOS 26.5 arm64,
Apple clang 21. The rspec suite was run there and is green apart from three failures
already present on the base commit: `client_spec.rb:101`, `:729`, and `:740`
-- the reconnect group.

An earlier revision of this change -- before the periodic yield existed -- was
also built and exercised inside a Rails application on a Heroku Linux dyno
(amd64) against MySQL 9.6. The revision in this PR, including the yield, has
been built and tested only on macOS.

Not tested: MariaDB, Windows, 32-bit platforms, or other Ruby versions. The
buffering argument above rests on libmysqlclient's behaviour for
`mysql_store_result` / `mysql_stmt_store_result`; MariaDB's client library is
the untested case that matters most for it.


---

Related but not addressed here: #1033 (`next_result` holds the GVL during a network call) is a different call site with a real network read; this PR only changes fetches from already-buffered results.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
