### PR TITLE
Fast-path integer parsing for integer result columns

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1,5 +1,7 @@
 #include <mysql2_ext.h>
 
+#include <limits.h>
+
 #include "mysql_enc_to_ruby.h"
 #define MYSQL2_CHARSETNR_SIZE (sizeof(mysql2_mysql_enc_to_rb)/sizeof(mysql2_mysql_enc_to_rb[0]))
 
@@ -673,6 +675,53 @@ static unsigned int msec_char_to_uint(char *msec_char, size_t len)
   return (unsigned int)strtoul(msec_char, NULL, 10);
 }
 
+/* Fast path for casting integer columns, in the spirit of trilogy's
+ * ll_from_buf/ull_from_buf. Every value an integer column can hold fits in
+ * long long / unsigned long long, so accumulate the magnitude directly
+ * instead of paying for rb_cstr2inum's base handling and Bignum machinery.
+ *
+ * Anything unexpected -- a non-digit, an empty string, or a magnitude that
+ * would overflow unsigned long long -- falls back to rb_cstr2inum, preserving
+ * the original semantics rather than trusting the wire format.
+ *
+ * The negative boundary needs care: the magnitude of LLONG_MIN is
+ * LLONG_MAX + 1, so casting it to long long before negating is undefined
+ * behavior. Return LL2NUM(LLONG_MIN) for exactly that magnitude and never
+ * negate it as a signed value. */
+static VALUE mysql2_cast_integer(const char *str, unsigned long len) {
+  unsigned long long mag = 0;
+  unsigned long i = 0;
+  int negative = 0;
+
+  if (len == 0) return rb_cstr2inum(str, 10);
+
+  if (str[0] == '-') {
+    negative = 1;
+    i = 1;
+  }
+
+  if (i == len) return rb_cstr2inum(str, 10);
+
+  for (; i < len; i++) {
+    unsigned char digit = (unsigned char)(str[i] - '0');
+    if (digit > 9) return rb_cstr2inum(str, 10);
+    if (mag > (ULLONG_MAX - digit) / 10) return rb_cstr2inum(str, 10);
+    mag = mag * 10 + digit;
+  }
+
+  if (negative) {
+    if (mag <= (unsigned long long)LLONG_MAX) {
+      return LL2NUM(-(long long)mag);
+    } else if (mag == (unsigned long long)LLONG_MAX + 1) {
+      return LL2NUM(LLONG_MIN);
+    } else {
+      return rb_cstr2inum(str, 10);
+    }
+  } else {
+    return ULL2NUM(mag);
+  }
+}
+
 static void rb_mysql_result_alloc_result_buffers(VALUE self, MYSQL_FIELD *fields) {
   unsigned int i;
   GET_RESULT(self);
@@ -1097,7 +1146,7 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
         case MYSQL_TYPE_INT24:      /* MEDIUMINT field */
         case MYSQL_TYPE_LONGLONG:   /* BIGINT field */
         case MYSQL_TYPE_YEAR:       /* YEAR field */
-          val = rb_cstr2inum(row[i], 10);
+          val = mysql2_cast_integer(row[i], fieldLengths[i]);
           break;
         case MYSQL_TYPE_DECIMAL:    /* DECIMAL or NUMERIC field */
         case MYSQL_TYPE_NEWDECIMAL: /* Precision math DECIMAL or NUMERIC field (MySQL 5.0.3 and up) */

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -526,6 +526,112 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
       expect(test_result['year_test']).to eql(2009)
     end
 
+    context "casting integer columns" do
+      before do
+        @client.query <<-SQL
+          CREATE TEMPORARY TABLE mysql2_int_cast_test (
+            tiny_int TINYINT, tiny_uint TINYINT UNSIGNED,
+            small_int SMALLINT, small_uint SMALLINT UNSIGNED,
+            medium_int MEDIUMINT, medium_uint MEDIUMINT UNSIGNED,
+            int_col INT, uint_col INT UNSIGNED,
+            big_int BIGINT, big_uint BIGINT UNSIGNED,
+            year_col YEAR
+          )
+        SQL
+      end
+
+      def roundtrip(column, value, **query_options)
+        @client.query "DELETE FROM mysql2_int_cast_test"
+        @client.query "INSERT INTO mysql2_int_cast_test (#{column}) VALUES (#{value})"
+        @client.query("SELECT #{column} AS v FROM mysql2_int_cast_test", **query_options).first['v']
+      end
+
+      boundaries = {
+        'tiny_int'    => [-128, -1, 0, 1, 127],
+        'tiny_uint'   => [0, 255],
+        'small_int'   => [-32_768, 32_767],
+        'small_uint'  => [0, 65_535],
+        'medium_int'  => [-8_388_608, 8_388_607],
+        'medium_uint' => [0, 16_777_215],
+        'int_col'     => [-2_147_483_648, 2_147_483_647],
+        'uint_col'    => [0, 4_294_967_295],
+        'big_int'     => [-9_223_372_036_854_775_808, -9_223_372_036_854_775_807,
+                          9_223_372_036_854_775_806, 9_223_372_036_854_775_807,],
+        'big_uint'    => [0, 9_223_372_036_854_775_807, 9_223_372_036_854_775_808,
+                          18_446_744_073_709_551_614, 18_446_744_073_709_551_615,],
+        'year_col'    => [1901, 2000, 2155],
+      }.freeze
+
+      it "returns exact Integers at every signed and unsigned column boundary" do
+        boundaries.each do |column, values|
+          values.each do |value|
+            returned = roundtrip(column, value)
+            expect(returned).to be_an_instance_of(Integer)
+            expect(returned).to eql(value)
+          end
+        end
+      end
+
+      it "matches Ruby integer values across every power-of-ten boundary" do
+        signed_range = -9_223_372_036_854_775_808..9_223_372_036_854_775_807
+        signed = []
+        unsigned = [18_446_744_073_709_551_614, 18_446_744_073_709_551_615]
+        (0..19).each do |k|
+          power = 10**k
+          [power - 1, power, power + 1].each do |v|
+            signed.push(v, -v) if signed_range.cover?(v)
+            unsigned.push(v) if v <= 18_446_744_073_709_551_615
+          end
+        end
+        signed = signed.uniq.sort
+        unsigned = unsigned.uniq.sort
+
+        @client.query "INSERT INTO mysql2_int_cast_test (big_int) VALUES #{signed.map { |v| "(#{v})" }.join(',')}"
+        returned = @client.query("SELECT big_int AS v FROM mysql2_int_cast_test ORDER BY v").map { |row| row['v'] }
+        expect(returned).to eql(signed)
+
+        @client.query "DELETE FROM mysql2_int_cast_test"
+        @client.query "INSERT INTO mysql2_int_cast_test (big_uint) VALUES #{unsigned.map { |v| "(#{v})" }.join(',')}"
+        returned = @client.query("SELECT big_uint AS v FROM mysql2_int_cast_test ORDER BY v").map { |row| row['v'] }
+        expect(returned).to eql(unsigned)
+      end
+
+      it "returns exact boundary values when streaming" do
+        expect(roundtrip('big_int', -9_223_372_036_854_775_808, stream: true, cache_rows: false)) \
+          .to eql(-9_223_372_036_854_775_808)
+        expect(roundtrip('big_uint', 18_446_744_073_709_551_615, stream: true, cache_rows: false)) \
+          .to eql(18_446_744_073_709_551_615)
+      end
+
+      it "returns boundary values as Strings when :cast is false" do
+        expect(roundtrip('big_int', -9_223_372_036_854_775_808, cast: false)).to eql("-9223372036854775808")
+        expect(roundtrip('big_uint', 18_446_744_073_709_551_615, cast: false)).to eql("18446744073709551615")
+      end
+
+      it "returns exact boundary values from prepared statements" do
+        @client.query "INSERT INTO mysql2_int_cast_test (big_int, big_uint) VALUES " \
+                      "(-9223372036854775808, 18446744073709551615)"
+        row = @client.prepare("SELECT big_int, big_uint FROM mysql2_int_cast_test").execute.first
+        expect(row['big_int']).to eql(-9_223_372_036_854_775_808)
+        expect(row['big_uint']).to eql(18_446_744_073_709_551_615)
+      end
+
+      it "casts DECIMAL(65,0) values beyond 64-bit range to Integer" do
+        [10**65 - 1, -(10**65 - 1), 123_456_789_012_345_678_901, -123_456_789_012_345_678_901].each do |value|
+          returned = @client.query("SELECT CAST('#{value}' AS DECIMAL(65,0)) AS v").first['v']
+          expect(returned).to be_an_instance_of(Integer)
+          expect(returned).to eql(value)
+        end
+      end
+
+      it "returns exact values for ZEROFILL columns despite leading zeros" do
+        @client.query "CREATE TEMPORARY TABLE mysql2_zerofill_test (zf INT ZEROFILL)"
+        @client.query "INSERT INTO mysql2_zerofill_test (zf) VALUES (42), (4294967295)"
+        returned = @client.query("SELECT zf FROM mysql2_zerofill_test ORDER BY zf").map { |row| row['zf'] }
+        expect(returned).to eql([42, 4_294_967_295])
+      end
+    end
+
     it "should return BigDecimal for a DECIMAL value" do
       expect(test_result['decimal_test']).to be_an_instance_of(BigDecimal)
       expect(test_result['decimal_test']).to eql(10.3)


### PR DESCRIPTION
Casting an integer column calls `rb_cstr2inum(row[i], 10)` once per value: a general-purpose parser that handles whitespace, signs, base prefixes, digit underscores, and arbitrary-precision magnitudes. An integer column produces none of that -- at most a leading `-` followed by up to 20 digits, always fitting `long long` / `unsigned long long`.

Adds `mysql2_cast_integer`, in the spirit of trilogy's `ll_from_buf`/`ull_from_buf`: accumulate the magnitude into an `unsigned long long` with a simple digit loop, then negate if a leading `-` was seen. Only the actual integer column types take it -- TINY, SHORT, LONG, INT24, LONGLONG, YEAR, exactly the types already sharing the `rb_cstr2inum` case in `rb_mysql_result_fetch_row`. The prepared-statement path reads binary values and does not parse digits at all; it is untouched.

DECIMAL/NEWDECIMAL with `decimals == 0` also casts to Integer but stays on `rb_cstr2inum` entirely: DECIMAL(65,0) holds 65 digits, far beyond any fixed-width accumulator, and a silent wrap there would return plausible-looking wrong Integers. A spec pins 65- and 21-digit values, and deliberately breaking this (routing DECIMAL through an unguarded accumulator) fails that spec.

The parser trusts nothing about the wire format. A non-digit byte (including leading `+` or whitespace, which the server does not send for these types), an empty string, or a magnitude that would overflow falls back to `rb_cstr2inum` for the whole value, preserving the original semantics. A string that ends before any digit is seen -- empty, or a bare `-` -- is rejected structurally before the digit loop rather than parsed as magnitude 0 (behavior is unchanged: `rb_cstr2inum` also yields 0 for `-`, but the fast path never trusts a digitless string). The overflow check runs before accumulating -- `mag > (ULLONG_MAX - digit) / 10` -- so the accumulator itself can never wrap.

The negative boundary needs specific care: the magnitude of LLONG_MIN is LLONG_MAX + 1, and casting that to `long long` before negating is undefined behavior. (trilogy's `ll_from_buf` negates through exactly such a cast, so this hazard exists there too; it works out on common ABIs but nothing guarantees it.) Here, magnitudes up to LLONG_MAX negate as signed; LLONG_MAX + 1 returns `LL2NUM(LLONG_MIN)` directly without negating; anything larger falls back.

Verified under UBSan with the sanitizer in both the compile and link flags:

    rake compile -- --with-sanitize=undefined \
                    --with-ldflags="-fsanitize=undefined"

with the runtime's presence proven via `otool -L mysql2.bundle` listing `libclang_rt.ubsan_osx_dynamic.dylib`. Candidate run: the full result spec under `UBSAN_OPTIONS="halt_on_error=1:print_stacktrace=1"` exits 0 with zero "runtime error:" lines. Negative control: reintroducing the signed negation of the boundary magnitude and rebuilding the same way fails the boundary specs with a nonzero exit and the diagnostic

    result.c:716:21: runtime error: negation of -9223372036854775808
    cannot be represented in type 'long long'

Reproduction pitfall: `--with-sanitize=undefined` alone puts `-fsanitize=undefined` in the compile flags only. macOS bundles link with `-undefined dynamic_lookup`, so the unresolved `__ubsan_handle_*` symbols survive linking and a triggered check crashes with a plain SIGSEGV instead of printing a diagnostic -- the sanitizer must be in the link flags too for the gate to prove anything.

Positive values return `ULL2NUM(mag)` regardless of column signedness, which produces the same Integers `rb_cstr2inum` did, verified up to BIGINT UNSIGNED's 18446744073709551615.

On the specs: a boundary matrix inserts the exact min/max of every integer column type, signed and unsigned -- including LLONG_MIN, LLONG_MAX, ULLONG_MAX, and YEAR's 1901/2155 -- into real columns and requires exact Integers back. A power-of-ten sweep drives 10^k -1/+0/+1 for every k across both signed and unsigned ranges through a BIGINT and BIGINT UNSIGNED column and compares against the Ruby literals. Streaming, `cast: false`, ZEROFILL (leading zeros), and prepared-statement variants pin the surrounding behavior. The specs have teeth: an experiment returning the LLONG_MIN magnitude as positive fails 2 of them, and returning unsigned magnitudes through LL2NUM fails 3.

Benchmarks (integer-heavy result sets, 100,000 rows x 7 INT/BIGINT columns fully materialized with `cache_rows: false`, identical seeded data both arms, min of 5 timings per sample, 9 samples per run; three runs per build, alternating base/branch to expose drift; per-run median + range in ms):

thelio -- AMD Ryzen 9 7950X (32 threads), Arch Linux, Ruby 4.0.6 x86_64, MySQL 9.6.0 in Docker (TCP loopback :3306), client libmariadb 12.3.2, load < 1.0 for every run:

| arm          | run 1            | run 2            | run 3            |
|--------------|------------------|------------------|------------------|
| base 82f9e18 | 71.5 (71.4-74.0) | 72.9 (72.3-73.8) | 71.5 (71.1-72.5) |
| this patch   | 66.6 (66.0-67.5) | 65.4 (65.0-66.9) | 65.2 (64.9-65.8) |

Median of medians: 71.5 ms -> 65.4 ms, -8.5%, with no overlap between any base and branch pair.

macOS -- arm64, Ruby 4.0.6, MySQL 9.6 (Homebrew, libmysqlclient.24):

| arm          | run 1               | run 2               | run 3               |
|--------------|---------------------|---------------------|---------------------|
| base 82f9e18 | 106.0 (105.2-106.6) | 105.5 (103.9-110.8) | 104.8 (104.3-106.3) |
| this patch   |  92.8 (92.3-94.5)   |  92.8 (92.5-93.7)   |  93.5 (93.0-94.6)   |

Median of medians: 105.5 ms -> 92.8 ms, -12.0%, with no overlap between any base and branch range.

Both benchmarked at base 82f9e18e65eabf3755b482feaf80c72d5f6f0ad8. The branch has since been rebased onto 96252dc, a CI-only change touching no library code, so the benchmarks remain valid; the full suite was re-run green (exit 0) after the rebase.
