### PR TITLE
Use eventmachine from git master on Ruby >= 4.0

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -13,7 +13,17 @@ gem 'rake-compiler', '~> 1.2.0'
 gem 'irb', require: false
 
 group :test do
-  gem 'eventmachine' unless RUBY_PLATFORM =~ /mswin|mingw/
+  unless RUBY_PLATFORM =~ /mswin|mingw/
+    if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('4.0')
+      # eventmachine 1.2.7's bundled fastfilereader C++ extension uses
+      # Data_Wrap_Struct/Data_Get_Struct, removed from Ruby 4.0's headers.
+      # Fixed on eventmachine's master (not yet released), so track that
+      # until a new release is cut.
+      gem 'eventmachine', github: 'eventmachine/eventmachine'
+    else
+      gem 'eventmachine'
+    end
+  end
   gem 'rspec', '~> 3.2'
 
   gem 'rubocop'

--- a/Gemfile
+++ b/Gemfile
@@ -15,10 +15,8 @@ gem 'irb', require: false
 group :test do
   unless RUBY_PLATFORM =~ /mswin|mingw/
     if Gem::Version.new(RUBY_VERSION) >= Gem::Version.new('4.0')
-      # eventmachine 1.2.7's bundled fastfilereader C++ extension uses
-      # Data_Wrap_Struct/Data_Get_Struct, removed from Ruby 4.0's headers.
-      # Fixed on eventmachine's master (not yet released), so track that
-      # until a new release is cut.
+      # Ruby 4.0 removed Data_Wrap_Struct, breaking eventmachine 1.2.7's
+      # fastfilereader ext; use git master until a fix is released.
       gem 'eventmachine', github: 'eventmachine/eventmachine'
     else
       gem 'eventmachine'


### PR DESCRIPTION
## Summary

The `ruby: 'head'` and `ruby: '4.0'` CI jobs in `build.yml` fail during `bundle install` because eventmachine 1.2.7's bundled `fastfilereader` C++ extension calls `Data_Wrap_Struct`/`Data_Get_Struct`, both of which Ruby 4.0 removed from its headers:

```
rubymain.cpp:53:19: error: 'Data_Wrap_Struct' was not declared in this scope
```

eventmachine has had no release since 1.2.7 (2019), but its maintainer confirmed this is already fixed on `master` (eventmachine/eventmachine@79f05e4) — just not yet cut into a release.

## Fix

`Gemfile` now points `eventmachine` at `github: 'eventmachine/eventmachine'` (git master) when `RUBY_VERSION >= 4.0`, falling back to the released 1.2.7 gem on older Rubies. `spec/em/em_spec.rb` already tolerates eventmachine being unavailable via a `begin/rescue LoadError`, so no spec changes were needed.

This is a stopgap: once eventmachine cuts a release containing the fix, the version constraint here should be updated to require that release instead of pinning to git master.

## Test plan

- [x] Installed Ruby 4.0.6 locally via mise, confirmed the CI failure reproduces with the Gemfile unchanged (eventmachine 1.2.7 fails to compile `fastfilereaderext`)
- [x] With this fix, `bundle install` resolves `eventmachine (1.3.0.dev.1)` from git master and compiles `fastfilereaderext.bundle`/`rubyeventmachine.bundle` cleanly under Ruby 4.0.6
- [x] `bundle exec rspec spec/em/em_spec.rb` — 6 examples, 0 failures
- [x] Full `bundle exec rspec` suite — 366 examples, 1 failure (pre-existing, unrelated fork/child-process flake), 7 pending (pre-existing SSL cert path skips)
- [x] `bundle exec rubocop` — clean

Ruby 4.0 and `ruby-head` are already present in the CI matrix in `build.yml`, so no workflow changes are needed — the Gemfile's version check applies automatically to those jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)