### PR TITLE
Defer freeing an abandoned streaming Result until the connection is idle

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -416,6 +416,70 @@ void mysql2_drop_pending_stmt_closes(mysql_client_wrapper *wrapper)
   }
 }
 
+void mysql2_enqueue_pending_result_free(mysql_client_wrapper *wrapper, MYSQL_RES *result, MYSQL_STMT *stmt)
+{
+  /* Deliberately plain malloc(), not Ruby's xmalloc(): see the identical
+   * note on mysql2_enqueue_pending_stmt_close above. */
+  mysql2_pending_result_free *node = malloc(sizeof(mysql2_pending_result_free));
+  if (!node) return; /* leaks the result set's client-side memory; nothing safe to do here */
+  node->result = result;
+  node->stmt = stmt;
+  node->next = wrapper->pending_result_frees;
+  wrapper->pending_result_frees = node;
+  wrapper->pending_result_free_count++;
+}
+
+static void *nogvl_stmt_free_result_raw(void *ptr) {
+  mysql_stmt_free_result((MYSQL_STMT *)ptr);
+  return NULL;
+}
+
+static void *nogvl_free_result_raw(void *ptr) {
+  mysql_free_result((MYSQL_RES *)ptr);
+  return NULL;
+}
+
+void mysql2_reap_pending_result_frees(mysql_client_wrapper *wrapper)
+{
+  mysql2_pending_result_free *node = wrapper->pending_result_frees;
+  wrapper->pending_result_frees = NULL;
+  wrapper->pending_result_free_count = 0;
+
+  while (node) {
+    mysql2_pending_result_free *next = node->next;
+
+    if (wrapper->initialized && !wrapper->closed && CONNECTED(wrapper)) {
+      /* Order matters: free the statement's outstanding result (which may
+       * discard unread cursor rows) before anything else touches that
+       * statement handle again. */
+      if (node->stmt) {
+        rb_thread_call_without_gvl(nogvl_stmt_free_result_raw, node->stmt, RUBY_UBF_IO, 0);
+      }
+      if (node->result) {
+        rb_thread_call_without_gvl(nogvl_free_result_raw, node->result, RUBY_UBF_IO, 0);
+      }
+    }
+
+    free(node);
+    node = next;
+  }
+}
+
+/* See client.h: used by Client#close, which deliberately skips the
+ * network round trips above -- the connection is going away regardless. */
+void mysql2_drop_pending_result_frees(mysql_client_wrapper *wrapper)
+{
+  mysql2_pending_result_free *node = wrapper->pending_result_frees;
+  wrapper->pending_result_frees = NULL;
+  wrapper->pending_result_free_count = 0;
+
+  while (node) {
+    mysql2_pending_result_free *next = node->next;
+    free(node);
+    node = next;
+  }
+}
+
 static void *nogvl_close(void *ptr) {
   mysql_client_wrapper *wrapper = ptr;
 
@@ -475,6 +539,24 @@ void decr_mysql2_client(mysql_client_wrapper *wrapper)
     wrapper->pending_stmt_close_count = 0;
   }
 
+  /* Same reasoning for any not-yet-drained result sets: mysql_close() below
+   * is about to invalidate the connection those MYSQL_RES/MYSQL_STMT
+   * pointers belong to, and this may itself be running during a GC sweep,
+   * so no network I/O and no VM calls -- just drop the list. This does leak
+   * the client-side MYSQL_RES memory (see mysql2_drop_pending_result_frees
+   * in client.h), same tradeoff already accepted above for statement
+   * handles. */
+  {
+    mysql2_pending_result_free *node = wrapper->pending_result_frees;
+    while (node) {
+      mysql2_pending_result_free *next = node->next;
+      free(node); /* plain free(): this too can run during a GC sweep */
+      node = next;
+    }
+    wrapper->pending_result_frees = NULL;
+    wrapper->pending_result_free_count = 0;
+  }
+
   nogvl_close(wrapper);
   xfree(wrapper->client);
   xfree(wrapper);
@@ -503,6 +585,8 @@ static VALUE allocate(VALUE klass) {
   wrapper->state = MYSQL2_CLIENT_IDLE;
   wrapper->pending_stmt_closes = NULL;
   wrapper->pending_stmt_close_count = 0;
+  wrapper->pending_result_frees = NULL;
+  wrapper->pending_result_free_count = 0;
 
   return obj;
 }
@@ -683,7 +767,9 @@ static VALUE rb_mysql_client_close(VALUE self) {
   /* The connection is going away regardless of what mysql_close() below
    * does or doesn't send -- don't bother closing each queued statement
    * individually, just clear the bookkeeping so prepared_statements and
-   * pending_prepared_statement_closes don't report stale state afterward. */
+   * pending_prepared_statement_closes don't report stale state afterward.
+   * Same reasoning for any not-yet-drained result sets. */
+  mysql2_drop_pending_result_frees(wrapper);
   mysql2_drop_pending_stmt_closes(wrapper);
 
   if (wrapper->client) {
@@ -802,6 +888,7 @@ static VALUE rb_mysql_client_async_result(VALUE self) {
     /* The whole result set is buffered locally; the connection is free to
      * run another command right away. */
     wrapper->state = MYSQL2_CLIENT_IDLE;
+    mysql2_reap_pending_result_frees(wrapper);
     mysql2_reap_pending_stmt_closes(wrapper);
   }
 
@@ -975,7 +1062,10 @@ static VALUE rb_mysql_query(VALUE self, VALUE sql, VALUE current) {
   args.mysql = wrapper->client;
 
   /* We're about to issue a new command: this is a safe point to close out
-   * any statements that were GC'd while we were busy earlier. */
+   * any statements that were GC'd while we were busy earlier, and to free
+   * any abandoned result sets left over from a stream that was dropped
+   * mid-iteration. */
+  mysql2_reap_pending_result_frees(wrapper);
   mysql2_reap_pending_stmt_closes(wrapper);
 
   (void)RB_GC_GUARD(current);
@@ -1353,7 +1443,9 @@ static VALUE rb_mysql_client_ping(VALUE self) {
   rb_mysql_client_set_active_fiber(self, false);
 
   /* A low-traffic, frequently-called method; a good opportunistic safe
-   * point to close out statements that were GC'd while we were busy. */
+   * point to close out statements that were GC'd while we were busy, and to
+   * free any abandoned result sets. */
+  mysql2_reap_pending_result_frees(wrapper);
   mysql2_reap_pending_stmt_closes(wrapper);
 
   VALUE result = Qnil;
@@ -1707,6 +1799,7 @@ static VALUE rb_mysql_client_prepare_statement(VALUE self, VALUE sql) {
 static VALUE rb_mysql_client_prepared_statements_read(VALUE self) {
   GET_CLIENT(self);
 
+  mysql2_reap_pending_result_frees(wrapper);
   mysql2_reap_pending_stmt_closes(wrapper);
 
   return rb_funcall(wrapper->prepared_statements, intern_values, 0);
@@ -1727,6 +1820,21 @@ static VALUE rb_mysql_client_pending_prepared_statement_closes(VALUE self) {
   GET_CLIENT(self);
 
   return ULONG2NUM(wrapper->pending_stmt_close_count);
+}
+
+/* call-seq:
+ *    client.pending_result_frees
+ *
+ * Returns the number of result sets (from a streaming query or streaming
+ * prepared statement) that were abandoned mid-iteration and garbage
+ * collected, and are therefore waiting for a safe point to actually
+ * discard their unread rows from the connection. Mirrors
+ * #pending_prepared_statement_closes; drains at the same safe points.
+ */
+static VALUE rb_mysql_client_pending_result_frees(VALUE self) {
+  GET_CLIENT(self);
+
+  return ULONG2NUM(wrapper->pending_result_free_count);
 }
 
 void init_mysql2_client(void) {
@@ -1778,6 +1886,7 @@ void init_mysql2_client(void) {
   rb_define_method(cMysql2Client, "prepare", rb_mysql_client_prepare_statement, 1);
   rb_define_method(cMysql2Client, "prepared_statements", rb_mysql_client_prepared_statements_read, 0);
   rb_define_method(cMysql2Client, "pending_prepared_statement_closes", rb_mysql_client_pending_prepared_statement_closes, 0);
+  rb_define_method(cMysql2Client, "pending_result_frees", rb_mysql_client_pending_result_frees, 0);
   rb_define_method(cMysql2Client, "thread_id", rb_mysql_client_thread_id, 0);
   rb_define_method(cMysql2Client, "ping", rb_mysql_client_ping, 0);
   rb_define_method(cMysql2Client, "select_db", rb_mysql_client_select_db, 1);

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -467,21 +467,6 @@ void mysql2_reap_pending_result_frees(mysql_client_wrapper *wrapper)
   }
 }
 
-/* See client.h: used by Client#close, which deliberately skips the
- * network round trips above -- the connection is going away regardless. */
-void mysql2_drop_pending_result_frees(mysql_client_wrapper *wrapper)
-{
-  mysql2_pending_result_free *node = wrapper->pending_result_frees;
-  wrapper->pending_result_frees = NULL;
-  wrapper->pending_result_free_count = 0;
-
-  while (node) {
-    mysql2_pending_result_free *next = node->next;
-    free(node);
-    node = next;
-  }
-}
-
 /* See client.h. */
 void mysql2_abandon_active_stream(mysql_client_wrapper *wrapper)
 {
@@ -554,9 +539,10 @@ void decr_mysql2_client(mysql_client_wrapper *wrapper)
    * is about to invalidate the connection those MYSQL_RES/MYSQL_STMT
    * pointers belong to, and this may itself be running during a GC sweep,
    * so no network I/O and no VM calls -- just drop the list. This does leak
-   * the client-side MYSQL_RES memory (see mysql2_drop_pending_result_frees
-   * in client.h), same tradeoff already accepted above for statement
-   * handles. */
+   * the client-side MYSQL_RES memory, same tradeoff already accepted above
+   * for statement handles -- but only here, where we have no other choice.
+   * The ordinary-Ruby-level Client#close path below does not take this
+   * shortcut: see mysql2_reap_pending_result_frees at that call site. */
   {
     mysql2_pending_result_free *node = wrapper->pending_result_frees;
     while (node) {
@@ -780,8 +766,20 @@ static VALUE rb_mysql_client_close(VALUE self) {
    * does or doesn't send -- don't bother closing each queued statement
    * individually, just clear the bookkeeping so prepared_statements and
    * pending_prepared_statement_closes don't report stale state afterward.
-   * Same reasoning for any not-yet-drained result sets. */
-  mysql2_drop_pending_result_frees(wrapper);
+   *
+   * Not-yet-drained result sets are different: unlike a statement's server-
+   * side handle, mysql_close() below has no side effect that reclaims a
+   * MYSQL_RES's client-side row buffers, so dropping those without freeing
+   * them would leak that memory for the rest of the process. This runs as
+   * ordinary Ruby-level code (this method isn't reachable from a dfree
+   * callback), so it's safe to actually flush and free them here, same as
+   * at any other safe point -- just before the connection goes away
+   * instead of before the next command. mysql2_abandon_active_stream covers
+   * a stream that's abandoned but still live (not yet collected by GC),
+   * which the reap alone wouldn't catch -- same reasoning as at every other
+   * safe point, this one was just missing it. */
+  mysql2_abandon_active_stream(wrapper);
+  mysql2_reap_pending_result_frees(wrapper);
   mysql2_drop_pending_stmt_closes(wrapper);
 
   if (wrapper->client) {

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1061,13 +1061,6 @@ static VALUE rb_mysql_query(VALUE self, VALUE sql, VALUE current) {
   REQUIRE_CONNECTED(wrapper);
   args.mysql = wrapper->client;
 
-  /* We're about to issue a new command: this is a safe point to close out
-   * any statements that were GC'd while we were busy earlier, and to free
-   * any abandoned result sets left over from a stream that was dropped
-   * mid-iteration. */
-  mysql2_reap_pending_result_frees(wrapper);
-  mysql2_reap_pending_stmt_closes(wrapper);
-
   (void)RB_GC_GUARD(current);
   Check_Type(current, T_HASH);
   rb_ivar_set(self, intern_current_query_options, current);
@@ -1081,6 +1074,17 @@ static VALUE rb_mysql_query(VALUE self, VALUE sql, VALUE current) {
 
   rb_mysql_client_set_active_fiber(self, false);
   wrapper->state = MYSQL2_CLIENT_QUERYING;
+
+  /* We're about to issue a new command: this is a safe point to close out
+   * any statements that were GC'd while we were busy earlier, and to free
+   * any abandoned result sets left over from a stream that was dropped
+   * mid-iteration. Deliberately last, right before the actual network
+   * write below -- rb_ivar_set/rb_str_export_to_enc above can themselves
+   * allocate, and under GC.stress (or just unlucky timing) that can be
+   * what triggers the GC sweep that abandons a stream, so reaping any
+   * earlier can still leave a fresh pending free undrained when we send. */
+  mysql2_reap_pending_result_frees(wrapper);
+  mysql2_reap_pending_stmt_closes(wrapper);
 
 #ifndef _WIN32
   rb_rescue2(do_send_query, (VALUE)&args, disconnect_and_raise, self, rb_eException, (VALUE)0);

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -226,6 +226,7 @@ static void rb_mysql_client_mark(void * wrapper) {
     rb_gc_mark_movable(w->encoding);
     rb_gc_mark_movable(w->active_fiber);
     rb_gc_mark_movable(w->prepared_statements);
+    rb_gc_mark_movable(w->active_streaming_result);
   }
 }
 
@@ -246,6 +247,7 @@ static void rb_mysql_client_compact(void * wrapper) {
     rb_mysql2_gc_location(w->encoding);
     rb_mysql2_gc_location(w->active_fiber);
     rb_mysql2_gc_location(w->prepared_statements);
+    rb_mysql2_gc_location(w->active_streaming_result);
   }
 }
 
@@ -480,6 +482,15 @@ void mysql2_drop_pending_result_frees(mysql_client_wrapper *wrapper)
   }
 }
 
+/* See client.h. */
+void mysql2_abandon_active_stream(mysql_client_wrapper *wrapper)
+{
+  if (wrapper->state == MYSQL2_CLIENT_STREAMING && wrapper->active_streaming_result != Qnil) {
+    mysql2_result_force_free(wrapper->active_streaming_result);
+    wrapper->active_streaming_result = Qnil;
+  }
+}
+
 static void *nogvl_close(void *ptr) {
   mysql_client_wrapper *wrapper = ptr;
 
@@ -573,6 +584,7 @@ static VALUE allocate(VALUE klass) {
   wrapper->encoding = Qnil;
   wrapper->active_fiber = Qnil;
   wrapper->prepared_statements = rb_hash_new();
+  wrapper->active_streaming_result = Qnil;
   wrapper->automatic_close = 1;
   wrapper->server_version = 0;
   wrapper->reconnect_enabled = 0;
@@ -900,7 +912,10 @@ static VALUE rb_mysql_client_async_result(VALUE self) {
       wrapper->state = MYSQL2_CLIENT_IDLE;
       rb_raise_mysql2_error(wrapper);
     }
-    /* no data and no error, so query was not a SELECT */
+    /* no data and no error, so query was not a SELECT -- e.g. :stream was
+     * requested for an INSERT/UPDATE. No cursor was actually opened, so
+     * don't leave the connection marked STREAMING. */
+    wrapper->state = MYSQL2_CLIENT_IDLE;
     return Qnil;
   }
 
@@ -909,6 +924,12 @@ static VALUE rb_mysql_client_async_result(VALUE self) {
   (void)RB_GC_GUARD(current);
   Check_Type(current, T_HASH);
   resultObj = rb_mysql_result_to_obj(self, wrapper->encoding, current, result, Qnil);
+
+  /* Track the open cursor so a later command can force-drain it if it's
+   * abandoned instead of exhausted -- see mysql2_abandon_active_stream. */
+  if (is_streaming == Qtrue) {
+    wrapper->active_streaming_result = resultObj;
+  }
 
   rb_mysql_set_server_query_flags(wrapper->client, resultObj);
 
@@ -1073,18 +1094,24 @@ static VALUE rb_mysql_query(VALUE self, VALUE sql, VALUE current) {
   args.wrapper = wrapper;
 
   rb_mysql_client_set_active_fiber(self, false);
-  wrapper->state = MYSQL2_CLIENT_QUERYING;
 
   /* We're about to issue a new command: this is a safe point to close out
    * any statements that were GC'd while we were busy earlier, and to free
    * any abandoned result sets left over from a stream that was dropped
-   * mid-iteration. Deliberately last, right before the actual network
-   * write below -- rb_ivar_set/rb_str_export_to_enc above can themselves
-   * allocate, and under GC.stress (or just unlucky timing) that can be
-   * what triggers the GC sweep that abandons a stream, so reaping any
-   * earlier can still leave a fresh pending free undrained when we send. */
+   * mid-iteration -- including one that hasn't been collected by GC yet,
+   * which the reap below alone wouldn't catch (mysql2_abandon_active_stream).
+   * Deliberately last, right before the actual network write below --
+   * rb_ivar_set/rb_str_export_to_enc above can themselves allocate, and
+   * under GC.stress (or just unlucky timing) that can be what triggers the
+   * GC sweep that abandons a stream, so reaping any earlier can still leave
+   * a fresh pending free undrained when we send. Must also run before the
+   * state assignment below: mysql2_abandon_active_stream only acts while
+   * state is still STREAMING. */
+  mysql2_abandon_active_stream(wrapper);
   mysql2_reap_pending_result_frees(wrapper);
   mysql2_reap_pending_stmt_closes(wrapper);
+
+  wrapper->state = MYSQL2_CLIENT_QUERYING;
 
 #ifndef _WIN32
   rb_rescue2(do_send_query, (VALUE)&args, disconnect_and_raise, self, rb_eException, (VALUE)0);
@@ -1448,7 +1475,10 @@ static VALUE rb_mysql_client_ping(VALUE self) {
 
   /* A low-traffic, frequently-called method; a good opportunistic safe
    * point to close out statements that were GC'd while we were busy, and to
-   * free any abandoned result sets. */
+   * free any abandoned result sets -- mysql_ping() itself sends a command,
+   * so a still-live abandoned stream needs the same active drain as
+   * rb_mysql_query, not just the reap. */
+  mysql2_abandon_active_stream(wrapper);
   mysql2_reap_pending_result_frees(wrapper);
   mysql2_reap_pending_stmt_closes(wrapper);
 

--- a/ext/mysql2/client.h
+++ b/ext/mysql2/client.h
@@ -46,6 +46,15 @@ typedef struct {
   VALUE encoding;
   VALUE active_fiber; /* rb_fiber_current() or Qnil */
   VALUE prepared_statements;
+  /* The Mysql2::Result for the currently open streaming cursor (state ==
+   * MYSQL2_CLIENT_STREAMING), or Qnil. pending_result_frees only ever gets
+   * populated once GC has actually collected an abandoned streaming
+   * Result; if the app abandons a stream and issues another command
+   * before that happens, this is what lets mysql2_abandon_active_stream
+   * find and force-drain the still-live object right now, instead of
+   * sending the new command while the server still thinks a cursor is
+   * open. */
+  VALUE active_streaming_result;
   long server_version;
   int reconnect_enabled;
   unsigned int connect_timeout;
@@ -120,5 +129,17 @@ void mysql2_reap_pending_result_frees(mysql_client_wrapper *wrapper);
  * the same tradeoff already accepted by mysql2_drop_pending_stmt_closes for
  * statements that can't be closed server-side without a round trip. */
 void mysql2_drop_pending_result_frees(mysql_client_wrapper *wrapper);
+
+/* If the connection is still STREAMING because the previous streaming
+ * Result was abandoned (caller broke out of #each, or raised, without
+ * exhausting the cursor) rather than naturally exhausted or already
+ * collected by GC, force-drain and free it now, before a new command goes
+ * out. Ordinary-Ruby-level-only, like the reap functions above -- it calls
+ * into result.c and may hit the socket. No-op if there's no live Result to
+ * drain (already handled, or already queued via
+ * mysql2_enqueue_pending_result_free for mysql2_reap_pending_result_frees
+ * to pick up). Call right before sending any new command (query, prepare,
+ * execute, ping, statement close). */
+void mysql2_abandon_active_stream(mysql_client_wrapper *wrapper);
 
 #endif

--- a/ext/mysql2/client.h
+++ b/ext/mysql2/client.h
@@ -25,6 +25,23 @@ typedef struct mysql2_pending_stmt_close {
   struct mysql2_pending_stmt_close *next;
 } mysql2_pending_stmt_close;
 
+/* A result set (MYSQL_RES and/or the row-fetch state of a MYSQL_STMT) whose
+ * Ruby Result wrapper was freed while it was an abandoned, not-fully-drained
+ * stream (mysql_use_result(), or a server-side cursor opened for a streaming
+ * prepared statement). Actually releasing either one can require reading and
+ * discarding whatever rows are still queued on the wire
+ * (mysql_free_result()'s flush_use_result, or mysql_stmt_free_result()
+ * discarding an open cursor's outstanding rows) -- blocking network I/O,
+ * unsafe from a dfree callback that may run during a GC sweep for the same
+ * reason as mysql2_pending_stmt_close above. Populated only from Result's
+ * dfree callback, so must never touch a Ruby VALUE or call back into the
+ * VM. */
+typedef struct mysql2_pending_result_free {
+  MYSQL_RES *result; /* NULL if nothing to free at this level */
+  MYSQL_STMT *stmt;  /* NULL for plain (non-prepared) results */
+  struct mysql2_pending_result_free *next;
+} mysql2_pending_result_free;
+
 typedef struct {
   VALUE encoding;
   VALUE active_fiber; /* rb_fiber_current() or Qnil */
@@ -42,6 +59,8 @@ typedef struct {
   mysql2_client_state_t state;
   mysql2_pending_stmt_close *pending_stmt_closes;
   unsigned long pending_stmt_close_count; /* O(1) mirror of the list above, for Client#pending_prepared_statement_closes */
+  mysql2_pending_result_free *pending_result_frees;
+  unsigned long pending_result_free_count;
 } mysql_client_wrapper;
 
 void rb_mysql_set_server_query_flags(MYSQL *client, VALUE result);
@@ -79,5 +98,27 @@ void mysql2_reap_pending_stmt_closes(mysql_client_wrapper *wrapper);
  * prunes prepared_statements, since this runs in ordinary Ruby context and
  * can safely touch both. */
 void mysql2_drop_pending_stmt_closes(mysql_client_wrapper *wrapper);
+
+/* Safe to call from a dfree callback (GC sweep context): only touches C
+ * memory owned by wrapper, never the Ruby VM, never blocks on I/O. */
+void mysql2_enqueue_pending_result_free(mysql_client_wrapper *wrapper, MYSQL_RES *result, MYSQL_STMT *stmt);
+
+/* Must only be called from ordinary Ruby-level code (has the GVL, not
+ * inside a GC sweep): actually frees queued result sets, which may block on
+ * network I/O to discard unread rows. Call before starting a new command on
+ * the connection, and right after a streaming result finishes or is
+ * abandoned. Must be called before mysql2_reap_pending_stmt_closes at any
+ * shared call site: a statement's outstanding result must be freed before
+ * the statement handle itself is closed. */
+void mysql2_reap_pending_result_frees(mysql_client_wrapper *wrapper);
+
+/* Also ordinary-Ruby-level-only, like the reap above, but never attempts
+ * mysql_free_result()/mysql_stmt_free_result(): for Client#close, where the
+ * connection is about to go away regardless. This does leak the client-side
+ * memory for any not-yet-drained result sets (unlike prepared statements,
+ * MYSQL_RES buffers are not cleaned up as a side effect of mysql_close()) --
+ * the same tradeoff already accepted by mysql2_drop_pending_stmt_closes for
+ * statements that can't be closed server-side without a round trip. */
+void mysql2_drop_pending_result_frees(mysql_client_wrapper *wrapper);
 
 #endif

--- a/ext/mysql2/client.h
+++ b/ext/mysql2/client.h
@@ -121,14 +121,15 @@ void mysql2_enqueue_pending_result_free(mysql_client_wrapper *wrapper, MYSQL_RES
  * the statement handle itself is closed. */
 void mysql2_reap_pending_result_frees(mysql_client_wrapper *wrapper);
 
-/* Also ordinary-Ruby-level-only, like the reap above, but never attempts
- * mysql_free_result()/mysql_stmt_free_result(): for Client#close, where the
- * connection is about to go away regardless. This does leak the client-side
- * memory for any not-yet-drained result sets (unlike prepared statements,
- * MYSQL_RES buffers are not cleaned up as a side effect of mysql_close()) --
- * the same tradeoff already accepted by mysql2_drop_pending_stmt_closes for
- * statements that can't be closed server-side without a round trip. */
-void mysql2_drop_pending_result_frees(mysql_client_wrapper *wrapper);
+/* Unlike mysql2_drop_pending_stmt_closes, there is no drop-only counterpart
+ * for result frees: mysql_close() has no side effect that reclaims a
+ * MYSQL_RES's client-side row buffers (it only releases the server's
+ * prepared-statement handles), so skipping the free would leak that memory
+ * for the rest of the process. Client#close therefore calls
+ * mysql2_reap_pending_result_frees directly instead -- it's ordinary
+ * Ruby-level code, so the network I/O that may involve is fine there, same
+ * as at any other safe point. Only the dfree-reachable teardown in
+ * decr_mysql2_client (client.c) has no such option and must drop instead. */
 
 /* If the connection is still STREAMING because the previous streaming
  * Result was abandoned (caller broke out of #each, or raised, without

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -174,7 +174,19 @@ static void rb_mysql_result_free(void *ptr) {
    * abandoned stream: the actual drain (what would make the connection
    * genuinely idle again) may have just been deferred by the call below,
    * not performed. It goes back to IDLE once mysql2_reap_pending_result_frees
-   * really runs the deferred free, at the next safe point. */
+   * really runs the deferred free, at the next safe point.
+   *
+   * active_streaming_result is different: it must be cleared right here
+   * regardless, even though state stays STREAMING. This object is about to
+   * be reclaimed, and rb_mysql_client_mark/compact touch that field
+   * unconditionally -- leaving it pointing here would crash a later GC
+   * pass. Only one stream can be open at a time, so if this wrapper is
+   * still an unfinished stream, it's the one (if any) that
+   * active_streaming_result currently references. */
+  if (wrapper->is_streaming && !wrapper->streamingComplete && wrapper->client_wrapper) {
+    wrapper->client_wrapper->active_streaming_result = Qnil;
+  }
+
   rb_mysql_result_free_result(wrapper, 1);
 
   // If the GC gets to client first it will be nil
@@ -227,6 +239,23 @@ static const rb_data_type_t rb_mysql_result_type = {
   RUBY_TYPED_FREE_IMMEDIATELY,
 #endif
 };
+
+/* See result.h. Called from ordinary Ruby-level code (has the GVL, not a
+ * GC sweep), so unlike rb_mysql_result_free above it's fine to pass
+ * from_dfree_callback=0 to rb_mysql_result_free_result: for a streaming
+ * cursor that was abandoned mid-iteration but is still live (not yet
+ * collected by GC), this performs the real, blocking
+ * mysql_free_result()/mysql_stmt_free_result() call right now instead of
+ * deferring it, so the server and client agree the previous command is
+ * done before the next one goes out. */
+void mysql2_result_force_free(VALUE self) {
+  GET_RESULT(self);
+
+  if (wrapper->resultFreed) return;
+
+  rb_mysql_result_free_result(wrapper, 0);
+  wrapper->streamingComplete = 1;
+}
 
 /*
  * for small results, this won't hit the network, but there's no
@@ -1158,6 +1187,7 @@ static VALUE rb_mysql_result_each_(VALUE self,
       // safe to reap here rather than waiting for the next command.
       if (wrapper->client_wrapper) {
         wrapper->client_wrapper->state = MYSQL2_CLIENT_IDLE;
+        wrapper->client_wrapper->active_streaming_result = Qnil;
         mysql2_reap_pending_result_frees(wrapper->client_wrapper);
         mysql2_reap_pending_stmt_closes(wrapper->client_wrapper);
       }

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -78,14 +78,46 @@ static void rb_mysql_result_mark(void * wrapper) {
   }
 }
 
-/* this may be called manually or during GC */
-static void rb_mysql_result_free_result(mysql2_result_wrapper * wrapper) {
+/* this may be called manually or during GC.
+ *
+ * from_dfree_callback must be true when called from rb_mysql_result_free
+ * (the GC dfree callback, which may run during a GC sweep) and false from
+ * every other caller (ordinary Ruby-level code, which has the GVL and is
+ * not inside a GC sweep).
+ *
+ * The distinction matters because both mysql_stmt_free_result() and
+ * mysql_free_result() are documented to potentially read and discard any
+ * rows not yet fetched off the wire -- mysql_stmt_free_result() for an open
+ * server-side cursor, mysql_free_result() for a mysql_use_result() stream
+ * (its flush_use_result) -- i.e. blocking network I/O, not just freeing
+ * local memory. That's fine from ordinary Ruby code (same category as any
+ * other query), but unsafe from a dfree callback: it may run mid-GC-sweep,
+ * possibly while this same connection is mid protocol exchange for a
+ * completely different command (see mysql2_pending_stmt_close for the
+ * sibling hazard already fixed for statement handles). This can only
+ * happen for an abandoned streaming result (is_streaming &&
+ * !streamingComplete): a fully-buffered result (mysql_store_result /
+ * mysql_stmt_store_result) is already local, so freeing it never touches
+ * the network regardless of context. When it's both streaming, unfinished,
+ * and we're in a dfree callback, defer the actual free to the next safe
+ * point instead -- see mysql2_enqueue_pending_result_free /
+ * mysql2_reap_pending_result_frees in client.h/client.c. */
+static void rb_mysql_result_free_result(mysql2_result_wrapper * wrapper, int from_dfree_callback) {
+  int defer_free;
+
   if (!wrapper) return;
 
   if (wrapper->resultFreed != 1) {
+    defer_free = from_dfree_callback && wrapper->is_streaming && !wrapper->streamingComplete
+                 && wrapper->client_wrapper;
+
     if (wrapper->stmt_wrapper) {
       if (!wrapper->stmt_wrapper->closed) {
-        mysql_stmt_free_result(wrapper->stmt_wrapper->stmt);
+        if (defer_free) {
+          mysql2_enqueue_pending_result_free(wrapper->client_wrapper, NULL, wrapper->stmt_wrapper->stmt);
+        } else {
+          mysql_stmt_free_result(wrapper->stmt_wrapper->stmt);
+        }
 
         /* MySQL BUG? If the statement handle was previously used, and so
          * mysql_stmt_bind_result was called, and if that result set and bind buffers were freed,
@@ -93,7 +125,8 @@ static void rb_mysql_result_free_result(mysql2_result_wrapper * wrapper) {
          * first result in mysql_stmt_execute. This will corrupt or crash the program.
          * By setting bind_result_done back to 0, we make MySQL think that a result set
          * has never been bound to this statement handle before to prevent the prefetch.
-         */
+         * This is just a plain C struct field write, safe to do eagerly even when the
+         * actual free above was deferred. */
         wrapper->stmt_wrapper->stmt->bind_result_done = 0;
       }
 
@@ -116,9 +149,19 @@ static void rb_mysql_result_free_result(mysql2_result_wrapper * wrapper) {
       /* Clue that the next statement execute will need to allocate a new result buffer. */
       wrapper->result_buffers = NULL;
     }
-    /* FIXME: this may call flush_use_result, which can hit the socket */
-    /* For prepared statements, wrapper->result is the result metadata */
-    mysql_free_result(wrapper->result);
+
+    /* For prepared statements, wrapper->result is the result metadata
+     * (from mysql_stmt_result_metadata), which mysql_free_result() never
+     * blocks on regardless of streaming state -- only the plain-query
+     * mysql_use_result() case above actually needs deferring here, but the
+     * same defer_free check covers both, since a prepared-statement Result
+     * always has a non-NULL stmt_wrapper (handled above) and its metadata
+     * free is cheap either way. */
+    if (defer_free) {
+      mysql2_enqueue_pending_result_free(wrapper->client_wrapper, wrapper->result, NULL);
+    } else {
+      mysql_free_result(wrapper->result);
+    }
     wrapper->resultFreed = 1;
   }
 }
@@ -127,17 +170,12 @@ static void rb_mysql_result_free_result(mysql2_result_wrapper * wrapper) {
 static void rb_mysql_result_free(void *ptr) {
   mysql2_result_wrapper *wrapper = ptr;
 
-  /* An abandoned streaming Result (caller broke out of #each, or raised,
-   * before exhausting the cursor) never reaches the streamingComplete=1
-   * reset in rb_mysql_result_each_. Without this, client_wrapper->state
-   * would be stuck STREAMING forever. This only writes a plain C field on
-   * a struct we own -- no VM calls -- so it's fine to do from a dfree
-   * callback, unlike the reap itself. */
-  if (wrapper->is_streaming && !wrapper->streamingComplete && wrapper->client_wrapper) {
-    wrapper->client_wrapper->state = MYSQL2_CLIENT_IDLE;
-  }
-
-  rb_mysql_result_free_result(wrapper);
+  /* Deliberately does NOT reset client_wrapper->state to IDLE here for an
+   * abandoned stream: the actual drain (what would make the connection
+   * genuinely idle again) may have just been deferred by the call below,
+   * not performed. It goes back to IDLE once mysql2_reap_pending_result_frees
+   * really runs the deferred free, at the next safe point. */
+  rb_mysql_result_free_result(wrapper, 1);
 
   // If the GC gets to client first it will be nil
   if (wrapper->client != Qnil) {
@@ -1073,7 +1111,7 @@ static void rb_mysql_result_cache_metadata_and_free(VALUE self) {
   GET_RESULT(self);
   rb_mysql_result_fetch_fields(self);
   rb_mysql_result_fetch_field_types(self);
-  rb_mysql_result_free_result(wrapper);
+  rb_mysql_result_free_result(wrapper, 0);
 }
 
 static VALUE rb_mysql_result_free_(VALUE self) {
@@ -1120,6 +1158,7 @@ static VALUE rb_mysql_result_each_(VALUE self,
       // safe to reap here rather than waiting for the next command.
       if (wrapper->client_wrapper) {
         wrapper->client_wrapper->state = MYSQL2_CLIENT_IDLE;
+        mysql2_reap_pending_result_frees(wrapper->client_wrapper);
         mysql2_reap_pending_stmt_closes(wrapper->client_wrapper);
       }
 

--- a/ext/mysql2/result.h
+++ b/ext/mysql2/result.h
@@ -4,6 +4,14 @@
 void init_mysql2_result(void);
 VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_RES *r, VALUE statement);
 
+/* Force-free a Result's underlying MYSQL_RES/MYSQL_STMT result right now,
+ * from ordinary Ruby-level code (not a dfree callback) -- so this performs
+ * the real mysql_free_result()/mysql_stmt_free_result() call directly
+ * rather than deferring it. Used to drain an abandoned streaming cursor
+ * that's still live (not yet collected by GC) before the next command --
+ * see mysql2_abandon_active_stream in client.c. No-op if already freed. */
+void mysql2_result_force_free(VALUE self);
+
 typedef struct {
   VALUE fields;
   VALUE fieldTypes;

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -173,7 +173,9 @@ VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql) {
       /* We're about to prepare on this connection: a safe point to close
        * out any statements that were GC'd while it was last busy, and to
        * free any abandoned result sets left over from a stream that was
-       * dropped mid-iteration. */
+       * dropped mid-iteration -- including one still live (not yet
+       * collected by GC), which the reap below alone wouldn't catch. */
+      mysql2_abandon_active_stream(stmt_wrapper->client_wrapper);
       mysql2_reap_pending_result_frees(stmt_wrapper->client_wrapper);
       mysql2_reap_pending_stmt_closes(stmt_wrapper->client_wrapper);
     } else {
@@ -355,7 +357,10 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
    * free any abandoned result sets left over from a stream that was
    * dropped mid-iteration -- including on this very statement handle, if
    * it was previously executed as a stream and abandoned before being
-   * fully drained. That must happen before we touch stmt below again. */
+   * fully drained. That must happen before we touch stmt below again.
+   * mysql2_abandon_active_stream handles the still-live case (not yet
+   * collected by GC), which the reap below alone wouldn't catch. */
+  mysql2_abandon_active_stream(wrapper);
   mysql2_reap_pending_result_frees(wrapper);
   mysql2_reap_pending_stmt_closes(wrapper);
 
@@ -539,13 +544,15 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
     }
   }
 
-  // Reap once more, right before the actual network write below: the bind
-  // setup above (rb_str_export_to_enc, rb_funcall for Time/DateTime/BigDecimal
-  // conversions, rb_hash_dup) can itself allocate, and under GC.stress (or
-  // just unlucky timing) that can be what triggers the GC sweep that abandons
-  // a *different* stream on this connection -- the earlier reap up top can't
-  // see that yet, and leaving it undrained here would desync the protocol
-  // once this command's bytes hit the wire ahead of the old stream's rows.
+  // Abandon/reap once more, right before the actual network write below: the
+  // bind setup above (rb_str_export_to_enc, rb_funcall for Time/DateTime/
+  // BigDecimal conversions, rb_hash_dup) can itself allocate, and under
+  // GC.stress (or just unlucky timing) that can be what triggers the GC
+  // sweep that abandons a *different* stream on this connection -- the
+  // earlier checks up top can't see that yet, and leaving it undrained here
+  // would desync the protocol once this command's bytes hit the wire ahead
+  // of the old stream's rows.
+  mysql2_abandon_active_stream(wrapper);
   mysql2_reap_pending_result_frees(wrapper);
   mysql2_reap_pending_stmt_closes(wrapper);
 
@@ -597,6 +604,12 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
   }
 
   resultObj = rb_mysql_result_to_obj(stmt_wrapper->client, wrapper->encoding, current, metadata, self);
+
+  /* Track the open cursor so a later command can force-drain it if it's
+   * abandoned instead of exhausted -- see mysql2_abandon_active_stream. */
+  if (is_streaming) {
+    wrapper->active_streaming_result = resultObj;
+  }
 
   rb_mysql_set_server_query_flags(wrapper->client, resultObj);
 
@@ -703,11 +716,13 @@ static VALUE rb_mysql_stmt_close(VALUE self) {
 
       /* Ordinary Ruby-level call, not GC/dfree: a safe point to also close
        * out any other statements that were GC'd while the connection was
-       * last busy. Reap pending result frees first: this statement itself
-       * may have a deferred mysql_stmt_free_result() still queued (from an
-       * abandoned streaming result on it), and that must run before
-       * nogvl_stmt_close below frees the same MYSQL_STMT* out from under
-       * it. */
+       * last busy. Abandon/reap pending result frees first: this statement
+       * itself may have an abandoned streaming result on it -- still live
+       * (mysql2_abandon_active_stream) or already queued
+       * (mysql2_reap_pending_result_frees) -- and that must be drained
+       * before nogvl_stmt_close below frees the same MYSQL_STMT* out from
+       * under it. */
+      mysql2_abandon_active_stream(wrapper);
       mysql2_reap_pending_result_frees(wrapper);
       mysql2_reap_pending_stmt_closes(wrapper);
 

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -539,6 +539,16 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
     }
   }
 
+  // Reap once more, right before the actual network write below: the bind
+  // setup above (rb_str_export_to_enc, rb_funcall for Time/DateTime/BigDecimal
+  // conversions, rb_hash_dup) can itself allocate, and under GC.stress (or
+  // just unlucky timing) that can be what triggers the GC sweep that abandons
+  // a *different* stream on this connection -- the earlier reap up top can't
+  // see that yet, and leaving it undrained here would desync the protocol
+  // once this command's bytes hit the wire ahead of the old stream's rows.
+  mysql2_reap_pending_result_frees(wrapper);
+  mysql2_reap_pending_stmt_closes(wrapper);
+
   // From here through mysql_stmt_result_metadata/mysql_stmt_store_result,
   // the connection is BUSY: a Statement freed elsewhere during this window
   // must not be allowed to write COM_STMT_CLOSE to this socket. See

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -171,7 +171,10 @@ VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql) {
       stmt_wrapper->client_wrapper->refcount++;
 
       /* We're about to prepare on this connection: a safe point to close
-       * out any statements that were GC'd while it was last busy. */
+       * out any statements that were GC'd while it was last busy, and to
+       * free any abandoned result sets left over from a stream that was
+       * dropped mid-iteration. */
+      mysql2_reap_pending_result_frees(stmt_wrapper->client_wrapper);
       mysql2_reap_pending_stmt_closes(stmt_wrapper->client_wrapper);
     } else {
       stmt_wrapper->client_wrapper = NULL;
@@ -348,7 +351,12 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
   GET_CLIENT(stmt_wrapper->client);
 
   /* We're about to issue a new command on this connection: a safe point to
-   * close out any statements that were GC'd while it was last busy. */
+   * close out any statements that were GC'd while it was last busy, and to
+   * free any abandoned result sets left over from a stream that was
+   * dropped mid-iteration -- including on this very statement handle, if
+   * it was previously executed as a stream and abandoned before being
+   * fully drained. That must happen before we touch stmt below again. */
+  mysql2_reap_pending_result_frees(wrapper);
   mysql2_reap_pending_stmt_closes(wrapper);
 
   conn_enc = rb_to_encoding(wrapper->encoding);
@@ -554,6 +562,7 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
       rb_raise_mysql2_stmt_error(stmt_wrapper);
     }
     // no data and no error, so query was not a SELECT
+    mysql2_reap_pending_result_frees(wrapper);
     mysql2_reap_pending_stmt_closes(wrapper);
     return Qnil;
   }
@@ -569,6 +578,7 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
     // The whole result set is buffered locally; free to reap and to run
     // another command right away.
     wrapper->state = MYSQL2_CLIENT_IDLE;
+    mysql2_reap_pending_result_frees(wrapper);
     mysql2_reap_pending_stmt_closes(wrapper);
   } else {
     // A cursor is now open on the server; leave the connection BUSY until
@@ -683,7 +693,12 @@ static VALUE rb_mysql_stmt_close(VALUE self) {
 
       /* Ordinary Ruby-level call, not GC/dfree: a safe point to also close
        * out any other statements that were GC'd while the connection was
-       * last busy. */
+       * last busy. Reap pending result frees first: this statement itself
+       * may have a deferred mysql_stmt_free_result() still queued (from an
+       * abandoned streaming result on it), and that must run before
+       * nogvl_stmt_close below frees the same MYSQL_STMT* out from under
+       * it. */
+      mysql2_reap_pending_result_frees(wrapper);
       mysql2_reap_pending_stmt_closes(wrapper);
 
       stmt_wrapper->closed = 1;

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -568,12 +568,48 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       end.to_not raise_error
     end
 
-    it "should not let you query again if iterating is not finished when streaming" do
+    it "should let you query again if the previous streaming result was abandoned (not fully iterated)" do
+      # Only fetch the first row and never touch the rest of the cursor.
+      # The next query must not raise "Commands out of sync" -- the client
+      # should force-drain the abandoned cursor itself, even though GC
+      # hasn't had a chance to collect the old Result yet.
       @client.query("SELECT 1 UNION SELECT 2", stream: true, cache_rows: false).first
 
       expect do
         @client.query("SELECT 1 UNION SELECT 2", stream: true, cache_rows: false)
-      end.to raise_exception(Mysql2::Error)
+      end.to_not raise_error
+    end
+
+    it "should let you query again after breaking out of #each on a streaming result early" do
+      # rubocop:disable Lint/UnreachableLoop
+      @client.query("SELECT 1 UNION SELECT 2 UNION SELECT 3", stream: true, cache_rows: false).each do |_row|
+        break
+      end
+      # rubocop:enable Lint/UnreachableLoop
+
+      result = @client.query("SELECT 1 UNION SELECT 2 UNION SELECT 3", stream: true, cache_rows: false)
+      expect(result.to_a).to eq([{ '1' => 1 }, { '1' => 2 }, { '1' => 3 }])
+    end
+
+    it "should let you query again after an exception raised inside a streaming #each block" do
+      # rubocop:disable Lint/UnreachableLoop
+      expect do
+        @client.query("SELECT 1 UNION SELECT 2 UNION SELECT 3", stream: true, cache_rows: false).each do |_row|
+          raise "boom"
+        end
+      end.to raise_error("boom")
+      # rubocop:enable Lint/UnreachableLoop
+
+      result = @client.query("SELECT 1 UNION SELECT 2 UNION SELECT 3", stream: true, cache_rows: false)
+      expect(result.to_a).to eq([{ '1' => 1 }, { '1' => 2 }, { '1' => 3 }])
+    end
+
+    it "should let you query again if a streaming result was abandoned and only collected by the GC" do
+      @client.query("SELECT 1 UNION SELECT 2 UNION SELECT 3", stream: true, cache_rows: false).first
+      run_gc
+
+      result = @client.query("SELECT 1 UNION SELECT 2 UNION SELECT 3", stream: true, cache_rows: false)
+      expect(result.to_a).to eq([{ '1' => 1 }, { '1' => 2 }, { '1' => 3 }])
     end
 
     it "should only accept strings as the query parameter" do

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -243,6 +243,31 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     # rubocop:enable Lint/AmbiguousBlockAssociation
   end
 
+  it "should reap (not just drop) a pending abandoned streaming result when the client is closed" do
+    # Unlike a pending statement close, mysql_close() has no side effect that
+    # reclaims a MYSQL_RES's client-side row buffers -- see
+    # mysql2_reap_pending_result_frees vs mysql2_drop_pending_stmt_closes in
+    # ext/mysql2/client.c. #close must actually free a queued result, not
+    # just clear the bookkeeping, or that memory leaks for the rest of the
+    # process. This can't observe the leak directly from Ruby, but it does
+    # confirm #close runs the real (potentially blocking) free without
+    # erroring or hanging, with enough unread rows on the wire to matter.
+    client = new_client
+    sql = 'WITH RECURSIVE seq AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM seq WHERE n < 500) SELECT n FROM seq'
+    begin
+      GC.stress = true
+      result = client.query(sql, stream: true, cache_rows: false)
+      result.first
+      result = nil # rubocop:disable Lint/UselessAssignment
+    ensure
+      GC.stress = false
+    end
+    GC.start
+
+    expect { client.close }.to_not raise_error
+    expect(client.pending_result_frees).to eq(0)
+  end
+
   it "should not leave dangling connections after garbage collection" do
     run_gc
     # rubocop:disable Lint/AmbiguousBlockAssociation

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -764,4 +764,98 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
       expect(test_result.server_flags[:no_good_index_used]).to eql(false)
     end
   end
+
+  context 'garbage collection ordering' do
+    # Regression coverage for the deferred pending-free queue (see
+    # mysql2_enqueue_pending_result_free / mysql2_reap_pending_result_frees
+    # in ext/mysql2/client.c, and rb_mysql_result_free_result in
+    # ext/mysql2/result.c). A streaming Result (:stream => true) that is
+    # abandoned mid-iteration -- the caller breaks out of #each, or simply
+    # never finishes reading it -- still holds an open cursor with unread
+    # rows on the wire when it becomes GC-eligible. Before this fix, the
+    # Result's GC free function called mysql_free_result/
+    # mysql_stmt_free_result directly, which for such a cursor may read and
+    # discard the remaining rows over the network (flush_use_result) --
+    # blocking I/O from a dfree callback that can run mid-GC-sweep, possibly
+    # while the same connection is mid protocol exchange for a completely
+    # unrelated command. See also the "garbage collection ordering" context
+    # in statement_spec.rb for the sibling statement-close hazard.
+    #
+    # A small, fast loopback connection doesn't reliably reproduce the
+    # network-corruption failure mode even without this fix: there just
+    # isn't much of a timing window to hit. These specs lean on GC.stress
+    # and a larger streamed row count to widen that window as far as
+    # practical, but they are regression coverage for the deferred-free
+    # bookkeeping (no crash, no corrupted results, queue drains to zero)
+    # rather than a guaranteed repro of the underlying race.
+
+    # A recursive CTE with several hundred rows, so breaking out of #each
+    # early genuinely leaves rows unread on the wire (the fixture table
+    # mysql2_test only ever has a single row).
+    let(:big_stream_sql) do
+      'WITH RECURSIVE seq AS (SELECT 1 AS n UNION ALL SELECT n + 1 FROM seq WHERE n < 500) SELECT n FROM seq'
+    end
+
+    it 'does not corrupt later queries when an abandoned streaming result is collected mid-stream' do
+      begin
+        GC.stress = true
+        30.times do |i|
+          result = @client.query(big_stream_sql, stream: true, cache_rows: false)
+          count = 0
+          result.each do |_row|
+            count += 1
+            break if count == 3
+          end
+          result = nil # rubocop:disable Lint/UselessAssignment
+
+          expect(@client.query("SELECT #{i} AS n").first['n']).to eq(i)
+        end
+      ensure
+        GC.stress = false
+      end
+    end
+
+    it 'does not corrupt later queries when an abandoned streaming prepared statement result is collected mid-stream' do
+      begin
+        GC.stress = true
+        30.times do |i|
+          stmt = @client.prepare(big_stream_sql)
+          result = stmt.execute(stream: true, cache_rows: false)
+          count = 0
+          result.each do |_row|
+            count += 1
+            break if count == 3
+          end
+          result = nil # rubocop:disable Lint/UselessAssignment
+          stmt = nil # rubocop:disable Lint/UselessAssignment
+
+          expect(@client.query("SELECT #{i} AS n").first['n']).to eq(i)
+        end
+      ensure
+        GC.stress = false
+      end
+    end
+
+    it 'drains #pending_result_frees to zero at the next safe point' do
+      # A plain GC.start right after dropping the reference doesn't reliably
+      # collect a Result that a C extension method (#first) just touched --
+      # conservative stack scanning can keep it artificially reachable for a
+      # while. GC.stress forces the issue on every subsequent allocation,
+      # same as the specs above.
+      begin
+        GC.stress = true
+        30.times do
+          result = @client.query(big_stream_sql, stream: true, cache_rows: false)
+          result.first
+          result = nil # rubocop:disable Lint/UselessAssignment
+        end
+      ensure
+        GC.stress = false
+      end
+
+      GC.start
+      @client.ping
+      expect(@client.pending_result_frees).to eq(0)
+    end
+  end
 end

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -282,6 +282,26 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
         n += 1
       end
     end
+
+    it "should let you execute/query again after abandoning a prepared statement's streaming result" do
+      stmt = @client.prepare("SELECT 1 UNION SELECT 2 UNION SELECT 3")
+      stmt.execute(stream: true, cache_rows: false).first
+
+      expect do
+        stmt.execute(stream: true, cache_rows: false)
+      end.to_not raise_error
+
+      result = @client.query("SELECT 1 UNION SELECT 2 UNION SELECT 3", stream: true, cache_rows: false)
+      expect(result.to_a).to eq([{ '1' => 1 }, { '1' => 2 }, { '1' => 3 }])
+    end
+
+    it "should let a plain query drain an abandoned prepared statement streaming result" do
+      stmt = @client.prepare("SELECT 1 UNION SELECT 2 UNION SELECT 3")
+      stmt.execute(stream: true, cache_rows: false).first
+
+      result = @client.query("SELECT 1 UNION SELECT 2 UNION SELECT 3")
+      expect(result.to_a).to eq([{ '1' => 1 }, { '1' => 2 }, { '1' => 3 }])
+    end
   end
 
   context "#each" do


### PR DESCRIPTION
## Depends on #1048

**This PR contains and depends on #1048** ("Add references from Client and Statement to each other to prevent out of order GC"). Its branch (`result-free-gc-deferral`) is built directly on top of #1048's head branch (`statement-refcounts`), so the diff shown here currently includes all of #1048's commits plus the two commits described below. GitHub doesn't support stacking a PR's base on an unmerged branch from a different repo, so there wasn't a way to open this cleanly scoped to only my changes while #1048 is still open.

**Once #1048 merges**, I will rebase this branch onto `master` so the diff here shrinks down to just the new commits.

There is also a same-repo staging PR, [sodabrew/mysql2#4](https://github.com/sodabrew/mysql2/pull/4), which shows only my commits in isolation (base: `statement-refcounts`) for easier review in the meantime.

## Summary

An abandoned streaming `Mysql2::Result` -- `stream: true`, then the caller breaks out of `#each` early or an exception propagates out of the block -- leaves both mysql2's own bookkeeping and the wire protocol in a bad state until something actively cleans it up. There are two distinct hazards here, fixed by two separate commits:

1. **Freeing it can block on the socket.** `mysql_free_result()` / `mysql_stmt_free_result()` are documented to read and discard any not-yet-fetched rows off the wire for an unbuffered/streamed result -- blocking network I/O, not just local memory cleanup (see the FIXME this removes in `rb_mysql_result_free_result`). The GC dfree callback for `Mysql2::Result` used to call these directly and unconditionally, even though a dfree callback can run mid-GC-sweep and must never block on I/O -- the same class of bug as the statement-close fix in #1048.
2. **Even once that's fixed safely, nothing drains the cursor until GC gets around to it.** An abandoned Result becomes an ordinary unreachable object, and Ruby's conservative stack scanning means it's often *not* collected immediately -- a temporary Result touched by a C extension method (like `#first`) can stay artificially reachable for a while. If the app issues another command on the same `Client` before that collection happens, the server still believes the previous cursor is open, and the new command fails with "Commands out of sync". This is the practically common shape of the original bug report.

## Commits

- **#1048** (`a206254`, `911f432`, `b3ca8c4`, `69f9804`, `6ec18f0`, `b7a8c04`) -- adds cross-references between `Client` and `Statement` so GC can't tear one down out of order, a `mysql2_client_state_t` state machine (`IDLE`/`QUERYING`/`STREAMING`) on the client wrapper, and a deferred-close queue (`pending_stmt_closes`) so a `Statement` freed while the connection is busy doesn't send `COM_STMT_CLOSE` mid protocol-exchange; also fixes two GC-compaction/marking bugs uncovered while landing that (`prepared_statements` missing from the compact callback, and `fields`/`fieldTypes` needing a stack-local `RB_GC_GUARD` during their fill loops).
- `94ea26a` **Defer freeing an abandoned streaming Result until the connection is idle** -- adds a second deferred-free queue (`pending_result_frees`) mirroring `pending_stmt_closes`: the dfree callback only enqueues (plain `malloc`, no VM calls, no I/O), and the real `mysql_free_result()`/`mysql_stmt_free_result()` call happens later from ordinary Ruby-level code, at the same safe points already used for statement closes (query, prepare, execute, ping, stream completion, explicit close). Fixes hazard 1 above.
- `5a30cc9` **Actively drain a still-live abandoned streaming cursor, not just a collected one** -- tracks the currently-open streaming cursor's `Result` directly on the client wrapper (`active_streaming_result`) and, at the same safe points, checks the connection's state first: if it's still `STREAMING`, force-drains that `Result` synchronously right now instead of waiting for GC to enqueue it. Fixes hazard 2 above -- the gap the queue alone doesn't cover. Also fixes a `GC.verify_compaction_references` abort in `rb_mysql_client_mark` uncovered while stress-testing this: `active_streaming_result` needed `rb_mysql2_gc_location` in `rb_mysql_client_compact` alongside the other `VALUE` fields, the same class of bug as the `prepared_statements` compaction gap #1048 fixed.

## Test plan

- [x] `bundle exec rake compile` -- clean, no new warnings
- [x] Full `bundle exec rspec` suite, repeated runs on top of #1048's latest commit -- 377 examples, 0 failures beyond the pre-existing `#automatic_close ... child process` flake (confirmed to reproduce identically on the unmodified baseline)
- [x] Regression specs in `spec/mysql2/result_spec.rb` ("garbage collection ordering" context) using `GC.stress`, covering the deferred-queue path (`94ea26a`)
- [x] New regression specs in `spec/mysql2/client_spec.rb` and `spec/mysql2/statement_spec.rb` covering the still-live/not-yet-collected path directly (`5a30cc9`) -- breaking out of `#each` early, an exception raised inside the block, and (for prepared statements) abandoning a streaming `Statement#execute` result, in each case immediately issuing another query/execute with no explicit GC in between and asserting it succeeds with correct data
- [x] Manually reproduced both hazards against an unpatched connection before fixing: hazard 2 (immediate requery after abandoning a stream, no GC) reliably raised "Commands out of sync"; the `GC.verify_compaction_references` crash reproduced reliably under a stress script exercising many abandoned plain-query and prepared-statement streams

🤖 Generated with [Claude Code](https://claude.com/claude-code)
