### PR TITLE
Parse canonical DATETIME and DATE without sscanf

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -534,6 +534,60 @@ static VALUE mysql2_set_field_string_encoding(VALUE val, MYSQL_FIELD field, rb_e
   return val;
 }
 
+/* Read exactly n decimal digits. Returns 0 (leaving *out untouched) on any
+ * non-digit, so callers fall back to the general parser. */
+static inline int mysql2_read_uint(const char *p, int n, unsigned int *out) {
+  unsigned int v = 0;
+  int i;
+  for (i = 0; i < n; i++) {
+    unsigned char d = (unsigned char)(p[i] - '0');
+    if (d > 9) return 0;
+    v = v * 10 + d;
+  }
+  *out = v;
+  return 1;
+}
+
+/* Fast path for the canonical wire format the server sends:
+ * YYYY-MM-DD HH:MM:SS[.ffffff]. Fractional digits are left-aligned, so ".5"
+ * is 500000 microseconds -- the same interpretation msec_char_to_uint gives
+ * the sscanf output. Anything not matching exactly returns 0 and the caller
+ * falls back to sscanf, preserving the original semantics for unusual input. */
+static int mysql2_parse_datetime(const char *s, unsigned long len,
+                                 unsigned int *year, unsigned int *month, unsigned int *day,
+                                 unsigned int *hour, unsigned int *min, unsigned int *sec,
+                                 unsigned int *msec) {
+  unsigned int frac = 0;
+
+  if (len < 19 || len > 26) return 0;
+  if (s[4] != '-' || s[7] != '-' || s[10] != ' ' || s[13] != ':' || s[16] != ':') return 0;
+  if (!mysql2_read_uint(s, 4, year) || !mysql2_read_uint(s + 5, 2, month) ||
+      !mysql2_read_uint(s + 8, 2, day) || !mysql2_read_uint(s + 11, 2, hour) ||
+      !mysql2_read_uint(s + 14, 2, min) || !mysql2_read_uint(s + 17, 2, sec)) return 0;
+
+  if (len > 19) {
+    unsigned long i;
+    unsigned int scale = 100000;
+    if (s[19] != '.' || len == 20) return 0;
+    for (i = 20; i < len; i++) {
+      unsigned char d = (unsigned char)(s[i] - '0');
+      if (d > 9) return 0;
+      frac += d * scale;
+      scale /= 10;
+    }
+  }
+  *msec = frac;
+  return 1;
+}
+
+/* Fast path for the canonical DATE wire format YYYY-MM-DD. */
+static int mysql2_parse_date(const char *s, unsigned long len,
+                             unsigned int *year, unsigned int *month, unsigned int *day) {
+  if (len != 10 || s[4] != '-' || s[7] != '-') return 0;
+  return mysql2_read_uint(s, 4, year) && mysql2_read_uint(s + 5, 2, month) &&
+         mysql2_read_uint(s + 8, 2, day);
+}
+
 /* Interpret microseconds digits left-aligned in fixed-width field.
  * e.g. 10.123 seconds means 10 seconds and 123000 microseconds,
  * because the microseconds are to the right of the decimal point.
@@ -956,14 +1010,19 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
         case MYSQL_TYPE_TIMESTAMP:  /* TIMESTAMP field */
         case MYSQL_TYPE_DATETIME: { /* DATETIME field */
           int tokens;
+          int parsed_msec = 0;
           unsigned int year=0, month=0, day=0, hour=0, min=0, sec=0, msec=0;
           char msec_char[7] = {'0','0','0','0','0','0','\0'};
           uint64_t seconds;
 
-          tokens = sscanf(row[i], "%4u-%2u-%2u %2u:%2u:%2u.%6s", &year, &month, &day, &hour, &min, &sec, msec_char);
-          if (tokens < 6) { /* msec might be empty */
-            val = Qnil;
-            break;
+          if (mysql2_parse_datetime(row[i], fieldLengths[i], &year, &month, &day, &hour, &min, &sec, &msec)) {
+            parsed_msec = 1;
+          } else {
+            tokens = sscanf(row[i], "%4u-%2u-%2u %2u:%2u:%2u.%6s", &year, &month, &day, &hour, &min, &sec, msec_char);
+            if (tokens < 6) { /* msec might be empty */
+              val = Qnil;
+              break;
+            }
           }
           seconds = (year*31557600ULL) + (month*2592000ULL) + (day*86400ULL) + (hour*3600ULL) + (min*60ULL) + sec;
 
@@ -989,7 +1048,9 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
                   }
                 }
               } else {
-                msec = msec_char_to_uint(msec_char, sizeof(msec_char));
+                if (!parsed_msec) {
+                  msec = msec_char_to_uint(msec_char, sizeof(msec_char));
+                }
                 val = rb_funcall(rb_cTime, args->db_timezone, 7, UINT2NUM(year), UINT2NUM(month), UINT2NUM(day), UINT2NUM(hour), UINT2NUM(min), UINT2NUM(sec), UINT2NUM(msec));
                 if (!NIL_P(args->app_timezone)) {
                   if (args->app_timezone == intern_local) {
@@ -1007,10 +1068,12 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
         case MYSQL_TYPE_NEWDATE: {  /* Newer const used > 5.0 */
           int tokens;
           unsigned int year=0, month=0, day=0;
-          tokens = sscanf(row[i], "%4u-%2u-%2u", &year, &month, &day);
-          if (tokens < 3) {
-            val = Qnil;
-            break;
+          if (!mysql2_parse_date(row[i], fieldLengths[i], &year, &month, &day)) {
+            tokens = sscanf(row[i], "%4u-%2u-%2u", &year, &month, &day);
+            if (tokens < 3) {
+              val = Qnil;
+              break;
+            }
           }
           if (year+month+day == 0) {
             val = Qnil;

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -578,6 +578,51 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
       expect(test_result['timestamp_test'].strftime("%Y-%m-%d %H:%M:%S")).to eql('2010-04-04 11:44:00')
     end
 
+    it "should parse DATETIME values identically to the sscanf path across fractional widths" do
+      # Each literal is cast to the DATETIME(N) that actually puts N fractional
+      # digits on the wire. Casting everything to DATETIME(6) would not do:
+      # the server normalises '...56.5' to '...56.500000', so the short forms
+      # would never reach the parser at all. The cast: false read pins that
+      # premise, so if the server ever stopped emitting these widths the test
+      # fails rather than quietly stopping testing them.
+      # Microseconds are left-aligned: ".5" is 500000, not 5.
+      [
+        ['2026-07-28 12:34:56',        'DATETIME',    0],
+        ['2026-07-28 12:34:56.5',      'DATETIME(1)', 500_000],
+        ['2026-07-28 12:34:56.05',     'DATETIME(2)', 50_000],
+        ['2026-07-28 12:34:56.123',    'DATETIME(3)', 123_000],
+        ['2026-07-28 12:34:56.000001', 'DATETIME(6)', 1],
+        ['2026-07-28 12:34:56.123456', 'DATETIME(6)', 123_456],
+        ['1000-01-01 00:00:00.999999', 'DATETIME(6)', 999_999],
+      ].each do |literal, type, usec|
+        sql = "SELECT CAST('#{literal}' AS #{type}) AS t"
+
+        raw = @client.query(sql, cast: false).first['t']
+        expect(raw).to eql(literal), "#{type}: parser was handed #{raw.inspect}, not #{literal.inspect}"
+
+        row = @client.query(sql, database_timezone: :utc).first['t']
+        expect(row).to be_an_instance_of(Time)
+        expect(row.usec).to eql(usec), "#{literal}: expected usec #{usec}, got #{row.usec}"
+        expect(row.strftime('%Y-%m-%d %H:%M:%S')).to eql(literal[0, 19])
+        expect(row.utc_offset).to eql(0)
+      end
+    end
+
+    it "should return nil for a zero DATETIME, as the sscanf path did" do
+      # A zero date is canonical in shape, so it is accepted by the fast parser
+      # rather than handed to the fallback. It must still come back as nil.
+      expect(@client.query("SELECT CAST('0000-00-00 00:00:00' AS DATETIME) AS t").first['t']).to be_nil
+    end
+
+    it "should parse DATE values identically to the sscanf path" do
+      # 1000-01-01 and 9999-12-31 are MySQL's DATE range edges.
+      ['2026-07-28', '1000-01-01', '9999-12-31'].each do |literal|
+        row = @client.query("SELECT CAST('#{literal}' AS DATE) AS d").first['d']
+        expect(row).to be_an_instance_of(Date)
+        expect(row.strftime('%Y-%m-%d')).to eql(literal)
+      end
+    end
+
     it "should return Time for a TIME value" do
       expect(test_result['time_test']).to be_an_instance_of(Time)
       expect(test_result['time_test'].strftime("%Y-%m-%d %H:%M:%S")).to eql('2000-01-01 11:44:00')


### PR DESCRIPTION
### Motivation / Background

Casting a text-protocol DATETIME or DATE runs `sscanf` once per value. On a
20,000-row result with one DATETIME column, `sscanf` accounted for 653 of 10,176
stack samples (~6% of wall time) in a macOS `sample` profile -- more than the
Time construction it feeds.

`sscanf` is doing general-purpose format interpretation for the canonical shape
MySQL normally emits: `YYYY-MM-DD HH:MM:SS[.ffffff]`.

### Detail

Adds a strict parser for exactly that canonical form (and `YYYY-MM-DD` for
DATE), with the original `sscanf` retained as the fallback for anything that
does not match byte-for-byte -- unusual widths, unexpected separators, anything
a proxy or an older server might emit. The fallback keeps the previous semantics
intact rather than trying to reproduce them.

The fast parser validates shape, not meaning. A canonical-shaped but
semantically invalid value such as `0000-00-00 00:00:00` is accepted by the
parser and then handled by the same downstream code as before, which is what
keeps the two paths equivalent -- the parser is not the place where zero dates
or out-of-range components were ever rejected.

Microsecond handling is the subtle part: `sscanf` captures the fractional digits
as a string that `msec_char_to_uint` then interprets left-aligned, so ".5" means
500000 microseconds, not 5. The fast path applies the same left-aligned scaling
directly, and `parsed_msec` tells the call site not to re-run
`msec_char_to_uint` over an untouched buffer.

### On the specs

The DATETIME spec casts each literal to the `DATETIME(N)` that actually puts N
fractional digits on the wire. This matters: a `DATETIME(6)` cast normalises
`...56.5` to `...56.500000`, so a spec that casts everything to `DATETIME(6)`
never hands the parser a short fractional part and does not test what it appears
to. Each case therefore also reads the value back with `cast: false` and asserts
the exact bytes the parser was given, so the premise cannot rot silently.

What the specs do not cover: the `sscanf` fallback itself. The existing
integration suite, running against a stock MySQL server, does not naturally
produce a non-canonical DATETIME on the wire to drive it with. The fallback is retained for
producers that are not a stock MySQL server (proxies, older servers, MariaDB),
and that path is unchanged from the current code rather than reimplemented --
but it is reasoned, not exercised here.

Verified separately that these specs exercise the new parser rather than
silently falling through to `sscanf`: with the fast path's microsecond output
deliberately corrupted, the fractional-widths spec fails.

### Benchmark

20,000 rows, single DATETIME column, `as: :array` with
`database_timezone: :utc`, timing materialisation only (the query is issued
outside the measured region). Each sample is the min of 9 runs in one process;
9 samples per arm, arms interleaved.

| | median | range |
|---|---|---|
| master | 9.60 ms | 9.24 - 9.98 |
| patch  | 7.43 ms | 7.25 - 8.57 |

-22.6%, distributions non-overlapping.

### Where this was tested

Ruby 3.3.10, MySQL 9.6.0 (Homebrew, libmysqlclient.24), macOS 26.5 arm64,
Apple clang 21. The rspec suite was run there and is green apart from three failures already
present on the base commit: `client_spec.rb:101`, `:729`, and `:740` -- the
reconnect group.

Not tested: MariaDB, Windows, 32-bit platforms, other Ruby versions, or any
Linux CI matrix. Nothing in this commit is platform-specific -- it is byte
inspection of an ASCII string -- but the claim that the server always emits
the canonical form is a MySQL claim, and MariaDB in particular is unverified
here. That is the case the retained `sscanf` fallback exists for.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
