### PR TITLE
CI: Cancel superseded runs, cap job runtime, and drop a redundant brew search

### DIFF
--- a/.github/workflows/build-cross-version.yml
+++ b/.github/workflows/build-cross-version.yml
@@ -14,6 +14,7 @@ jobs:
       ${{ matrix.os }} ruby ${{ matrix.ruby }} ${{ matrix.db }}
     runs-on: ${{ matrix.os }}
     services: ${{ matrix.services }}
+    timeout-minutes: 30
     strategy:
       matrix:
         include:

--- a/.github/workflows/build-fedora.yml
+++ b/.github/workflows/build-fedora.yml
@@ -9,6 +9,7 @@ jobs:
     # Fedora isn't offered as a native runner OS -- these run inside a
     # container on the ubuntu-24.04 host instead.
     container: ${{ matrix.container }}
+    timeout-minutes: 30
     strategy:
       matrix:
         include:

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -6,6 +6,7 @@ jobs:
     name: >-
       ${{ matrix.os }} ruby ${{ matrix.ruby }} ${{ matrix.db }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         include:

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -6,6 +6,7 @@ jobs:
     name: >-
       ${{ matrix.os }} ruby ${{ matrix.ruby }} ${{ matrix.db }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 30
     strategy:
       matrix:
         include:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,5 +1,13 @@
 name: Build
 on: [push, pull_request]
+
+# A newer push to the same pull request obsoletes whatever is still in
+# flight for it. Pushes to master are not cancelled -- every commit that
+# lands there should get a run of its own.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   ubuntu:
     uses: ./.github/workflows/build-ubuntu.yml

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -10,6 +10,7 @@ concurrency:
 jobs:
   build:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     env:
       BUNDLE_WITHOUT: development
     steps:

--- a/.github/workflows/rubocop.yml
+++ b/.github/workflows/rubocop.yml
@@ -2,6 +2,11 @@ name: RuboCop
 
 on: [push, pull_request]
 
+# The concurrency rule mirrors build.yml, which explains it.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -61,11 +61,7 @@ fi
 if [[ x$OSTYPE =~ ^xdarwin ]]; then
   brew update > /dev/null
 
-  # Check available packages.
-  for KEYWORD in mysql mariadb; do
-    brew search "${KEYWORD}"
-  done
-
+  # Log which version we actually resolved to.
   brew info "$DB"
   brew install "$DB" zstd
   brew link "$DB" # explicitly activate in case of kegged LTS versions


### PR DESCRIPTION
## Cancel superseded pull request runs

Neither `Build` nor `RuboCop` declared a `concurrency` group, so a fixup push left the previous run going to completion. Of the last 60 `Build` runs on pull requests, 11 were still in flight when a newer push obsoleted them -- the longest overlap ran over five hours of the ~29-job matrix.

Grouping by workflow and ref cancels those. Master is exempt, since every commit that lands there should get its own result. `build.yml` is the caller for the four reusable workflows, so one group covers the whole fan-out.

## Add a 30 minute job timeout

Jobs finish in 2 to 3 minutes, but with no `timeout-minutes` they inherit GitHub's 360 minute default. On `ci-always-tls-tcp`, `macos-latest ruby 4.0 mariadb@11.4` hung and held a macOS runner for the full 360 minutes, on three consecutive runs ([one](https://github.com/brianmario/mysql2/actions/runs/31247515906)).

`build.yml`'s `uses:` jobs don't accept `timeout-minutes`, so it goes on the job inside each called workflow.

## Drop the brew search survey from the macOS setup

`ci/setup.sh` listed every mysql\* and mariadb\* formula before installing -- a question about Homebrew, not about this build, asked identically on every macOS job of every run. `brew info "$DB"` stays for the resolved version.

## Test plan

- [x] `actionlint` -- no findings on any changed line (the remaining notes are pre-existing, on untouched lines)
- [x] All six workflow files parse as YAML at each of the three commits
- [x] `bash -n ci/setup.sh` -- clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)
