### PR TITLE
Cache encoding lookups instead of redoing them per row

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -7,6 +7,19 @@
 
 static rb_encoding *binaryEncoding;
 
+/* Per-process cache of MySQL charsetnr -> Ruby encoding index, indexed by
+ * charsetnr - 1 to mirror mysql2_mysql_enc_to_rb. Both sides of the mapping
+ * are fixed for the life of the process -- the table is compiled in, and a
+ * Ruby encoding's index never changes once assigned -- so entries are computed
+ * once and never invalidated. Slot values are offset by +1 (0 is the "not yet
+ * cached" sentinel) so that encoding index 0, ASCII-8BIT, remains cacheable;
+ * -1 caches "this charsetnr has no table mapping", whose fallback (the
+ * connection's encoding) is applied per result at use time, never cached.
+ *
+ * Concurrent writers can only race to store the same deterministic value in
+ * an int slot, which is benign everywhere Ruby's GVL-based threading runs. */
+static int mysql2_enc_index_cache[MYSQL2_CHARSETNR_SIZE];
+
 /* on 64bit platforms we can handle dates way outside 2038-01-19T03:14:07
  *
  * (9999*31557600) + (12*2592000) + (31*86400) + (11*3600) + (59*60) + 59
@@ -56,6 +69,10 @@ typedef struct {
   ID db_timezone;
   ID app_timezone;
   int block_given; /* boolean */
+  /* Encoding.default_internal, captured once per #each call rather than once
+   * per row. Changing it mid-iteration therefore no longer affects later rows
+   * of that same call; the next #each call observes the new value. */
+  rb_encoding *default_internal_enc;
 } result_each_args;
 
 extern VALUE mMysql2, cMysql2Client, cMysql2Error;
@@ -312,7 +329,7 @@ static VALUE rb_mysql_result_fetch_field(VALUE self, unsigned int idx, int symbo
   if (rb_field == Qnil) {
     MYSQL_FIELD *field = NULL;
     rb_encoding *default_internal_enc = rb_default_internal_encoding();
-    rb_encoding *conn_enc = rb_to_encoding(wrapper->encoding);
+    rb_encoding *conn_enc = wrapper->conn_enc;
 
     field = mysql_fetch_field_direct(wrapper->result, idx);
     if (symbolize_keys) {
@@ -399,7 +416,7 @@ static VALUE rb_mysql_result_fetch_field_type(VALUE self, unsigned int idx) {
   if (rb_field_type == Qnil) {
     MYSQL_FIELD *field = NULL;
     rb_encoding *default_internal_enc = rb_default_internal_encoding();
-    rb_encoding *conn_enc = rb_to_encoding(wrapper->encoding);
+    rb_encoding *conn_enc = wrapper->conn_enc;
     int precision;
 
     field = mysql_fetch_field_direct(wrapper->result, idx);
@@ -572,15 +589,33 @@ static VALUE mysql2_set_field_string_encoding(VALUE val, MYSQL_FIELD field, rb_e
     /* MySQL 4.x may not provide an encoding, binary will get the bytes through */
     rb_enc_associate(val, binaryEncoding);
   } else {
-    /* lookup the encoding configured on this field */
-    const char *enc_name;
-    int enc_index;
+    /* lookup the encoding configured on this field, consulting the
+     * per-process charsetnr cache before the name-based lookup */
+    int enc_index = -1;
 
-    enc_name = (field.charsetnr-1 < MYSQL2_CHARSETNR_SIZE) ? mysql2_mysql_enc_to_rb[field.charsetnr-1] : NULL;
+    if (field.charsetnr >= 1 && field.charsetnr <= MYSQL2_CHARSETNR_SIZE) {
+      const int cached = mysql2_enc_index_cache[field.charsetnr - 1];
 
-    if (enc_name != NULL) {
+      if (cached > 0) {
+        enc_index = cached - 1;
+      } else if (cached == 0) {
+        /* not yet cached: do the name-based lookup once and store it */
+        const char *enc_name = mysql2_mysql_enc_to_rb[field.charsetnr - 1];
+
+        if (enc_name != NULL) {
+          enc_index = rb_enc_find_index(enc_name);
+          if (enc_index >= 0) {
+            mysql2_enc_index_cache[field.charsetnr - 1] = enc_index + 1;
+          }
+        } else {
+          mysql2_enc_index_cache[field.charsetnr - 1] = -1;
+        }
+      }
+      /* cached < 0: known to have no table mapping; fall through to conn_enc */
+    }
+
+    if (enc_index >= 0) {
       /* use the field encoding we were able to match */
-      enc_index = rb_enc_find_index(enc_name);
       rb_enc_set_index(val, enc_index);
     } else {
       /* otherwise fall-back to the connection's encoding */
@@ -852,8 +887,9 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
     return Qnil;
   }
 
-  default_internal_enc = rb_default_internal_encoding();
-  conn_enc = rb_to_encoding(wrapper->encoding);
+  /* Cached at #each entry / Result creation to avoid per-row lookups. */
+  default_internal_enc = args->default_internal_enc;
+  conn_enc = wrapper->conn_enc;
 
   if (wrapper->fields == Qnil) {
     wrapper->numberOfFields = mysql_num_fields(wrapper->result);
@@ -1123,8 +1159,9 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
     return Qnil;
   }
 
-  default_internal_enc = rb_default_internal_encoding();
-  conn_enc = rb_to_encoding(wrapper->encoding);
+  /* Cached at #each entry / Result creation to avoid per-row lookups. */
+  default_internal_enc = args->default_internal_enc;
+  conn_enc = wrapper->conn_enc;
 
   ptr = wrapper->result;
   /* See the note above nogvl_fetch_row. A streaming result reads from the
@@ -1736,6 +1773,9 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
   args.db_timezone = db_timezone;
   args.app_timezone = app_timezone;
   args.block_given = rb_block_given_p();
+  /* Captured once per #each call; see the field's comment in
+   * result_each_args. */
+  args.default_internal_enc = rb_default_internal_encoding();
 
   if (wrapper->stmt_wrapper) {
     fetch_row_func = rb_mysql_result_fetch_row_stmt;
@@ -1834,6 +1874,12 @@ VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_
   wrapper->rows = Qnil;
   wrapper->server_flags = Qnil;
   wrapper->encoding = encoding;
+  /* encoding is always the client's Encoding instance (set unconditionally by
+   * Client#initialize via charset_name=, before any query can produce a
+   * Result), so rb_to_encoding is a plain data unwrap here: no coercion, no
+   * allocation, and -- required in this function, which must not raise between
+   * taking ownership of r and returning -- no exception path. */
+  wrapper->conn_enc = rb_to_encoding(encoding);
   wrapper->streamingComplete = 0;
   wrapper->client = client;
   wrapper->client_wrapper = DATA_PTR(client);

--- a/ext/mysql2/result.h
+++ b/ext/mysql2/result.h
@@ -46,6 +46,11 @@ typedef struct {
   /* Memoized #server_flags Hash, Qnil until first access. Marked (and
    * compacted) alongside the other VALUEs above. */
   VALUE server_flags;
+  /* The connection's encoding, unwrapped once at Result creation.
+   * wrapper->encoding is fixed at connect time (Client#initialize always
+   * runs charset_name=), so this never goes stale; caching it avoids a
+   * rb_to_encoding() call per row fetch. */
+  rb_encoding *conn_enc;
   my_ulonglong numberOfFields;
   my_ulonglong numberOfRows;
   unsigned long lastRowProcessed;

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -1118,6 +1118,175 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
     end
   end
 
+  context "string value encodings across character sets" do
+    # Exercises the per-process charsetnr -> Ruby encoding index cache and the
+    # per-Result connection-encoding cache in ext/mysql2/result.c.
+    # `SET character_set_results = NULL` stops the server from converting
+    # result values to the connection's character set, so every field below
+    # arrives tagged with its own charsetnr -- including collation ids above
+    # 255 (utf8mb4_ja_0900_as_cs is id 303), which only resolve because the
+    # cache is sized to the full mapping table rather than one byte.
+    #
+    # The 0900 collations are MySQL 8.0+ only. MariaDB cannot pin the >255
+    # slots at all: its only collation ids above 255 (the uca1400 family,
+    # ids 2304+) lie beyond the mapping table entirely and take the
+    # connection-encoding fallback, so that column is skipped there.
+    let(:server_supports_0900_collations) do
+      server_info = @client.server_info
+      !server_info[:version].include?('MariaDB') && server_info[:id] >= 80000
+    end
+
+    let(:charset_matrix_sql) do
+      fields = [
+        "_utf8mb4 0x68C3A96C6C6F AS utf8mb4_val",
+        "CONVERT(_utf8mb4 0x68C3A96C6C6F USING latin1) AS latin1_val",
+        "CONVERT('abc' USING latin2) AS latin2_val",
+        "CONVERT('abc' USING greek) AS greek_val",
+        "CONVERT('abc' USING koi8r) AS koi8r_val",
+        "CONVERT('abc' USING ascii) AS ascii_val",
+        "CONVERT(_utf8mb4 0xE38182 USING sjis) AS sjis_val",
+        "CONVERT(_utf8mb4 0xE38182 USING cp932) AS cp932_val",
+        "CONVERT('abc' USING big5) AS big5_val",
+        "CONVERT('abc' USING gb2312) AS gb2312_val",
+        "UNHEX('DEADBEEF') AS binary_val",
+        "CONVERT('abc' USING dec8) AS dec8_val",
+      ]
+      fields << "_utf8mb4 0xE38182 COLLATE utf8mb4_ja_0900_as_cs AS ja_collation_val" \
+        if server_supports_0900_collations
+      "SELECT #{fields.join(', ')}"
+    end
+
+    # Expected bytes and encoding per field. dec8 (charsetnr 3) has no entry
+    # in the mapping table, so it falls back to the connection's encoding.
+    let(:charset_matrix_expected) do
+      {
+        'utf8mb4_val' => ["h\xC3\xA9llo", Encoding::UTF_8],
+        'latin1_val'  => ["h\xE9llo", Encoding::ISO_8859_1],
+        'latin2_val'  => ['abc', Encoding::ISO_8859_2],
+        'greek_val'   => ['abc', Encoding::ISO_8859_7],
+        'koi8r_val'   => ['abc', Encoding::KOI8_R],
+        'ascii_val'   => ['abc', Encoding::US_ASCII],
+        'sjis_val'    => ["\x82\xA0", Encoding::Shift_JIS],
+        'cp932_val'   => ["\x82\xA0", Encoding::Windows_31J],
+        'big5_val'    => ['abc', Encoding::Big5],
+        'gb2312_val'  => ['abc', Encoding::GB2312],
+        'binary_val'  => ["\xDE\xAD\xBE\xEF", Encoding::BINARY],
+        'dec8_val'    => ['abc', Encoding::UTF_8],
+      }.tap do |expected|
+        expected['ja_collation_val'] = ["\xE3\x81\x82", Encoding::UTF_8] if server_supports_0900_collations
+      end
+    end
+
+    def expect_charset_matrix_row(row)
+      expect(row.keys).to match_array(charset_matrix_expected.keys)
+      row.each do |name, value|
+        bytes, encoding = charset_matrix_expected[name]
+        expect(value.encoding).to eql(encoding), "#{name}: expected #{encoding}, got #{value.encoding}"
+        expect(value.b).to eql(bytes.b), "#{name}: expected #{bytes.b.inspect}, got #{value.b.inspect}"
+      end
+    end
+
+    it "tags each field with its own character set, consistently across repeated queries" do
+      with_internal_encoding nil do
+        @client.query("SET character_set_results = NULL")
+        2.times do
+          expect_charset_matrix_row(@client.query(charset_matrix_sql).first)
+        end
+      end
+    end
+
+    it "converts every non-binary field to Encoding.default_internal when set" do
+      with_internal_encoding Encoding::UTF_8 do
+        @client.query("SET character_set_results = NULL")
+        row = @client.query(charset_matrix_sql).first
+        row.each do |name, value|
+          expected = name == 'binary_val' ? Encoding::BINARY : Encoding::UTF_8
+          expect(value.encoding).to eql(expected), "#{name}: expected #{expected}, got #{value.encoding}"
+        end
+        expect(row['latin1_val']).to eql("héllo")
+        expect(row['sjis_val']).to eql("あ")
+      end
+    end
+
+    it "applies the same encodings through the prepared statement path" do
+      with_internal_encoding nil do
+        @client.query("SET character_set_results = NULL")
+        stmt = @client.prepare(charset_matrix_sql)
+        2.times do
+          expect_charset_matrix_row(stmt.execute.first)
+        end
+      end
+    end
+
+    it "applies the same encodings while streaming" do
+      with_internal_encoding nil do
+        @client.query("SET character_set_results = NULL")
+        rows = @client.query(charset_matrix_sql, stream: true, cache_rows: false).to_a
+        expect(rows.length).to eql(1)
+        expect_charset_matrix_row(rows.first)
+      end
+    end
+
+    context "for table columns of differing character sets" do
+      before(:example) do
+        @client.query(
+          "CREATE TEMPORARY TABLE mysql2_enc_matrix_test (" \
+          "utf8mb4_col VARCHAR(20) CHARACTER SET utf8mb4, " \
+          "latin1_col VARCHAR(20) CHARACTER SET latin1, " \
+          "blob_col BLOB)",
+        )
+        @client.query("INSERT INTO mysql2_enc_matrix_test VALUES ('héllo', 'héllo', UNHEX('DEADBEEF'))")
+        @client.query("SET character_set_results = NULL")
+      end
+
+      it "tags each column with its column character set if Encoding.default_internal is nil" do
+        with_internal_encoding nil do
+          row = @client.query("SELECT * FROM mysql2_enc_matrix_test").first
+          expect(row['utf8mb4_col']).to eql("héllo")
+          expect(row['utf8mb4_col'].encoding).to eql(Encoding::UTF_8)
+          expect(row['latin1_col'].b).to eql("h\xE9llo".b)
+          expect(row['latin1_col'].encoding).to eql(Encoding::ISO_8859_1)
+          expect(row['blob_col'].encoding).to eql(Encoding::BINARY)
+        end
+      end
+
+      it "converts text columns but not blobs to Encoding.default_internal" do
+        with_internal_encoding Encoding::UTF_8 do
+          row = @client.query("SELECT * FROM mysql2_enc_matrix_test").first
+          expect(row['utf8mb4_col']).to eql("héllo")
+          expect(row['latin1_col']).to eql("héllo")
+          expect(row['latin1_col'].encoding).to eql(Encoding::UTF_8)
+          expect(row['blob_col'].encoding).to eql(Encoding::BINARY)
+        end
+      end
+    end
+
+    it "captures Encoding.default_internal at each #each call, not per row" do
+      # Deliberate behavior pin: Encoding.default_internal is read once at
+      # #each entry (per call) instead of once per row. Changing it from
+      # inside the iteration block no longer affects later rows of that same
+      # call; the next #each call observes the new value.
+      with_internal_encoding nil do
+        result = @client.query("SELECT 'a' AS s UNION ALL SELECT 'b' UNION ALL SELECT 'c'", cache_rows: false)
+
+        first_pass = []
+        result.each do |row|
+          first_pass << row['s'].encoding
+          old_verbose = $VERBOSE
+          $VERBOSE = nil
+          Encoding.default_internal = Encoding::ISO_8859_1
+          $VERBOSE = old_verbose
+        end
+        expect(first_pass).to eql([Encoding::UTF_8] * 3)
+
+        # cache_rows: false forces the second #each to re-materialize rows
+        # from the C result set, capturing the new default_internal.
+        second_pass = result.map { |row| row['s'].encoding }
+        expect(second_pass).to eql([Encoding::ISO_8859_1] * 3)
+      end
+    end
+  end
+
   context "server flags" do
     let(:test_result) { @client.query("SELECT * FROM mysql2_test ORDER BY null_test DESC LIMIT 1") }
 


### PR DESCRIPTION
Materializing a string-heavy result runs three encoding lookups per row (two of them per string value) that always produce the same answer:

* `rb_to_encoding(wrapper->encoding)` -- unwraps the connection's Encoding object. Fixed at connect time (`Client#initialize` always runs `charset_name=`), so it can never change over a Result's life.
* `rb_default_internal_encoding()` -- re-read on every row.
* `rb_enc_find_index(enc_name)` -- a name-based hash lookup mapping the field's charsetnr to a Ruby encoding index, re-done for every string value of every row, though both sides of the mapping are fixed for the process.

Cache each at the widest scope that preserves its semantics:

* **Connection encoding, per Result.** Unwrapped once in `rb_mysql_result_to_obj` and stored on the wrapper as `rb_encoding *`. `rb_encoding` structs are immortal and unmoved by compaction, so the pointer cannot go stale. `to_obj` must not raise between taking ownership of the `MYSQL_RES` and returning (the streaming lifecycle depends on it); `rb_to_encoding` on a genuine Encoding instance is a plain data unwrap with no coercion, allocation, or exception path, and both call sites (client.c, statement.c) pass the client's Encoding instance.
* **`Encoding.default_internal`, per `#each` call.** Captured once at `rb_mysql_result_each` entry into `result_each_args` instead of once per row. `#fields`, `#field_types`, and field-name interning keep their per-call read.
* **charsetnr -> encoding index, per process.** A static array mirroring `mysql2_mysql_enc_to_rb` (323 entries), indexed by `charsetnr - 1` and bounds-checked to `1 <= charsetnr <= MYSQL2_CHARSETNR_SIZE`; out-of-range charsetnrs fall back to the connection encoding, uncached, exactly as before. Slot values are stored offset by +1 so 0 stays the "not yet cached" sentinel without conflating Ruby encoding index 0 (ASCII-8BIT); -1 caches "no table mapping". Only connection-independent facts are stored: the fallback for unmapped charsetnrs is resolved per Result at use time, so clients with different connection encodings share the cache soundly. Writers all hold the GVL (nothing in `mysql2_set_field_string_encoding` releases it); even without that, racing writers could only store the same deterministic int.

One disclosed behavior change: changing `Encoding.default_internal` from inside an iteration block no longer affects later rows of that same `#each` call -- the next `#each` call observes the new value. A spec pins the new behavior deliberately (it fails against the per-row capture). Nothing else observable moves: rows, fields, field_types, and every encoding/transcode result are byte-identical.

One unreachable corner hardened rather than preserved: if `rb_enc_find_index` ever returned a negative index, master passed it straight to `rb_enc_set_index`; now the value falls back to the connection encoding (and is not cached). Unreachable in practice -- every name in the table resolves under CRuby.

On the ASCII-8BIT (encoding index 0) cache slot: its only charsetnr mapping is 63 (binary), and every charsetnr-63 field MySQL 9.6 produces carries BINARY_FLAG -- probed with `mysql --column-type-info` across `BINARY 'a'`, `CAST(... AS BINARY)`, `UNHEX`, `RANDOM_BYTES`, `COMPRESS`, `WEIGHT_STRING`, `UUID_TO_BIN`, `LOAD_FILE`, `ST_GeomFromText`, `b'101'`, and `_binary'a'` -- so the earlier `BINARY_FLAG && charsetnr == 63` branch always intercepts before the cache is consulted. The index-0 path is therefore not constructible against this server and is untested at the integration level; the +1 offset keeps it correct by design should a server ever send charsetnr 63 without BINARY_FLAG.

Specs (`SET character_set_results = NULL` so fields arrive tagged with their own charsetnr rather than converted to the connection charset):

* A 13-field matrix across utf8mb4, latin1, latin2, greek, koi8r, ascii, sjis, cp932, big5, gb2312, binary, a collation id above 255 (utf8mb4_ja_0900_as_cs, id 303 -- exercising the cache beyond one byte), and dec8 (no table mapping -> connection-encoding fallback), asserting bytes and encoding per field, queried twice per example to hit warm cache slots. Run through the text protocol, the prepared-statement path, and streaming. The 0900 column runs on MySQL 8.0+ only: MariaDB has no in-table collation id above 255 (its uca1400 family, ids 2304+, lies beyond the mapping table and takes the connection-encoding fallback), so that pin is skipped there and the MySQL CI legs carry it.
* The same matrix under `Encoding.default_internal = UTF-8` (binary stays binary, everything else transcodes).
* Table columns of differing character sets (utf8mb4/latin1/BLOB) with and without default_internal.
* The deliberate mid-iteration default_internal pin described above.

Verified the specs bite: an off-by-one cache read (slot `charsetnr` instead of `charsetnr - 1`) fails three of them (text, prepared, columns); reverting the per-call default_internal capture to per-row fails the pin.

Benchmark: string-heavy shape (50,000 rows x 6 VARCHAR(32) utf8mb4 columns, multibyte content), `each {}` with `cache_rows: false`, three runs per build alternating base/branch, min of 5 timings per sample, 15 samples per run, per-run median (range) in ms per pass:

| arm          | run 1               | run 2               | run 3               |
|--------------|---------------------|---------------------|---------------------|
| base 82f9e18 | 57.09 (55.48-58.08) | 56.45 (55.33-60.89) | 56.05 (54.96-56.79) |
| this patch   | 48.82 (48.13-51.72) | 48.70 (48.24-54.24) | 48.55 (47.30-52.92) |

Median of medians: 56.45 ms -> 48.70 ms per pass, -13.7% on this workload (190.3 -> 162.3 ns per value), with no overlap between any base and branch range. Ruby 4.0.6, MySQL 9.6 (Homebrew, libmysqlclient.24), macOS arm64.

Independently reproduced on a second platform -- AMD Ryzen 9 7950X, Arch Linux x86_64, Ruby 4.0.6, MySQL 9.6.0 (Docker, TCP loopback), client libmariadb 12.3.2, machine load < 1.0 for every run; same protocol:

| arm          | run 1 | run 2 | run 3 |
|--------------|-------|-------|-------|
| base 82f9e18 | 35.66 | 35.60 | 35.41 |
| this patch   | 31.65 | 31.82 | 31.90 |

Median of medians: 35.60 ms -> 31.82 ms per pass, -10.6% (118.7 -> 106.1 ns per value), non-overlapping ranges in all three pairs.

Implemented and measured at 82f9e18, then rebased onto 96252dcc575e8626026c1e823e06a3d25739d915 (CI-only change -- apt-key to Signed-By swap in MySQL/MariaDB setup scripts, no library code -- so the measurements remain valid).

Full suite on the rebased head: 412 examples, 0 failures, 10 pending (SSL-gated), RuboCop clean, exit 0 verified unpiped.
