### PR TITLE
Bind prepared-statement result buffers once per result set

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -148,6 +148,7 @@ static void rb_mysql_result_free_result(mysql2_result_wrapper * wrapper, int fro
       }
       /* Clue that the next statement execute will need to allocate a new result buffer. */
       wrapper->result_buffers = NULL;
+      wrapper->result_buffers_bound = 0;
     }
 
     /* For prepared statements, wrapper->result is the result metadata
@@ -657,8 +658,23 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
     rb_mysql_result_alloc_result_buffers(self, fields);
   }
 
-  if (mysql_stmt_bind_result(wrapper->stmt_wrapper->stmt, wrapper->result_buffers)) {
-    rb_raise_mysql2_stmt_error(wrapper->stmt_wrapper);
+  /* Bind once per result set rather than once per row. The buffers are
+   * allocated exactly once (rb_mysql_result_alloc_result_buffers returns early
+   * when they exist) and are never resized -- a buffer too short for a value
+   * raises on MYSQL_DATA_TRUNCATED rather than reallocating -- and they are
+   * only released by rb_mysql_result_free_result, which nulls the pointer and
+   * clears this flag. So the addresses registered here stay valid for every
+   * subsequent mysql_stmt_fetch on this result. Re-binding per row copied the
+   * whole MYSQL_BIND array into the statement each time for no gain.
+   *
+   * Binding is tracked separately from allocation so that a failed bind is
+   * still retried on a later fetch, exactly as it was when the bind ran on
+   * every row. */
+  if (!wrapper->result_buffers_bound) {
+    if (mysql_stmt_bind_result(wrapper->stmt_wrapper->stmt, wrapper->result_buffers)) {
+      rb_raise_mysql2_stmt_error(wrapper->stmt_wrapper);
+    }
+    wrapper->result_buffers_bound = 1;
   }
 
   {
@@ -1403,6 +1419,7 @@ VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_
   wrapper->client_wrapper = DATA_PTR(client);
   wrapper->client_wrapper->refcount++;
   wrapper->result_buffers = NULL;
+  wrapper->result_buffers_bound = 0;
   wrapper->is_null = NULL;
   wrapper->error = NULL;
   wrapper->length = NULL;

--- a/ext/mysql2/result.h
+++ b/ext/mysql2/result.h
@@ -29,6 +29,7 @@ typedef struct {
   mysql_stmt_wrapper *stmt_wrapper;
   mysql_client_wrapper *client_wrapper;
   /* statement result bind buffers */
+  char result_buffers_bound;
   MYSQL_BIND *result_buffers;
   my_bool *is_null;
   my_bool *error;

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -315,6 +315,23 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
       end
     end
 
+    it "should return every row of a multi-row result" do
+      # The result buffers are bound on the first fetch and reused for the rest
+      # of the result set, so a binding that went stale would show up as wrong
+      # or repeated values from the second row onward, not on the first.
+      result = @client.prepare("SELECT 1 AS n UNION ALL SELECT 2 UNION ALL SELECT 3 UNION ALL SELECT 4").execute
+      expect(result.to_a).to eq([{ 'n' => 1 }, { 'n' => 2 }, { 'n' => 3 }, { 'n' => 4 }])
+    end
+
+    it "should return wide variable-width columns correctly on every row" do
+      # Variable-width buffers are sized once, from fields[i].max_length. A row
+      # fetched into a stale or too-short buffer would be truncated or wrong
+      # here, where the value is far larger than any inline buffer.
+      expected = ['a' * 60_000, 'b' * 60_000]
+      result = @client.prepare("SELECT REPEAT('a', 60000) AS v UNION ALL SELECT REPEAT('b', 60000)").execute
+      expect(result.to_a.map { |row| row['v'] }).to eq(expected)
+    end
+
     it "should yield rows as hash's with symbol keys if :symbolize_keys was set to true" do
       @result = @client.prepare("SELECT 1").execute(symbolize_keys: true)
       @result.each do |row|


### PR DESCRIPTION
### Motivation / Background

`rb_mysql_result_fetch_row_stmt` calls `mysql_stmt_bind_result` before every
fetch, re-registering the same buffers with the statement on every row. The
call copies the whole `MYSQL_BIND` array into the statement handle, so the cost
is proportional to the column count and is paid per row.

The buffers do not move. `rb_mysql_result_alloc_result_buffers` returns early
when they already exist, so they are allocated exactly once per result. They are
never resized either: variable-width columns are allocated at
`fields[i].max_length`, and a value too large for its buffer is treated as an
internal bug (`MYSQL_DATA_TRUNCATED` raises "IMPLBUG") rather than triggering a
reallocation. The only place they are released is `rb_mysql_result_free_result`,
which frees them and nulls the pointer. So the addresses registered on the first
fetch stay valid for every later `mysql_stmt_fetch` on that result.

### Detail

Binds once per result set instead of once per row, tracked by an explicit
`result_buffers_bound` flag on the result wrapper.

The flag matters and is not redundant with the existing `result_buffers != NULL`
allocation guard: allocation succeeding does not mean binding succeeded. Hanging
the bind off the allocation guard alone would mean that if
`mysql_stmt_bind_result` failed, the buffers would already be non-NULL, and any
later fetch on that result would skip binding entirely and fetch into buffers
the statement was never bound to. Tracking the two separately keeps the retry
behaviour identical to the current code, where a failed bind is simply attempted
again on the next fetch. `rb_mysql_result_free_result` clears the flag alongside
the pointer.

### On the specs

Two specs cover the invariant this change relies on: that one binding serves
every row of the result. One reads a multi-row result and asserts every row,
since a stale binding would show up from the second row onward rather than on
the first; the other reads 60,000-byte values across two rows, which is where a
buffer that had been resized or replaced after binding would surface.

Both pass on the unpatched base commit as well -- they are regression pins for a
change that is meant to be behaviour-preserving, not proof of a fix. The one
behaviour that genuinely changed, the failed-bind retry path above, is reasoned
from the code rather than tested: provoking a `mysql_stmt_bind_result` failure
needs fault injection the suite has no mechanism for.

### Benchmark

Two shapes, because the saving scales with column count. Min of 9 runs per
sample, interleaved arms.

| | master | patch | |
|---|---|---|---|
| 20,000 rows x 6 cols (9 samples) | 20.09 ms (18.07 - 23.65) | 20.58 ms (17.78 - 21.84) | no measurable difference |
| 5,000 rows x 42 cols (15 samples) | 35.74 ms (30.60 - 40.47) | 33.99 ms (30.24 - 40.07) | -4.9% |

Both shapes have overlapping distributions. Repeated measurement of the wide
shape across bases and runs has ranged from -2.8% to -5.7%, so treat this as
"a few percent on wide rows", not a precise figure. On this
hardware the honest summary is that removing a per-row `memcpy` of the bind
array is a small win on wide results and nothing on narrow ones -- worth doing
because the per-row call is redundant, not because it is dramatic.

### Where this was tested

Ruby 3.3.10, MySQL 9.6.0 (Homebrew, libmysqlclient.24), macOS 26.5 arm64,
Apple clang 21. The rspec suite was run there and is green apart from three failures already
present on the base commit: `client_spec.rb:101`, `:729`, and `:740` -- the
reconnect group.

Not tested: MariaDB, Windows, 32-bit platforms, or other Ruby versions. The
"buffers are never resized after binding" argument rests on libmysqlclient's
prepared-statement behaviour; MariaDB's client library is the untested case
that matters most here, since a client that grew result buffers on truncation
instead of erroring would invalidate the premise.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
