### PR TITLE
Treat empty string same as NULL in Client#database

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1359,9 +1359,11 @@ static VALUE rb_mysql_client_database(VALUE self) {
   GET_CLIENT(self);
 
   char *db = wrapper->client->db;
-  // Oracle's libmysqlclient leaves this NULL when no database is selected;
-  // MariaDB Connector/C leaves it as an empty string instead. Treat both as
-  // "no database" so the two client libraries behave consistently.
+  // NULL when no database is selected against MariaDB servers < 12.3 (and
+  // any MySQL server); an empty string against MariaDB servers >= 12.3,
+  // confirmed by pairing MariaDB 11.8/12.3 client libraries against both
+  // server versions independently -- the client library version made no
+  // difference, only the server's did. Treat both as "no database".
   if (!db || db[0] == '\0') {
     return Qnil;
   }

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1359,11 +1359,11 @@ static VALUE rb_mysql_client_database(VALUE self) {
   GET_CLIENT(self);
 
   char *db = wrapper->client->db;
-  if (!db) {
+  if (!db || db[0] == '\0') {
     return Qnil;
   }
 
-  return rb_str_new_cstr(wrapper->client->db);
+  return rb_str_new_cstr(db);
 }
 
 /* call-seq:

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1359,6 +1359,9 @@ static VALUE rb_mysql_client_database(VALUE self) {
   GET_CLIENT(self);
 
   char *db = wrapper->client->db;
+  // Oracle's libmysqlclient leaves this NULL when no database is selected;
+  // MariaDB Connector/C leaves it as an empty string instead. Treat both as
+  // "no database" so the two client libraries behave consistently.
   if (!db || db[0] == '\0') {
     return Qnil;
   }


### PR DESCRIPTION
## Summary

`Client#database should be nil when no database is selected` was failing on the Fedora `Container` CI job:

```
expected: nil
     got: ""
```

**Updated diagnosis**: this is a MariaDB **server** behavior change (server version >= 12.3), not a client library difference as originally suspected. The initial theory was that Oracle's `libmysqlclient` leaves `MYSQL::db` as `NULL` while MariaDB Connector/C leaves it as `""` -- but that was confounded: every environment tested always paired a MariaDB-track client library with a same-track MariaDB server, so it couldn't distinguish "client library" from "server" as the actual cause.

This was resolved with a CI matrix ([brianmario/mysql2#1473](https://github.com/brianmario/mysql2/pull/1473)) that pairs MariaDB 11.8 and 12.3 client libraries against *both* server versions independently:

| Client | Server | Bug reproduces? |
|---|---|---|
| MariaDB 11.8 | MariaDB 11.8 | No |
| MariaDB 11.8 | MariaDB 12.3 | **Yes** |
| MariaDB 12.3 | MariaDB 11.8 | No |
| MariaDB 12.3 | MariaDB 12.3 | **Yes** |

The client library version made no difference in either direction -- only the server version did. I checked MariaDB's official 12.3 release notes, changelogs, and Jira for any documented change here and found nothing; this looks like an undocumented server-side behavior change.

`rb_mysql_client_database` only checked for a NULL pointer, so it returned `""` instead of `nil` against these newer servers.

## Fix

Treat an empty string the same as NULL, with a comment documenting the actual (server-version-based) cause.

## Test plan

- [x] `bundle exec rspec spec/mysql2/client_spec.rb -e database` — 9 examples, 0 failures (this machine's MariaDB is < 12.3, so the empty-string case doesn't reproduce here, but the fix is a straightforward superset check)
- [x] Confirmed via #1473's CI matrix that this fix is necessary and sufficient against a real MariaDB 12.3 server, independent of client library version
- [x] `bundle exec rubocop` — clean (Ruby-only; this is a C extension change)

(Narrowed from this PR's original broader scope -- the DateTime microsecond fix and flaky-test timing-margin fixes that were originally bundled here now have their own PRs: #1469 and #1471.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
