### PR TITLE
Treat empty string same as NULL in Client#database

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1359,11 +1359,11 @@ static VALUE rb_mysql_client_database(VALUE self) {
   GET_CLIENT(self);
 
   char *db = wrapper->client->db;
-  if (!db) {
+  if (!db || db[0] == '\0') {
     return Qnil;
   }
 
-  return rb_str_new_cstr(wrapper->client->db);
+  return rb_str_new_cstr(db);
 }
 
 /* call-seq:

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1359,6 +1359,9 @@ static VALUE rb_mysql_client_database(VALUE self) {
   GET_CLIENT(self);
 
   char *db = wrapper->client->db;
+  // Oracle's libmysqlclient leaves this NULL when no database is selected;
+  // MariaDB Connector/C leaves it as an empty string instead. Treat both as
+  // "no database" so the two client libraries behave consistently.
   if (!db || db[0] == '\0') {
     return Qnil;
   }


### PR DESCRIPTION
## Summary

Split out from #1465 for a focused, single-topic PR.

`Client#database should be nil when no database is selected` was failing on the Fedora `Container` CI job:

```
expected: nil
     got: ""
```

Fedora's container links against `mariadb-connector-c-devel` rather than Oracle's `libmysqlclient`. Oracle's libmysqlclient leaves `MYSQL::db` as `NULL` when no database is selected; MariaDB Connector/C leaves it as an empty string (`""`) instead. `rb_mysql_client_database` only checked for a NULL pointer, so it returned `""` instead of `nil` on that connector.

## Fix

Treat an empty string the same as NULL, with a comment documenting the two client libraries' differing behavior.

## Test plan

- [x] `bundle exec rspec spec/mysql2/client_spec.rb -e database` — 9 examples, 0 failures (macOS/libmysqlclient locally, so the empty-string case doesn't reproduce here, but the fix is a straightforward superset check)
- [x] `bundle exec rubocop` — clean (Ruby-only; this is a C extension change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)