### PR TITLE
Share one frozen default for Client#query's options argument

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,7 +39,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 144
+  Max: 147
 
 # Offense count: 3
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -144,7 +144,16 @@ module Mysql2
       end
     end
 
-    def query(sql, options = {})
+    # Shared frozen default for the options argument, so the no-options case
+    # skips allocating a fresh empty hash per call. The merge itself is
+    # unchanged: it still produces the per-query snapshot the C extension
+    # retains as @current_query_options, and explicit-but-invalid arguments
+    # like nil or false still raise TypeError from Hash#merge as they
+    # always have.
+    EMPTY_QUERY_OPTIONS = {}.freeze
+    private_constant :EMPTY_QUERY_OPTIONS
+
+    def query(sql, options = EMPTY_QUERY_OPTIONS)
       Thread.handle_interrupt(::Mysql2::Util::TIMEOUT_ERROR_NEVER) do
         _query(sql, @query_options.merge(options))
       end

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -670,6 +670,11 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       expect(@client.query_options[:something]).to be_nil
     end
 
+    it "should raise TypeError when options are explicitly nil or false" do
+      expect { @client.query "SELECT 1", nil }.to raise_error(TypeError, 'no implicit conversion of nil into Hash')
+      expect { @client.query "SELECT 1", false }.to raise_error(TypeError, 'no implicit conversion of false into Hash')
+    end
+
     it "should return results as a hash by default" do
       expect(@client.query("SELECT 1").first).to be_an_instance_of(Hash)
     end
@@ -721,6 +726,19 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
         expect do
           @client.query("SELECT 1")
         end.to raise_error(Mysql2::Error)
+      end
+
+      it "should not let query_options mutations affect an already-issued async query" do
+        @client.query_options[:async] = true
+        @client.query("SELECT 1 AS one")
+
+        # Neither mutation may leak into the issued query's snapshot:
+        # :stream would switch async_result to streaming delivery, and
+        # :symbolize_keys would change how its rows are built.
+        @client.query_options[:stream] = true
+        @client.query_options[:symbolize_keys] = true
+
+        expect(@client.async_result.first).to eql('one' => 1)
       end
 
       it "should prevent using a connection held by a dead thread, but not closing it" do
@@ -970,6 +988,16 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
         expect(@multi_client.store_result.first).to eql('set_2' => 2)
 
         expect(@multi_client.next_result).to be false
+      end
+
+      it "should not let query_options mutations affect an already-issued query's later result sets" do
+        expect(@multi_client.query("SELECT 1 AS 'set_1'; SELECT 2 AS 'set_2'").first).to eql('set_1' => 1)
+
+        # Must not leak into the remaining result sets' snapshot.
+        @multi_client.query_options[:symbolize_keys] = true
+
+        expect(@multi_client.next_result).to be true
+        expect(@multi_client.store_result.first).to eql('set_2' => 2)
       end
 
       it "does not interfere with other statements" do


### PR DESCRIPTION
### Motivation / Background

`Client#query` declares `options = {}` as its default argument, so every no-options call allocates a fresh empty hash just to feed it to `@query_options.merge(options)`. Calling `query` with no per-call options is the main path for callers that configure options once on the client. Rails' mysql2 adapter is one: it sets `query_options[:as]` / `[:database_timezone]` at connect and its unprepared statement path is `raw_connection.query(sql)` (activerecord 8.1.3.1, `mysql2/database_statements.rb`).

### Detail

The default argument becomes a shared frozen empty hash:

    EMPTY_QUERY_OPTIONS = {}.freeze
    private_constant :EMPTY_QUERY_OPTIONS

    def query(sql, options = EMPTY_QUERY_OPTIONS)

The body is unchanged: still `@query_options.merge(options)`. `Hash#merge` never mutates its argument, so a shared frozen hash is indistinguishable from a fresh `{}` there -- every semantic of master is preserved by construction: the merged snapshot copy (retained by the C extension as `@current_query_options` and read after `query` returns by `async_result` for its `:stream` delivery choice and by `store_result` for later multi-statement result sets), propagation of `@query_options`' default_proc and compare_by_identity state into the snapshot, and the exact `TypeError: no implicit conversion of nil into Hash` for explicit `query(sql, nil)` / `query(sql, false)`.

Sharper shapes were measured and rejected for semantic drift: `Hash[@query_options]` is the fastest copy (155-161 ns vs 181-190 ns for `merge({})` and 204-207 ns for `dup`, isolated on Ruby 4.0.6 with the client's 10-key options hash) but drops default_proc and compare_by_identity, both observable through the C extension's option lookups; zero-arg `merge` is Ruby 2.6+ while this gem's floor is 2.0. The frozen default keeps master's exact merge and simply deletes the dead `{}` allocation.

### On the specs

Three new specs, each verified to fail against a naive variant (`options = nil` passing `@query_options` through uncopied) and pass here:

* Async delivery: set `query_options[:async] = true` on the client (so the query call itself passes no options and exercises the shared default), issue a query, then mutate `:stream` and `:symbolize_keys` before `async_result`. The issued query must keep its snapshot; the naive variant switches it to streaming delivery with symbolized keys.
* Multi-statement result sets: mutate `:symbolize_keys` between `query` and `next_result`/`store_result`. Later result sets must keep the snapshot; the naive variant symbolizes them.
* Explicit `nil` / `false` options still raise the exact `TypeError` master raises. Against the naive variant, nil silently skips the merge instead.

The constant and its comments put `lib/mysql2/client.rb` over the `Metrics/ClassLength` maximum recorded in `.rubocop_todo.yml`, so that entry is bumped by hand (a full `--regenerate-todo` under the currently-bundled RuboCop rewrites unrelated entries from version drift).

### Benchmark

End-to-end this is flat: the saving is one small allocation against a socket round trip, so no honest query benchmark can resolve it in time. What is deterministic is the allocation count: 7 -> 6 allocated objects per no-options query (the removed `{}`), measured via `GC.stat(:total_allocated_objects)` and reproduced on both platforms below.

Both shapes in one process against the same connection (`SELECT 1`, no per-call options; the branch arm is the real `Client#query`, the master arm is master's exact body installed alongside; a sample is the min of 5 timings of 400 back-to-back queries, 15 samples per arm, arms interleaved with order alternating each round):

thelio -- AMD Ryzen 9 7950X, Arch Linux x86_64, Ruby 4.0.6, MySQL 9.6.0 (Docker, TCP loopback), client libmariadb 12.3.2, machine load < 1.0:

| arm | median | range | allocs/query |
|---|---|---|---|
| master_merge | 29.035 us/query | 27.752 .. 33.746 | 7.0 |
| branch | 29.134 us/query | 27.947 .. 31.713 | 6.0 |

macOS arm64, Ruby 4.0.6, MySQL 9.6 (Homebrew, libmysqlclient.24) over a Unix socket:

| arm | median | range | allocs/query |
|---|---|---|---|
| master_merge | 17.515 us/query | 15.500 .. 25.360 | 7.0 |
| branch | 17.305 us/query | 16.200 .. 21.792 | 6.0 |

Ranges overlap on both platforms; the wall-time deltas are noise. The allocation delta is the measurable win.

### Where this was tested

Implemented and measured at 82f9e18, rebased onto 96252dcc575e8626026c1e823e06a3d25739d915 (a CI-only change -- apt-key to Signed-By swap in the MySQL/MariaDB setup scripts -- touching no library code, so measurements remain valid). Full rake on the rebased head: 408 examples, 0 failures, 10 pending (all SSL-gated), RuboCop clean, exit 0 verified unpiped.

Not tested locally: Windows (the `#ifndef _WIN32` async path in client.c is compiled out there, but `query`'s Ruby-side change is platform-independent), MariaDB-server behavior beyond the thelio libmariadb client run, or other Ruby versions; CI covers those.
