### PR TITLE
Fix HAVE_CONST_MYSQL_DEFAULT_AUTH and SSL-mode version specs

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1245,7 +1245,7 @@ static VALUE _mysql_client_options(VALUE self, int opt, VALUE value) {
       break;
 #endif
 
-#ifdef HAVE_MYSQL_DEFAULT_AUTH
+#ifdef HAVE_CONST_MYSQL_DEFAULT_AUTH
     case MYSQL_DEFAULT_AUTH:
       charval = (const char *)StringValueCStr(value);
       retval  = charval;
@@ -1782,7 +1782,7 @@ static VALUE set_get_server_public_key(VALUE self, VALUE value) {
 }
 
 static VALUE set_default_auth(VALUE self, VALUE value) {
-#ifdef HAVE_MYSQL_DEFAULT_AUTH
+#ifdef HAVE_CONST_MYSQL_DEFAULT_AUTH
   return _mysql_client_options(self, MYSQL_DEFAULT_AUTH, value);
 #else
   rb_raise(cMysql2Error, "pluggable authentication is not available, you may need a newer MySQL client library");

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -177,10 +177,10 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     end
 
     # 'preferred' or 'verify_ca' are only in MySQL 5.6.36+, 5.7.11+, 8.0+
-    version = Mysql2::Client.info
+    version = Mysql2::Client.info[:id]
     ssl_modes = case version
     when 50636...50700, 50711...50800, 80000...90000
-      %i[disabled preferred required verifa_ca verify_identity]
+      %i[disabled preferred required verify_ca verify_identity]
     else
       %i[disabled required verify_identity]
     end

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -176,10 +176,15 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       new_client(option_overrides)
     end
 
-    # 'preferred' or 'verify_ca' are only in MySQL 5.6.36+, 5.7.11+, 8.0+
+    # 'preferred' or 'verify_ca' are only in MySQL 5.6.36+, 5.7.11+, 8.0+.
+    # The upper bound stops at 100000 (not left unbounded) because MariaDB's
+    # client version numbering starts there (10.x = 100000+, 11.x = 110000+,
+    # 12.x = 120000+) and MariaDB has never implemented the 5-value ssl_mode
+    # API this branch is testing -- see FULL_SSL_MODE_SUPPORT in extconf.rb
+    # and rb_set_ssl_mode_option's own version >= 100000 MariaDB check.
     version = Mysql2::Client.info[:id]
     ssl_modes = case version
-    when 50636...50700, 50711...50800, 80000...90000
+    when 50636...50700, 50711...50800, 80000...100000
       %i[disabled preferred required verify_ca verify_identity]
     else
       %i[disabled required verify_identity]


### PR DESCRIPTION
Both bugs found here are the same shape: a silent logic error that always took the wrong branch, with no crash and no visible signal.

Ruby's mkmf `have_const(const, header)` always generates a macro named `HAVE_CONST_<NAME>`, never `HAVE_<NAME>` -- that naming is what `have_func` generates instead. `extconf.rb` calls `have_const('MYSQL_DEFAULT_AUTH', mysql_h)`, but `client.c` guarded on `HAVE_MYSQL_DEFAULT_AUTH` (missing the `_CONST_` infix) in two places, so the guard was always false and `set_default_auth` always raised "pluggable authentication is not available" regardless of what the linked client library actually supported.

The SSL-mode spec's version-branch had a similar problem: it passed `Mysql2::Client.info` (a Hash: `{id:, version:, header_version:}`) directly into a `case/when` block matching against numeric Ranges. `Range#===` against a Hash silently returns false rather than raising, so the branch meant to enable `preferred`/`verify_ca` on MySQL 5.6.36+/5.7.11+/8.0+ never actually ran on any CI leg -- every run silently fell through to the narrower `else` branch. Fixed by using `Mysql2::Client.info[:id]`, the actual integer. This also uncovered a `verifa_ca` typo (should be `verify_ca`) sitting right next to it in the array literal.

Both found incidentally while working on unrelated PR #1405 (TLS SNI support) in this session.

Bugs:
- `HAVE_MYSQL_DEFAULT_AUTH` in client.c never matched the `HAVE_CONST_*` macro extconf.rb actually generates, so `set_default_auth()` was permanently disabled regardless of client library support.
- The SSL-mode spec compared a Range against a Hash (`Client.info`) instead of the Hash's `:id` value, so `preferred`/`verify_ca` were never exercised by CI on any MySQL version, and a `verifa_ca` typo went unnoticed alongside it.

Fixes:
- `ext/mysql2/client.c`: `HAVE_MYSQL_DEFAULT_AUTH` -> `HAVE_CONST_MYSQL_DEFAULT_AUTH` at both occurrences, matching the working sibling guards right next to them (`HAVE_CONST_MYSQL_OPT_GET_SERVER_PUBLIC_KEY`, `HAVE_CONST_MYSQL_ENABLE_CLEARTEXT_PLUGIN`).
- `spec/mysql2/client_spec.rb`: use `Mysql2::Client.info[:id]` for the version comparison, and fix `verifa_ca` -> `verify_ca`.

Notes:
- Audited every other `have_const` call in extconf.rb against every `HAVE_*` guard in the C extension; found no other instances of this mistake.
- Verified end-to-end, not just that it compiles: built a dedicated SSL-enabled MySQL instance and confirmed `preferred`/`verify_ca` connect successfully now that the branch is actually reachable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)