### PR TITLE
Add a README section on backport requests for old Rails releases

### DIFF
--- a/README.md
+++ b/README.md
@@ -812,24 +812,17 @@ though.
 
 ## I'm running an older version of Rails and need a back-ported feature
 
-Some Rails versions are pinned to specific release lines of mysql2
-that are no longer maintained. Applications using such older versions
-of Rails may find themselves trying to upgrade mysql2 gem to support
-a newer version of MySQL or MariaDB that is beyond the required
-version for the app's Rails gem.
+Requests to backport features, bug fixes, or newer MySQL/MariaDB
+compatibility to old mysql2 release lines can't be honored. Keeping old
+branches working would suggest they're properly supported and maintained,
+when they aren't. An EOL Rails or Ruby version isn't receiving security
+patches either, and testing it in CI becomes impossible over time as CI
+providers prune old runtime images.
 
-Requests for specific features, bug fixes, or database engine
-compatibility backports cannot be honored.
-
-An EOL Rails or Ruby version isn't receiving security patches either,
-and the whole works becomes impossible to test in CI over time as CI
-services prune older versions from their runtime environments.
-
-### Fork dependencies
-
-Fork Rails at the needed version branch, and repoint its bundled mysql2
-adapter at the newer gem version. For example, to use Rails 3.2 with a
-newer mysql2 gem:
+Keeping an older application running means taking responsibility for
+these older open-source dependencies. Fork Rails instead, and point its
+bundled mysql2 adapter at a newer mysql2 version. For example, to use
+Rails 3.2 with a newer mysql2 gem:
 
 1. Fork Rails and set the needed version branch as the default, e.g.
    [`3-2-stable`](https://github.com/rails/rails/tree/3-2-stable).
@@ -839,8 +832,8 @@ newer mysql2 gem:
    constraint.
 3. Point the Gemfile at the fork instead of the `rails` gem, using
    [Bundler's git source](https://bundler.io/guides/git.html).
-4. Test the combination in the specific dev, test, and production
-   environment that is needed.
+4. Test the combination in your actual dev, test, and production
+   environments.
 
 ## Special Thanks
 

--- a/README.md
+++ b/README.md
@@ -810,6 +810,38 @@ automatically when you run rake (or explicitly `rake spec/configuration.yml`).
 For a normal installation on a Mac, you most likely do not need to do anything,
 though.
 
+## I'm running an older version of Rails and need a back-ported feature
+
+Some Rails versions are pinned to specific release lines of mysql2
+that are no longer maintained. Applications using such older versions
+of Rails may find themselves trying to upgrade mysql2 gem to support
+a newer version of MySQL or MariaDB that is beyond the required
+version for the app's Rails gem.
+
+Requests for specific features, bug fixes, or database engine
+compatibility backports cannot be honored.
+
+An EOL Rails or Ruby version isn't receiving security patches either,
+and the whole works becomes impossible to test in CI over time as CI
+services prune older versions from their runtime environments.
+
+### Fork dependencies
+
+Fork Rails at the needed version branch, and repoint its bundled mysql2
+adapter at the newer gem version. For example, to use Rails 3.2 with a
+newer mysql2 gem:
+
+1. Fork Rails and set the needed version branch as the default, e.g.
+   [`3-2-stable`](https://github.com/rails/rails/tree/3-2-stable).
+2. Edit
+   [`mysql2_adapter.rb`](https://github.com/rails/rails/blob/3-2-stable/activerecord/lib/active_record/connection_adapters/mysql2_adapter.rb#L1-L6)
+   and change the `gem 'mysql2', '~> 0.3.10'` line to the needed version
+   constraint.
+3. Point the Gemfile at the fork instead of the `rails` gem, using
+   [Bundler's git source](https://bundler.io/guides/git.html).
+4. Test the combination in the specific dev, test, and production
+   environment that is needed.
+
 ## Special Thanks
 
 * Eric Wong - for the contribution (and the informative explanations) of some thread-safety, non-blocking I/O and cleanup patches. You rock dude

--- a/README.md
+++ b/README.md
@@ -821,7 +821,7 @@ providers prune old runtime images.
 
 Keeping an older application running means taking responsibility for
 its older open-source dependencies.
-bundled mysql2 adapter at a newer mysql2 version. For example, to use
+For example, to use
 Rails 3.2 with a newer mysql2 gem:
 
 1. Fork Rails and set the needed version branch as the default, e.g.

--- a/README.md
+++ b/README.md
@@ -816,7 +816,7 @@ Requests to backport features, bug fixes, or newer MySQL/MariaDB
 compatibility to old mysql2 release lines can't be honored. Keeping old
 branches working would suggest they're properly supported and maintained
 when they aren't. An EOL Rails or Ruby version isn't receiving security
-patches either, and testing it in CI becomes impossible over time as CI
+patches either, and testing in CI becomes impossible over time as CI
 providers prune old runtime images.
 
 Keeping an older application running means taking responsibility for

--- a/README.md
+++ b/README.md
@@ -814,7 +814,7 @@ though.
 
 Requests to backport features, bug fixes, or newer MySQL/MariaDB
 compatibility to old mysql2 release lines can't be honored. Keeping old
-branches working would suggest they're properly supported and maintained,
+branches working would suggest they're properly supported and maintained
 when they aren't. An EOL Rails or Ruby version isn't receiving security
 patches either, and testing it in CI becomes impossible over time as CI
 providers prune old runtime images.

--- a/README.md
+++ b/README.md
@@ -820,7 +820,7 @@ patches either, and testing in CI becomes impossible over time as CI
 providers prune old runtime images.
 
 Keeping an older application running means taking responsibility for
-these older open-source dependencies. Fork Rails instead, and point its
+its older open-source dependencies.
 bundled mysql2 adapter at a newer mysql2 version. For example, to use
 Rails 3.2 with a newer mysql2 gem:
 


### PR DESCRIPTION
## Summary

- Adds a README section addressing a recurring request pattern: users on old, EOL'd Rails/Ruby versions asking for mysql2 features, fixes, or newer MySQL/MariaDB compatibility backported to old mysql2 release lines.
- States plainly that these backport requests can't be honored, and why: an EOL Rails/Ruby stack isn't receiving security patches either, and becomes harder to even test in CI as CI providers prune old runtime images.
- Documents the actual working path instead: fork Rails at the needed version branch, repoint the bundled `mysql2_adapter.rb` at a newer mysql2 version constraint, and pull the fork in via Bundler's git source.

## Why

This has come up multiple times in open issues/PRs from users pinned to old Rails versions. Having a stable README anchor to link to means those threads (and future ones) get a consistent, complete answer instead of a one-off reply, and gives something concrete to point to when closing requests that can't be honored.

## Test plan

- [x] Reviewed rendered Markdown locally for correct heading levels and link targets