### PR TITLE
Fixes #1428: fix locale-sensitive strtod() misreading DECIMAL/FLOAT/DOUBLE

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -25,6 +25,8 @@ group :test do
   gem 'rspec', '~> 3.2'
 
   gem 'rubocop'
+
+  gem 'clocale'
 end
 
 group :benchmarks, optional: true do

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -59,7 +59,7 @@ extern VALUE mMysql2, cMysql2Client, cMysql2Error;
 static VALUE cMysql2Result, cDateTime, cDate;
 static VALUE opt_decimal_zero, opt_float_zero, opt_time_year, opt_time_month, opt_utc_offset;
 static ID intern_new, intern_utc, intern_local, intern_localtime, intern_local_offset,
-  intern_civil, intern_new_offset, intern_merge, intern_BigDecimal,
+  intern_civil, intern_new_offset, intern_merge, intern_BigDecimal, intern_Float,
   intern_query_options;
 static VALUE sym_symbolize_keys, sym_as, sym_array, sym_database_timezone,
   sym_application_timezone, sym_local, sym_utc, sym_cast_booleans,
@@ -739,6 +739,23 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
   return rowVal;
 }
 
+/* Whether a MySQL DECIMAL wire value is zero: sign, digits, '.', digits,
+ * no exponent, so a value is zero iff every digit is '0'. Checked with a
+ * plain character scan rather than strtod(), which reads '.' according to
+ * the current LC_NUMERIC and misparses this otherwise-locale-independent
+ * string under any locale that uses ',' instead. */
+static int decimal_str_is_zero(const char *str) {
+  const char *p = str;
+
+  if (*p == '-' || *p == '+') p++;
+
+  for (; *p; p++) {
+    if (*p != '0' && *p != '.') return 0;
+  }
+
+  return 1;
+}
+
 static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const result_each_args *args)
 {
   VALUE rowVal;
@@ -818,7 +835,7 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
         case MYSQL_TYPE_NEWDECIMAL: /* Precision math DECIMAL or NUMERIC field (MySQL 5.0.3 and up) */
           if (fields[i].decimals == 0) {
             val = rb_cstr2inum(row[i], 10);
-          } else if (strtod(row[i], NULL) == 0.000000){
+          } else if (decimal_str_is_zero(row[i])) {
             val = rb_funcall(rb_mKernel, intern_BigDecimal, 1, opt_decimal_zero);
           }else{
             val = rb_funcall(rb_mKernel, intern_BigDecimal, 1, rb_str_new(row[i], fieldLengths[i]));
@@ -826,12 +843,13 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
           break;
         case MYSQL_TYPE_FLOAT:      /* FLOAT field */
         case MYSQL_TYPE_DOUBLE: {     /* DOUBLE or REAL field */
-          double column_to_double;
-          column_to_double = strtod(row[i], NULL);
-          if (column_to_double == 0.000000){
+          /* Kernel#Float() parses this locale-independently; strtod()
+           * would read '.' according to the current LC_NUMERIC. */
+          VALUE column_as_float = rb_funcall(rb_mKernel, intern_Float, 1, rb_str_new(row[i], fieldLengths[i]));
+          if (RFLOAT_VALUE(column_as_float) == 0.000000){
             val = opt_float_zero;
           }else{
-            val = rb_float_new(column_to_double);
+            val = column_as_float;
           }
           break;
         }
@@ -1327,6 +1345,7 @@ void init_mysql2_result(void) {
   intern_civil        = rb_intern("civil");
   intern_new_offset   = rb_intern("new_offset");
   intern_BigDecimal   = rb_intern("BigDecimal");
+  intern_Float        = rb_intern("Float");
   intern_query_options = rb_intern("@query_options");
 
   sym_symbolize_keys  = ID2SYM(rb_intern("symbolize_keys"));

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -1,4 +1,5 @@
 require 'spec_helper'
+require 'clocale'
 
 RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
   before(:example) do
@@ -485,6 +486,41 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
     it "should return Float for a DOUBLE value" do
       expect(test_result['double_test']).to be_an_instance_of(Float)
       expect(test_result['double_test']).to eql(10.3)
+    end
+
+    context "under a locale that uses a comma as the decimal separator" do
+      before(:example) do
+        @original_locale = CLocale.setlocale(CLocale::LC_NUMERIC, nil)
+        begin
+          CLocale.setlocale(CLocale::LC_NUMERIC, "de_DE.UTF-8")
+        rescue RuntimeError
+          skip "de_DE.UTF-8 locale not installed on this system"
+        end
+      end
+
+      after(:example) do
+        CLocale.setlocale(CLocale::LC_NUMERIC, @original_locale) if @original_locale
+      end
+
+      it "should return the correct BigDecimal for a DECIMAL value between -1 and 1" do
+        result = @client.query("SELECT CAST(0.5 AS DECIMAL(10,2)) AS val")
+        expect(result.first['val']).to eql(BigDecimal("0.5"))
+      end
+
+      it "should return the correct BigDecimal for a zero DECIMAL value" do
+        result = @client.query("SELECT CAST(0.00 AS DECIMAL(10,2)) AS val")
+        expect(result.first['val']).to eql(BigDecimal("0.0"))
+      end
+
+      it "should return the correct Float for a FLOAT value" do
+        result = @client.query("SELECT CAST(2.7 AS FLOAT) AS val")
+        expect(result.first['val']).to eql(2.7)
+      end
+
+      it "should return the correct Float for a DOUBLE value" do
+        result = @client.query("SELECT CAST(2.7 AS DOUBLE) AS val")
+        expect(result.first['val']).to eql(2.7)
+      end
     end
 
     it "should return Time for a DATETIME value when within the supported range" do


### PR DESCRIPTION
Fixes #1428

## The problem

`rb_mysql_result_fetch_row` (the plain-text protocol row decoder) uses `strtod()` to parse the numeric strings MySQL sends over the wire for `DECIMAL`, `FLOAT`, and `DOUBLE` columns. `strtod()` is locale-sensitive, but the wire string is always a plain `.`-decimal digit string regardless of locale -- MySQL has no `lc_numeric` server variable. Under an `LC_NUMERIC` that expects `,` instead (`de_DE`, `fr_FR`, ...), `strtod()` stops parsing at the `.` it doesn't recognize.

`LC_NUMERIC` is process-global C state, not thread-local. Any gem in the process calling `setlocale(LC_ALL, "")` to pick up the deployment's `LANG` is enough to trigger this for every mysql2 connection afterward -- no deliberate locale change required.

Reproduced under `LC_NUMERIC=de_DE.UTF-8`:

| Query | Expected | Actual (before fix) |
|---|---|---|
| `CAST(0.5 AS DECIMAL(10,2))` | `0.5` | `0.0` |
| `CAST(0.15 AS DECIMAL(10,2))` | `0.15` | `0.0` |
| `CAST(0.5 AS FLOAT)` | `0.5` | `0.0` |
| `CAST(2.7 AS FLOAT)` | `2.7` | `2.0` |
| `CAST(2.7 AS DOUBLE)` | `2.7` | `2.0` |

The DECIMAL case (as filed) only misclassifies values between -1 and 1 as zero, because `strtod()` is used solely as a zero-check there. The FLOAT/DOUBLE case is worse and undiscussed in the original report: `strtod()`'s return value *is* the result, so any non-integer FLOAT/DOUBLE truncates to its integer part, not just values near zero.

Prepared statements are unaffected -- they use the binary protocol (native `MYSQL_BIND` doubles, no `strtod()` anywhere).

## The fix

- **DECIMAL**: drop `strtod()` entirely. DECIMAL wire values never use exponent notation, so "is this zero" only needs a locale-independent scan for a non-zero digit.
- **FLOAT/DOUBLE**: parse via Ruby's own `Kernel#Float()` instead, which is locale-independent by design -- the same idiom this function already uses for `BigDecimal()` two lines above.

## Test plan

- [x] `bundle exec rake compile` -- clean
- [x] `bundle exec rubocop` -- clean
- [x] Full `bundle exec rspec` -- 370 examples, 0 failures beyond the pre-existing `#automatic_close ... child process` flake (reproduces identically unpatched)
- [x] New specs in `spec/mysql2/result_spec.rb` flip `LC_NUMERIC` for the duration of the example via the [`clocale`](https://github.com/avdv/clocale) gem (test-group dependency only) and assert correct DECIMAL/FLOAT/DOUBLE values; confirmed they fail unpatched with the truncated values above, and pass with the fix. `clocale` reads its `LC_*` constants from the local `locale.h` at compile time rather than hardcoding them, since the `setlocale()` category values differ by platform (e.g. `LC_NUMERIC` is `1` on Linux/glibc, `4` on macOS/BSD)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
