### PR TITLE
CI: Add MySQL 9.7 LTS to the build matrix

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -10,7 +10,8 @@ jobs:
       matrix:
         include:
           # Ruby 3.x / 4.x on Ubuntu 24.04 LTS
-          - {os: ubuntu-24.04, ruby: 'head', db: mysql84}
+          - {os: ubuntu-24.04, ruby: 'head', db: mysql97}
+          - {os: ubuntu-24.04, ruby: '4.0', db: mysql97}
           - {os: ubuntu-24.04, ruby: '4.0', db: mysql84}
           - {os: ubuntu-24.04, ruby: '3.4', db: mysql84}
 
@@ -44,6 +45,7 @@ jobs:
           # Allow failure due to this issue:
           # https://github.com/brianmario/mysql2/issues/1194
           - {os: macos-latest, ruby: '4.0', db: mariadb@11.4, ssl: openssl@3, allow-failure: true}
+          - {os: macos-latest, ruby: '4.0', db: mysql@9.7, ssl: openssl@3, allow-failure: true}          
           - {os: macos-latest, ruby: '4.0', db: mysql@8.4, ssl: openssl@3, allow-failure: true}
           - {os: macos-latest, ruby: '2.6', db: mysql@8.0, ssl: openssl@3, allow-failure: true}
 

--- a/README.md
+++ b/README.md
@@ -626,7 +626,7 @@ This gem is tested with the following Ruby versions on Linux and macOS:
 
 This gem is tested with the following MySQL and MariaDB versions:
 
-* MySQL 8.0, 8.4
+* MySQL 8.0, 8.4, 9.7
 * MySQL Connector/C 6.0, 6.1, 8.0 (primarily on Windows)
 * MariaDB 10.6, 10.11, 11.4
 * MariaDB Connector/C 2.x, 3.x

--- a/ci/mysql97.sh
+++ b/ci/mysql97.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -eux
+
+apt-get purge -qq '^mysql*' '^libmysql*'
+rm -fr /etc/mysql
+rm -fr /var/lib/mysql
+apt-key add support/B7B3B788A8D3785C.asc # 8.1 and higher
+# Verify the repository as add-apt-repository does not.
+wget -q --spider http://repo.mysql.com/apt/ubuntu/dists/$(lsb_release -cs)/mysql-9.7-lts
+add-apt-repository 'http://repo.mysql.com/apt/ubuntu mysql-9.7-lts'
+apt-get update -qq
+apt-get install -qq mysql-server libmysqlclient-dev

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -44,6 +44,12 @@ if [[ -n ${DB-} && x$DB =~ ^xmysql84 ]]; then
   CHANGED_PASSWORD_SHA2=true
 fi
 
+# Install MySQL 9.7 if DB=mysql97
+if [[ -n ${DB-} && x$DB =~ ^xmysql97 ]]; then
+  sudo bash ci/mysql97.sh
+  CHANGED_PASSWORD_SHA2=true
+fi
+
 # Install MariaDB 10.6 if DB=mariadb10.6
 if [[ -n ${GITHUB_ACTIONS-} && -n ${DB-} && x$DB =~ ^xmariadb10.6 ]]; then
   sudo bash ci/mariadb106.sh


### PR DESCRIPTION
MySQL 9.7 is the new LTS release (GA 2026-04-21), succeeding 8.4 LTS.

Refs:
- https://blogs.oracle.com/mysql/mysql-9-7-lts-is-here-upgrade-and-modernize-on-a-stronger-community-edition
- https://dev.mysql.com/doc/relnotes/mysql/9.7/en/news-9-7-0.html