### PR TITLE
Revert #1425: MYSQL_OPT_RECONNECT #ifdef never holds

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -981,12 +981,10 @@ static VALUE _mysql_client_options(VALUE self, int opt, VALUE value) {
       retval = &intval;
       break;
 
-#ifdef MYSQL_OPT_RECONNECT
     case MYSQL_OPT_RECONNECT:
       boolval = (value == Qfalse ? 0 : 1);
       retval = &boolval;
       break;
-#endif
 
 #ifdef MYSQL_SECURE_AUTH
     case MYSQL_SECURE_AUTH:
@@ -1043,11 +1041,9 @@ static VALUE _mysql_client_options(VALUE self, int opt, VALUE value) {
   } else {
     /* Special case for options that are stored in the wrapper struct */
     switch (opt) {
-#ifdef MYSQL_OPT_RECONNECT
       case MYSQL_OPT_RECONNECT:
         wrapper->reconnect_enabled = boolval;
         break;
-#endif
       case MYSQL_OPT_CONNECT_TIMEOUT:
         wrapper->connect_timeout = intval;
         break;
@@ -1411,11 +1407,7 @@ static VALUE set_automatic_close(VALUE self, VALUE value) {
  * for more information.
  */
 static VALUE set_reconnect(VALUE self, VALUE value) {
-#ifdef MYSQL_OPT_RECONNECT
   return _mysql_client_options(self, MYSQL_OPT_RECONNECT, value);
-#else
-  return Qfalse;
-#endif
 }
 
 static VALUE set_local_infile(VALUE self, VALUE value) {


### PR DESCRIPTION
Reverts #1425, which broke CI on master.

`MYSQL_OPT_RECONNECT` is an `enum mysql_option` member, not a preprocessor macro, so `#ifdef MYSQL_OPT_RECONNECT` never holds. `Client#reconnect=` takes the `#else` branch and returns without doing anything, leaving `wrapper->reconnect_enabled` at 0 — the flag mysql2 checks before every query. So `reconnect: true` no longer reconnects; it raises `Mysql2::Error: MySQL client is not connected`. This affects users, not just CI.

### Where master started failing
| Build run | commit | failing jobs |
|---|---|---|
| [31079160222](https://github.com/brianmario/mysql2/actions/runs/31079160222) | b2b79bc (#1450) | 1 / 17 |
| [31079198811](https://github.com/brianmario/mysql2/actions/runs/31079198811) | 9eb7548 (#1453) | 1 / 17 |
| [31079365227](https://github.com/brianmario/mysql2/actions/runs/31079365227) | **69bfb71 (#1425)** | **17 / 17** |

The failures are the three reconnect examples in `spec/mysql2/client_spec.rb`

### Why revert rather than fix forward
I couldn't find a libmysqlclient where `MYSQL_OPT_RECONNECT` is undefined. it is still there in MySQL 9.6. so nothing in CI or locally would exercise the guarded branch, and a forward fix can't be validated today. Meanwhile several C-extension changes landed right around #1425 (#1450, #1453, #1455, #1456), and their CI results carry no signal while every spec job is red.