### PR TITLE
Build :utc DATETIME values without a 7-argument rb_funcall

### DIFF
--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -46,6 +46,9 @@ have_func('rb_enc_interned_str', 'ruby.h')
 # 3.2+
 have_func('rb_hash_new_capa', 'ruby.h')
 
+# 2.3+ (guarded so the funcall path remains available on anything older)
+have_func('rb_time_timespec_new', 'ruby.h')
+
 ### Find OpenSSL library
 
 # User-specified OpenSSL if explicitly specified

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -535,6 +535,57 @@ static VALUE mysql2_set_field_string_encoding(VALUE val, MYSQL_FIELD field, rb_e
   return val;
 }
 
+#ifdef HAVE_RB_TIME_TIMESPEC_NEW
+#include <limits.h>
+#include <time.h>
+
+/* days_from_civil: proleptic Gregorian civil date -> days since 1970-01-01.
+ * Howard Hinnant's public-domain algorithm (http://howardhinnant.github.io/date_algorithms.html). */
+static inline int64_t mysql2_days_from_civil(int64_t y, unsigned int m, unsigned int d) {
+  int64_t era;
+  unsigned int yoe, doy, doe;
+  y -= m <= 2;
+  era = (y >= 0 ? y : y - 399) / 400;
+  yoe = (unsigned int)(y - era * 400);
+  doy = (153 * (m > 2 ? m - 3 : m + 9) + 2) / 5 + d - 1;
+  doe = yoe * 365 + yoe / 4 - yoe / 100 + doy;
+  return era * 146097 + (int64_t)doe - 719468;
+}
+
+/* Time construction for :utc results, equivalent to
+ * Time.utc(year, month, day, hour, min, sec, usec) but without the varargs
+ * dispatch and per-argument boxing of a 7-argument rb_funcall.
+ *
+ * INT_MAX - 1 is rb_time_timespec_new's documented sentinel for "ts is in UTC"
+ * (INT_MAX means local time) -- see ruby/internal/intern/time.h.
+ *
+ * Returns Qnil when the value cannot be built this way, so the caller falls
+ * back to the funcall path: an epoch outside time_t (32-bit time_t platforms,
+ * for dates beyond 1901-2038) or an out-of-range subsecond. On 64-bit time_t
+ * the narrowing check folds away at compile time. */
+static VALUE mysql2_utc_time(unsigned int year, unsigned int month, unsigned int day,
+                             unsigned int hour, unsigned int min, unsigned int sec,
+                             unsigned long usec) {
+  struct timespec ts;
+  const int64_t secs = mysql2_days_from_civil((int64_t)year, month, day) * 86400LL
+                       + hour * 3600 + min * 60 + sec;
+  const time_t narrowed = (time_t)secs;
+
+  if ((int64_t)narrowed != secs) return Qnil;
+  if (usec >= 1000000UL) return Qnil;
+
+  ts.tv_sec = narrowed;
+  ts.tv_nsec = (long)(usec * 1000UL);
+  return rb_time_timespec_new(&ts, INT_MAX - 1);
+}
+
+/* The fast path applies only to :utc, and only to wall-clock components the
+ * generic Time.utc would itself accept -- it raises on out-of-range values,
+ * where plain epoch arithmetic would silently wrap them. */
+#define MYSQL2_UTC_FAST_PATH_OK(tz, hour, min, sec) \
+  ((tz) == intern_utc && (hour) < 24 && (min) < 60 && (sec) < 60)
+#endif
+
 /* Read exactly n decimal digits. Returns 0 (leaving *out untouched) on any
  * non-digit, so callers fall back to the general parser. */
 static inline int mysql2_read_uint(const char *p, int n, unsigned int *out) {
@@ -1097,12 +1148,28 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
                 if (!parsed_msec) {
                   msec = msec_char_to_uint(msec_char, sizeof(msec_char));
                 }
-                val = rb_funcall(rb_cTime, args->db_timezone, 7, UINT2NUM(year), UINT2NUM(month), UINT2NUM(day), UINT2NUM(hour), UINT2NUM(min), UINT2NUM(sec), UINT2NUM(msec));
-                if (!NIL_P(args->app_timezone)) {
+#ifdef HAVE_RB_TIME_TIMESPEC_NEW
+                /* month/day lower bounds were validated above; the upper bounds
+                 * keep a corrupt value from producing a silently-wrong epoch
+                 * instead of the ArgumentError Time.utc would raise. */
+                if (MYSQL2_UTC_FAST_PATH_OK(args->db_timezone, hour, min, sec) && month <= 12 && day <= 31) {
+                  val = mysql2_utc_time(year, month, day, hour, min, sec, msec);
+                }
+                if (!NIL_P(val)) {
+                  /* Already UTC, so app_timezone :utc needs no conversion. */
                   if (args->app_timezone == intern_local) {
                     val = rb_funcall(val, intern_localtime, 0);
-                  } else { /* utc */
-                    val = rb_funcall(val, intern_utc, 0);
+                  }
+                } else
+#endif
+                {
+                  val = rb_funcall(rb_cTime, args->db_timezone, 7, UINT2NUM(year), UINT2NUM(month), UINT2NUM(day), UINT2NUM(hour), UINT2NUM(min), UINT2NUM(sec), UINT2NUM(msec));
+                  if (!NIL_P(args->app_timezone)) {
+                    if (args->app_timezone == intern_local) {
+                      val = rb_funcall(val, intern_localtime, 0);
+                    } else { /* utc */
+                      val = rb_funcall(val, intern_utc, 0);
+                    }
                   }
                 }
               }

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -614,6 +614,59 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
       expect(@client.query("SELECT CAST('0000-00-00 00:00:00' AS DATETIME) AS t").first['t']).to be_nil
     end
 
+    it "should build :utc DATETIME values identically to the generic Time path" do
+      # Pins the arithmetic fast path against Time.utc across the range and
+      # precision edges, including both sides of the 32-bit time_t boundary:
+      # 2038-01-19 03:14:07 is the last representable second there, 03:14:08
+      # the first one past it, which on a 32-bit build must decline to the
+      # funcall rather than wrap.
+      [
+        ['1901-12-13 20:45:51.000000', 0],
+        ['1969-12-31 23:59:59.123456', 123_456],
+        ['1970-01-01 00:00:00.000001', 1],
+        ['2038-01-19 03:14:07.000000', 0],
+        ['2038-01-19 03:14:08.000000', 0],
+        ['2026-07-28 12:34:56.654321', 654_321],
+        ['9999-12-31 11:59:59.500000', 500_000],
+      ].each do |literal, usec|
+        date_part, time_part = literal.split(' ')
+        y, mo, d = date_part.split('-').map(&:to_i)
+        h, mi, s = time_part.split(':')
+        expected = Time.utc(y, mo, d, h.to_i, mi.to_i, s.to_i) + Rational(usec, 1_000_000)
+
+        actual = @client.query("SELECT CAST('#{literal}' AS DATETIME(6)) AS t", database_timezone: :utc).first['t']
+        expect(actual).to eql(expected), "#{literal}: expected #{expected.inspect}, got #{actual.inspect}"
+        expect(actual.utc_offset).to eql(0)
+        expect(actual.usec).to eql(usec)
+      end
+    end
+
+    it "should normalise invalid-but-in-range :utc DATETIME values exactly as Time.utc does" do
+      # With ALLOW_INVALID_DATES the server hands back dates that are canonical
+      # in shape but not real calendar days. Time.utc does not reject these --
+      # it normalises them (Feb 31 becomes Mar 3) -- so the arithmetic path must
+      # land on the same instant rather than on its own idea of the date.
+      client = new_client
+      client.query("SET SESSION sql_mode='ALLOW_INVALID_DATES'")
+      {
+        '2023-02-31 12:00:00' => Time.utc(2023, 3, 3, 12, 0, 0),
+        '2023-04-31 01:02:03' => Time.utc(2023, 5, 1, 1, 2, 3),
+        '2023-02-29 00:00:00' => Time.utc(2023, 3, 1, 0, 0, 0),
+        '2023-11-31 23:59:59' => Time.utc(2023, 12, 1, 23, 59, 59),
+        '2024-02-30 06:30:00' => Time.utc(2024, 3, 1, 6, 30, 0),
+      }.each do |literal, expected|
+        actual = client.query("SELECT CAST('#{literal}' AS DATETIME) AS t", database_timezone: :utc).first['t']
+        expect(actual).to eql(expected), "#{literal}: expected #{expected.inspect}, got #{actual.inspect}"
+      end
+    end
+
+    it "should leave :local DATETIME handling on the generic path" do
+      literal = '2026-07-28 12:34:56'
+      actual = @client.query("SELECT CAST('#{literal}' AS DATETIME) AS t", database_timezone: :local).first['t']
+      expect(actual).to eql(Time.local(2026, 7, 28, 12, 34, 56))
+      expect(actual.utc_offset).to eql(Time.local(2026, 7, 28, 12, 34, 56).utc_offset)
+    end
+
     it "should parse DATE values identically to the sscanf path" do
       # 1000-01-01 and 9999-12-31 are MySQL's DATE range edges.
       ['2026-07-28', '1000-01-01', '9999-12-31'].each do |literal|


### PR DESCRIPTION
**Stacks on #1458** — the first commit here is that PR; only the second commit (`Build :utc DATETIME values without a 7-argument rb_funcall`) is new to review. Submitted separately so the parse change can land on its own if this one doesn't.

### Motivation / Background

Casting a DATETIME with `database_timezone: :utc` calls
`rb_funcall(rb_cTime, :utc, 7, ...)` per row: seven `UINT2NUM` allocations plus
varargs dispatch into Ruby, to produce a value that is fully determined by
integers already sitting in C locals.

`:utc` is what the Rails mysql2 adapter configures
(`ActiveRecord.default_timezone` is `:utc` by default), so this is the common
path for Rails applications.

### Detail

For `:utc` results, converts the civil date to a day count with Howard
Hinnant's `days_from_civil` and builds the Time through
`rb_time_timespec_new(&ts, INT_MAX - 1)`. `INT_MAX - 1` is that function's
sentinel for "ts is in UTC" (`INT_MAX` means local time) -- see
`ruby/internal/intern/time.h`. That is a Ruby-internal contract read out of the
header rather than a documented public guarantee, which is part of why the
whole path is optional (below).

`:local` is deliberately untouched and keeps the funcall: reproducing
`Time.local`'s DST-gap and TZ-database semantics in C is not something to do
for a speedup.

The arithmetic path is used only when the components are in range
(`hour < 24`, `min < 60`, `sec < 60`, `month <= 12`, `day <= 31`) and
`database_timezone` is `:utc`; anything else goes to the original funcall
untouched. Having been entered, it still returns Qnil -- falling through to the
same funcall -- when the epoch does not fit `time_t` (on 32-bit `time_t` this
is everything outside 1901-2038; the check folds away at compile time where
`time_t` is 64-bit) or subseconds are out of range.

A note on those component bounds: they are not there to match an
`ArgumentError`. `Time.utc` does not reject an
in-range-but-impossible date -- `Time.utc(2023, 2, 31)` returns 2023-03-03, it
does not raise. `days_from_civil` normalises identically, and a spec pins that
against the server actually emitting such values under
`sql_mode='ALLOW_INVALID_DATES'`. The bounds exist only to keep a corrupt value
far outside the calendar from being turned into a plausible-looking epoch
instead of being handed to Ruby. Month and day lower bounds are handled before
this point by existing code this commit does not touch -- the
`if (month < 1 || day < 1)` branch a few lines up in the same
`MYSQL_TYPE_DATETIME` case, which raises.

`app_timezone: :utc` becomes a no-op rather than a `.utc` call, since the value
is already UTC; `app_timezone: :local` still converts via `localtime`.

The construction path -- not the parsing commit this branch sits on -- is behind
`have_func('rb_time_timespec_new')`. A build without that function keeps the
existing `Time.utc` funcall for every value.

### On the specs

Specs assert equality against `Time.utc` at microsecond precision across the
epoch, year 9999, and both sides of the 32-bit `time_t` boundary
(2038-01-19 03:14:07 is the last representable second there, 03:14:08 the first
past it, which a 32-bit build must decline rather than wrap). A `:local` case
pins that path to the unchanged funcall, and the invalid-date case described
above pins the normalisation.

Verified that these specs exercise the arithmetic rather than silently passing
through the funcall fallback: with `days_from_civil` deliberately shifted by one
day, both the equality spec and the invalid-date spec fail.

### Benchmark

20,000 rows, single DATETIME column, `as: :array` with
`database_timezone: :utc`, materialisation only. Min of 9 runs per sample,
9 samples per arm, arms interleaved. Each arm is a separately compiled checkout.

| | median |
|---|---|
| master | 9.60 ms |
| + parse change (previous commit) | 7.43 ms |
| + this commit | 6.51 ms |

-12.3% on top of the parse change; -32.2% against master for the two together.

### Where this was tested

Ruby 3.3.10, MySQL 9.6.0 (Homebrew, libmysqlclient.24), macOS 26.5 arm64,
Apple clang 21. The rspec suite was run there and is green apart from three failures already
present on the base commit: `client_spec.rb:101`, `:729`, and `:740` -- the
reconnect group.

Not tested: MariaDB, Windows, 32-bit platforms, other Ruby versions, or any
Linux CI matrix. The 32-bit `time_t` narrowing check exists specifically for a
platform not tested here -- on this machine `time_t` is 64-bit and that branch
folds away at compile time, so the 2038 spec cases prove the arithmetic, not
the narrowing fallback. A CI run on a 32-bit target is the thing that would
close that gap.


🤖 Generated with [Claude Code](https://claude.com/claude-code)
