### PR TITLE
Widen timing margins in three flaky specs

### DIFF
--- a/spec/em/em_spec.rb
+++ b/spec/em/em_spec.rb
@@ -120,7 +120,7 @@ begin
         defer.errback do
           callbacks_run << :errback
         end
-        EM.add_timer(0.1) do
+        EM.add_timer(0.5) do
           expect(callbacks_run).to eq([:callback])
           expect do
             client.close

--- a/spec/em/em_spec.rb
+++ b/spec/em/em_spec.rb
@@ -8,7 +8,7 @@ begin
       results = []
       EM.run do
         client1 = Mysql2::EM::Client.new DatabaseCredentials['root']
-        defer1 = client1.query "SELECT sleep(0.1) as first_query"
+        defer1 = client1.query "SELECT sleep(0.3) as first_query"
         defer1.callback do |result|
           results << result.first
           client1.close

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -713,7 +713,7 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       it 'should be impervious to connection-corrupting timeouts in #execute' do
         # attempt to break the connection
         stmt = @client.prepare('SELECT SLEEP(?)')
-        expect { Timeout.timeout(0.1) { stmt.execute(0.2) } }.to raise_error(Timeout::Error)
+        expect { Timeout.timeout(0.1) { stmt.execute(1) } }.to raise_error(Timeout::Error)
         stmt.close
 
         # expect the connection to not be broken


### PR DESCRIPTION
## Summary

Three specs paired a short `SELECT SLEEP(...)`/timer with too little headroom, making them flaky under CI scheduling load (all three failures were observed on the macOS CI jobs):

1. **`spec/em/em_spec.rb`** "should support async queries" — asserted completion order for two concurrent queries based on a 75ms difference (`SLEEP(0.1)` vs `SLEEP(0.025)`). Widened to `SLEEP(0.3)` vs `SLEEP(0.025)` (275ms margin).
2. **`spec/mysql2/client_spec.rb`** "should be impervious to connection-corrupting timeouts in #execute" — paired a `Timeout.timeout(0.1)` with only `SLEEP(0.2)`, a 2x margin. Every other `Timeout.timeout(0.1, ...)` spec in the same file pairs it with `SLEEP(1)`, a 10x margin; brought this one in line with that established pattern.
3. **`spec/em/em_spec.rb`** "should not raise error when closing client with no query running" — fired `SELECT SLEEP(0.025)` then checked, via a 0.1s timer, that the callback had already run (4x margin). Widened the timer to 0.5s (20x margin) to match the headroom used elsewhere in the file.

None of these are logic bugs — just insufficient timing headroom for CI's scheduling jitter.

## Test plan

- [x] Each spec run 10-20x locally after its fix, 0 failures in every run
- [x] `bundle exec rspec spec/em/em_spec.rb` — 6 examples, 0 failures
- [x] `bundle exec rubocop` — clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)