### PR TITLE
Silence -Wshorten-64-to-32 on the DECIMAL precision calculation

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -313,7 +313,8 @@ static VALUE rb_mysql_result_fetch_field_type(VALUE self, unsigned int idx) {
           Handle precision similar to this line from mysql's code:
           https://github.com/mysql/mysql-server/blob/ea7d2e2d16ac03afdd9cb72a972a95981107bf51/sql/field.cc#L2246
         */
-        precision = field->length - (field->decimals > 0 ? 2 : 1);
+        // DECIMAL's max precision is 65 digits, so this narrowing is safe for any field the server actually sent.
+        precision = (int)(field->length - (field->decimals > 0 ? 2 : 1));
         rb_field_type = rb_sprintf("decimal(%d,%d)", precision, field->decimals);
         break;
       case MYSQL_TYPE_STRING:       // char[]


### PR DESCRIPTION
`field->length` is `unsigned long` (64-bit); `precision` is `int` (32-bit). The subtraction promotes to 64-bit before narrowing back to `int` on assignment, which Apple Clang's `-Wshorten-64-to-32` flags:

```
../../../../ext/mysql2/result.c:316:35: warning: implicit conversion loses integer precision: 'unsigned long' to 'int' [-Wshorten-64-to-32]
        precision = field->length - (field->decimals > 0 ? 2 : 1);
                  ~ ~~~~~~~~~~~~~~^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

DECIMAL's max precision is 65 digits (`M <= 65` per MySQL's own limit), so `field->length` for any column a real server actually describes never exceeds ~70 -- the narrowing can't lose data in practice, just isn't provable to the compiler from the types alone. Adds an explicit cast with a one-line comment to document that and quiet the warning.

Cosmetic only, not a functional bug -- found while investigating pre-existing compile warnings, unrelated to #1428/#1474.

## Test plan

- [x] `bundle exec rake compile` -- warning gone (confirmed present before, absent after, same build)
- [x] `bundle exec rubocop` -- clean
- [x] `bundle exec rspec` -- 370 examples, 0 failures beyond the pre-existing `#automatic_close ... child process` flake

🤖 Generated with [Claude Code](https://claude.com/claude-code)
