### PR TITLE
Build Result#server_flags lazily from status captured at creation

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -18,7 +18,6 @@
 VALUE cMysql2Client;
 extern VALUE mMysql2, cMysql2Error, cMysql2TimeoutError;
 static VALUE sym_id, sym_version, sym_header_version, sym_async, sym_symbolize_keys, sym_as, sym_array, sym_stream;
-static VALUE sym_no_good_index_used, sym_no_index_used, sym_query_was_slow;
 static ID intern_brackets, intern_merge, intern_merge_bang, intern_new_with_args,
   intern_current_query_options, intern_read_timeout, intern_values;
 
@@ -939,8 +938,6 @@ static VALUE rb_mysql_client_async_result(VALUE self) {
   if (is_streaming == Qtrue) {
     wrapper->active_streaming_result = resultObj;
   }
-
-  rb_mysql_set_server_query_flags(wrapper->client, resultObj);
 
   return resultObj;
 }
@@ -1974,10 +1971,6 @@ void init_mysql2_client(void) {
   sym_array           = ID2SYM(rb_intern("array"));
   sym_stream          = ID2SYM(rb_intern("stream"));
 
-  sym_no_good_index_used = ID2SYM(rb_intern("no_good_index_used"));
-  sym_no_index_used      = ID2SYM(rb_intern("no_index_used"));
-  sym_query_was_slow     = ID2SYM(rb_intern("query_was_slow"));
-
   intern_brackets = rb_intern("[]");
   intern_merge = rb_intern("merge");
   intern_merge_bang = rb_intern("merge!");
@@ -2168,30 +2161,4 @@ void init_mysql2_client(void) {
 #else
   rb_const_set(cMysql2Client, rb_intern("TLS_SNI_SUPPORTED"), Qfalse);
 #endif
-}
-
-#define flag_to_bool(f) ((client->server_status & f) ? Qtrue : Qfalse)
-
-void rb_mysql_set_server_query_flags(MYSQL *client, VALUE result) {
-  VALUE server_flags = rb_hash_new();
-
-#ifdef HAVE_CONST_SERVER_QUERY_NO_GOOD_INDEX_USED
-  rb_hash_aset(server_flags, sym_no_good_index_used, flag_to_bool(SERVER_QUERY_NO_GOOD_INDEX_USED));
-#else
-  rb_hash_aset(server_flags, sym_no_good_index_used, Qnil);
-#endif
-
-#ifdef HAVE_CONST_SERVER_QUERY_NO_INDEX_USED
-  rb_hash_aset(server_flags, sym_no_index_used, flag_to_bool(SERVER_QUERY_NO_INDEX_USED));
-#else
-  rb_hash_aset(server_flags, sym_no_index_used, Qnil);
-#endif
-
-#ifdef HAVE_CONST_SERVER_QUERY_WAS_SLOW
-  rb_hash_aset(server_flags, sym_query_was_slow, flag_to_bool(SERVER_QUERY_WAS_SLOW));
-#else
-  rb_hash_aset(server_flags, sym_query_was_slow, Qnil);
-#endif
-
-  rb_iv_set(result, "@server_flags", server_flags);
 }

--- a/ext/mysql2/client.h
+++ b/ext/mysql2/client.h
@@ -72,8 +72,6 @@ typedef struct {
   unsigned long pending_result_free_count;
 } mysql_client_wrapper;
 
-void rb_mysql_set_server_query_flags(MYSQL *client, VALUE result);
-
 extern const rb_data_type_t rb_mysql_client_type;
 
 #ifdef NEW_TYPEDDATA_WRAPPER

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -64,7 +64,8 @@ static ID intern_new, intern_utc, intern_local, intern_localtime, intern_local_o
   intern_query_options;
 static VALUE sym_symbolize_keys, sym_as, sym_array, sym_database_timezone,
   sym_application_timezone, sym_local, sym_utc, sym_cast_booleans,
-  sym_cache_rows, sym_cast, sym_stream, sym_name, sym_rows_per_gvl_yield;
+  sym_cache_rows, sym_cast, sym_stream, sym_name, sym_rows_per_gvl_yield,
+  sym_no_good_index_used, sym_no_index_used, sym_query_was_slow;
 
 /* Mark any VALUEs that are only referenced in C, so the GC won't get them. */
 static void rb_mysql_result_mark(void * wrapper) {
@@ -76,6 +77,7 @@ static void rb_mysql_result_mark(void * wrapper) {
     rb_gc_mark_movable(w->encoding);
     rb_gc_mark_movable(w->client);
     rb_gc_mark_movable(w->statement);
+    rb_gc_mark_movable(w->server_flags);
   }
 }
 
@@ -221,6 +223,7 @@ static void rb_mysql_result_compact(void * wrapper) {
     rb_mysql2_gc_location(w->encoding);
     rb_mysql2_gc_location(w->client);
     rb_mysql2_gc_location(w->statement);
+    rb_mysql2_gc_location(w->server_flags);
   }
 }
 #endif
@@ -1604,6 +1607,53 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
   return rb_mysql_result_each_(self, fetch_row_func, &args);
 }
 
+/* call-seq:
+ *    result.server_flags # => Hash
+ *
+ * Returns the server status flags for the query that produced this result:
+ * +:no_good_index_used+, +:no_index_used+, and +:query_was_slow+. Flags the
+ * client library doesn't define at compile time are +nil+.
+ *
+ * Built on first access from the connection status captured when the result
+ * was created, then memoized -- so it reflects this result's own query even
+ * if the connection has run others since, and remains available after #free.
+ */
+#define flag_to_bool(f) ((wrapper->server_status & f) ? Qtrue : Qfalse)
+static VALUE rb_mysql_result_server_flags(VALUE self) {
+  GET_RESULT(self);
+
+  if (NIL_P(wrapper->server_flags)) {
+    VALUE server_flags = rb_hash_new();
+
+#ifdef HAVE_CONST_SERVER_QUERY_NO_GOOD_INDEX_USED
+    rb_hash_aset(server_flags, sym_no_good_index_used, flag_to_bool(SERVER_QUERY_NO_GOOD_INDEX_USED));
+#else
+    rb_hash_aset(server_flags, sym_no_good_index_used, Qnil);
+#endif
+
+#ifdef HAVE_CONST_SERVER_QUERY_NO_INDEX_USED
+    rb_hash_aset(server_flags, sym_no_index_used, flag_to_bool(SERVER_QUERY_NO_INDEX_USED));
+#else
+    rb_hash_aset(server_flags, sym_no_index_used, Qnil);
+#endif
+
+#ifdef HAVE_CONST_SERVER_QUERY_WAS_SLOW
+    rb_hash_aset(server_flags, sym_query_was_slow, flag_to_bool(SERVER_QUERY_WAS_SLOW));
+#else
+    rb_hash_aset(server_flags, sym_query_was_slow, Qnil);
+#endif
+
+    /* Memoize in the wrapper struct, marked from rb_mysql_result_mark: a
+     * plain C field write, so it works even on a frozen Result (an ivar set
+     * would raise FrozenError), and later calls return this same Hash object
+     * (mutations included), as the eager version did. */
+    wrapper->server_flags = server_flags;
+  }
+
+  return wrapper->server_flags;
+}
+#undef flag_to_bool
+
 static VALUE rb_mysql_result_count(VALUE self) {
   GET_RESULT(self);
 
@@ -1643,11 +1693,17 @@ VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_
   wrapper->fields = Qnil;
   wrapper->fieldTypes = Qnil;
   wrapper->rows = Qnil;
+  wrapper->server_flags = Qnil;
   wrapper->encoding = encoding;
   wrapper->streamingComplete = 0;
   wrapper->client = client;
   wrapper->client_wrapper = DATA_PTR(client);
   wrapper->client_wrapper->refcount++;
+  /* Capture the connection's server status now, while it still reflects the
+   * query that produced this result, so #server_flags can be built lazily.
+   * A plain uint copy: cannot raise, per the post-streaming-registration
+   * lifecycle rules in client.c/statement.c. */
+  wrapper->server_status = wrapper->client_wrapper->client->server_status;
   wrapper->result_buffers = NULL;
   wrapper->result_buffers_bound = 0;
   wrapper->is_null = NULL;
@@ -1688,6 +1744,7 @@ void init_mysql2_result(void) {
   rb_define_method(cMysql2Result, "field_types", rb_mysql_result_fetch_field_types, 0);
   rb_define_method(cMysql2Result, "free", rb_mysql_result_free_, 0);
   rb_define_method(cMysql2Result, "count", rb_mysql_result_count, 0);
+  rb_define_method(cMysql2Result, "server_flags", rb_mysql_result_server_flags, 0);
   rb_define_alias(cMysql2Result, "size", "count");
 
   intern_new          = rb_intern("new");
@@ -1715,6 +1772,9 @@ void init_mysql2_result(void) {
   sym_cast           = ID2SYM(rb_intern("cast"));
   sym_stream         = ID2SYM(rb_intern("stream"));
   sym_name           = ID2SYM(rb_intern("name"));
+  sym_no_good_index_used = ID2SYM(rb_intern("no_good_index_used"));
+  sym_no_index_used      = ID2SYM(rb_intern("no_index_used"));
+  sym_query_was_slow     = ID2SYM(rb_intern("query_was_slow"));
 
   opt_decimal_zero = rb_str_new2("0.0");
   rb_global_variable(&opt_decimal_zero); /*never GC */

--- a/ext/mysql2/result.h
+++ b/ext/mysql2/result.h
@@ -19,6 +19,9 @@ typedef struct {
   VALUE client;
   VALUE encoding;
   VALUE statement;
+  /* Memoized #server_flags Hash, Qnil until first access. Marked (and
+   * compacted) alongside the other VALUEs above. */
+  VALUE server_flags;
   my_ulonglong numberOfFields;
   my_ulonglong numberOfRows;
   unsigned long lastRowProcessed;
@@ -28,6 +31,10 @@ typedef struct {
   MYSQL_RES *result;
   mysql_stmt_wrapper *stmt_wrapper;
   mysql_client_wrapper *client_wrapper;
+  /* Connection server status captured at Result creation, so #server_flags
+   * can be built lazily without reading (possibly since-changed) live
+   * connection state. */
+  unsigned int server_status;
   /* statement result bind buffers */
   char result_buffers_bound;
   MYSQL_BIND *result_buffers;

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -611,8 +611,6 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
     wrapper->active_streaming_result = resultObj;
   }
 
-  rb_mysql_set_server_query_flags(wrapper->client, resultObj);
-
   if (!is_streaming) {
     // cache all result
     rb_funcall(resultObj, intern_each, 0);

--- a/lib/mysql2/result.rb
+++ b/lib/mysql2/result.rb
@@ -1,7 +1,5 @@
 module Mysql2
   class Result
-    attr_reader :server_flags
-
     include Enumerable
   end
 end

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -879,6 +879,53 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
     it "should set a definitive value for no_good_index_used" do
       expect(test_result.server_flags[:no_good_index_used]).to eql(false)
     end
+
+    it "returns the same hash object on every call" do
+      expect(test_result.server_flags).to equal(test_result.server_flags)
+    end
+
+    it "is available on a frozen Result, even when frozen before first access" do
+      test_result.freeze
+      expect(test_result.server_flags).to eql(no_good_index_used: false, no_index_used: true, query_was_slow: false)
+    end
+
+    it "returns the same hash object after the Result is frozen" do
+      flags = test_result.server_flags
+      test_result.freeze
+      expect(test_result.server_flags).to equal(flags)
+    end
+
+    it "is available after the result is fully iterated" do
+      test_result.to_a
+      expect(test_result.server_flags).to eql(no_good_index_used: false, no_index_used: true, query_was_slow: false)
+    end
+
+    it "is available after the result is freed" do
+      test_result.free
+      expect(test_result.server_flags).to eql(no_good_index_used: false, no_index_used: true, query_was_slow: false)
+    end
+
+    context "with multiple result sets" do
+      before(:example) do
+        @multi_client = new_client(flags: Mysql2::Client::MULTI_STATEMENTS)
+      end
+
+      it "reflects each result's own query, including results from store_result" do
+        # First statement touches no table (no_index_used false); second is a
+        # full scan (no_index_used true).
+        first = @multi_client.query("SELECT 1 AS a; SELECT * FROM mysql2_test")
+        expect(@multi_client.next_result).to be true
+        second = @multi_client.store_result
+        expect(@multi_client.next_result).to be false
+
+        # Deliberately read the first result's flags only after the connection
+        # has moved on to the second result: an implementation that read live
+        # connection status at call time would leak the second statement's
+        # full-scan flag into the first result here.
+        expect(first.server_flags[:no_index_used]).to eql(false)
+        expect(second.server_flags).to eql(no_good_index_used: false, no_index_used: true, query_was_slow: false)
+      end
+    end
   end
 
   context 'garbage collection ordering' do

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -768,6 +768,18 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
     end
   end
 
+  context 'server_flags' do
+    it "reflects the result's own execute, not later commands on the connection" do
+      full_scan = @client.prepare('SELECT * FROM mysql2_test').execute
+      # Move the connection's live status on to a query that touches no table
+      # before reading the first result's flags.
+      no_scan = @client.prepare('SELECT 1').execute
+
+      expect(full_scan.server_flags).to eql(no_good_index_used: false, no_index_used: true, query_was_slow: false)
+      expect(no_scan.server_flags[:no_index_used]).to eql(false)
+    end
+  end
+
   context 'affected_rows' do
     before(:example) do
       @client.query 'USE test'


### PR DESCRIPTION
Every Result construction on master eagerly builds a three-key hash -- rb_hash_new plus three rb_hash_aset and an ivar write -- to populate `#server_flags`, an accessor most applications never read. That is pure per-Result overhead on the hot query path.

This defers the hash. `rb_mysql_result_to_obj` now copies the connection's `server_status` into an `unsigned int` on the result wrapper -- a plain struct field copy that cannot raise, so it is safe inside the no-raise window between the network command and `active_streaming_result` registration (#1463). `Result#server_flags` becomes a C method that builds the same hash on first call from that captured status -- same keys, same true/false values, same nil where the client library lacks a flag constant at compile time -- then memoizes it in a `VALUE server_flags` slot on the result wrapper, marked from `rb_mysql_result_mark` with `rb_gc_mark_movable` and updated in the compact callback, exactly like the wrapper's other VALUEs. A struct slot rather than an ivar because an ivar write raises FrozenError on a frozen Result, while master's frozen Results answered `#server_flags` fine (the ivar predated any freeze); specs pin both freeze-before-first-access and freeze-after-first-access. Returning the same object on later calls preserves master's hash-identity and mutation-visibility semantics, and the hash itself stays mutable, as on master.

Capturing at creation rather than reading live status at call time is load-bearing: by the time flags are read, the connection may have run other statements. A spec pins this with a MULTI_STATEMENTS batch whose two statements differ in SERVER_QUERY_NO_INDEX_USED (no-table SELECT, then a full scan), reading the first result's flags only after the second has been stored. Under a call-time read of live status -- demonstrated by temporarily pointing the flag macro at `wrapper->client_wrapper->client->server_status` and recompiling -- that spec fails exactly as predicted: the first result reports the second statement's full-scan flag. The prepared-statement spec fails the same way in the opposite direction (full scan first, flags read after a later no-table execute).

Behavior change

Results from `Client#store_result` (the multi-result-set path) previously returned nil from `#server_flags`: master set the ivar only in the async-query and prepared-statement paths, and store_result had no spec coverage. Capture now lives in `rb_mysql_result_to_obj`, the single choke point all three creation paths share (client.c async_result, client.c store_result, statement.c execute), so store_result results now report real flags; a spec pins that. This is a deliberate change for maintainers to accept, not an accident of the refactor.

Removed: `rb_mysql_set_server_query_flags` (client.c/client.h), its two call sites, and the Ruby-side attr_reader.

New specs: hash identity across calls, frozen-Result access (freeze before first read; same object after freeze), availability after full iteration and after #free, the multi-result-set capture pin, and the prepared-statement pin.

Benchmarks: per-Result-creation overhead -- small result sets issued at high rate, where the eager hash is proportionally largest. The `query + server_flags` arm is the deliberate worst case for laziness: every result's flags actually read, paying construction at access time instead of skipping it. Min of 9 runs per sample, 9 samples per arm, arms interleaved; each build compiled and measured separately.

thelio -- AMD Ryzen 9 7950X (32 threads), Arch Linux, Ruby 4.0.6, MySQL 9.6.0 in Docker (TCP loopback, port 3306), client libmariadb 12.3.2, load < 1.0 for every run. Three alternating base/branch pairs, medians of medians (ms per 200 queries):

    arm                     base (82f9e18)   this branch
    query SELECT 1          5.60             5.61
    query 10x3 rows         7.60             7.52
    stmt execute            5.42             5.40
    query + server_flags    5.57             5.62

All arms within +/-1%. Allocations: 8.001 -> 7.001 objects/query with flags unread; 8.002 -> 8.002 with flags read.

macOS arm64, Ruby 4.0.6, MySQL 9.6 (Homebrew, libmysqlclient.24) over a Unix socket. Two clean base runs and two clean branch runs, alternating; a contaminated run was discarded and its samples excluded (median / median, min-max in ms per 200 queries):

    arm                     base (82f9e18)              this branch
    query SELECT 1          3.73 / 3.69  (3.61-5.22)    3.70 / 3.67  (3.61-4.08)
    query 10x3 rows         6.02 / 5.85  (4.72-6.38)    5.88 / 5.86  (5.77-6.40)
    stmt execute            3.11 / 3.10  (2.45-3.50)    3.12 / 3.16  (3.01-3.56)
    query + server_flags    3.69 / 3.71  (3.55-3.92)    3.73 / 3.76  (3.62-4.15)

Both platforms show wall time flat within noise on every arm, worst case included: the eager hash was sub-microsecond work against the round trip to the server, so no end-to-end query benchmark can resolve it. The deterministic win is allocation count, measured via GC.stat(:total_allocated_objects) over 1000 `SELECT 1` queries per shape (macOS: 8.0 -> 7.0 objects/query flags-unread; 8.0 -> 8.0 flags-read).

Flags go unread in virtually every real workload (no widely-used caller reads server_flags), so the common case saves the hash and its three entries; readers pay exactly what they paid before, just at access time.

Implemented and benchmarked at base 82f9e18e65eabf3755b482feaf80c72d5f6f0ad8, then rebased onto 96252dcc575e8626026c1e823e06a3d25739d915 -- a CI-only change (apt-key to Signed-By swap, MariaDB script alignment) touching no library code, so the benchmarks remain valid. Full suite re-run green on the rebased head, exit status checked: 412 examples, 0 failures, 10 pending (SSL). Not tested locally: MariaDB server, Windows, other Rubies; the missing-constant #else branches compile away on these platforms and are verified by inspection only.
