### PR TITLE
Add a :force_encoding query option that retags string results

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,22 @@ do_mysql               0.520000   0.010000   0.530000 (  0.574619)
 
 Although Mysql2 performs reasonably well at retrieving uncasted data, it (currently) is not as fast as the Mysql gem.  In spite of this small disadvantage, Mysql2 still sports a friendlier interface and doesn't block the entire ruby process when querying.
 
+### Forcing a string encoding
+
+Pass `:force_encoding` to `Client#query` or `Statement#execute` to retag string results with an encoding of your choosing:
+
+``` ruby
+result = client.query("SELECT * FROM legacy_table", force_encoding: Encoding::UTF_8)
+```
+
+It accepts an `Encoding` object or an encoding name (anything `Encoding.find` accepts). Invalid values raise before anything is sent to the server.
+
+Retag means exactly that: values keep their bytes and only the encoding tag changes — nothing is transcoded. Force means force, so the forced encoding wins over everything else: BLOB/`BINARY` columns are retagged too (instead of being tagged ASCII-8BIT), and the usual `Encoding.default_internal` conversion is skipped. This is useful for reading legacy data stored in a mislabeled character set (say, UTF-8 bytes living in latin1 columns), or for forcing `binary` when you want raw bytes for hashing or byte-wise comparison.
+
+Only values that arrive as strings are affected. With the default `cast: true`, columns cast to Integer/Date/Time and friends are untouched; with `cast: false`, every non-NULL value is a string and all of them are retagged. Field names are never affected.
+
+`:force_encoding` is fixed when the query or execute is issued — `Mysql2::Result#each` raises if you pass it there, because non-streaming `Statement#execute` materializes rows internally with `#each`, so a per-`each` value could never be honored consistently.
+
 ### Partial casting
 
 Between `:cast => true` and `:cast => false` sits `:cast => :fast`: cheap conversions still happen in C, while the expensive ones are skipped and their values returned as encoding-tagged Strings of the raw wire bytes.

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1090,6 +1090,11 @@ static VALUE rb_mysql_query(VALUE self, VALUE sql, VALUE current) {
 
   (void)RB_GC_GUARD(current);
   Check_Type(current, T_HASH);
+  /* Resolve :force_encoding to an Encoding object up front: invalid values
+   * raise here, before anything is written to the wire, leaving the
+   * connection untouched and reusable. Nothing downstream of the send may
+   * raise for this option -- rb_mysql_result_to_obj in particular. */
+  mysql2_canonicalize_force_encoding(current);
   rb_ivar_set(self, intern_current_query_options, current);
 
   Check_Type(sql, T_STRING);

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -95,7 +95,8 @@ static ID intern_new, intern_utc, intern_local, intern_localtime, intern_local_o
 static VALUE sym_symbolize_keys, sym_as, sym_array, sym_database_timezone,
   sym_application_timezone, sym_local, sym_utc, sym_cast_booleans,
   sym_cache_rows, sym_cast, sym_fast, sym_stream, sym_name, sym_rows_per_gvl_yield,
-  sym_no_good_index_used, sym_no_index_used, sym_query_was_slow;
+  sym_no_good_index_used, sym_no_index_used, sym_query_was_slow,
+  sym_force_encoding;
 
 /* Mark any VALUEs that are only referenced in C, so the GC won't get them. */
 static void rb_mysql_result_mark(void * wrapper) {
@@ -592,7 +593,26 @@ static VALUE rb_mysql_result_fetch_field_type(VALUE self, unsigned int idx) {
   return rb_field_type;
 }
 
-static VALUE mysql2_set_field_string_encoding(VALUE val, MYSQL_FIELD field, rb_encoding *default_internal_enc, rb_encoding *conn_enc) {
+/* See result.h. Runs at the query/execute entry points, never per row. */
+void mysql2_canonicalize_force_encoding(VALUE opts) {
+  VALUE requested = rb_hash_aref(opts, sym_force_encoding);
+
+  if (!NIL_P(requested)) {
+    rb_hash_aset(opts, sym_force_encoding, rb_enc_from_encoding(rb_to_encoding(requested)));
+  }
+}
+
+static VALUE mysql2_set_field_string_encoding(VALUE val, MYSQL_FIELD field, rb_encoding *default_internal_enc, rb_encoding *conn_enc, rb_encoding *forced_enc) {
+  /* :force_encoding retags the value with the caller's chosen encoding --
+   * bytes unchanged, no transcoding. Force means force: it overrides the
+   * binary branch below (BLOB/BINARY columns get retagged too) and skips
+   * the default_internal conversion. Returning before the charsetnr cache
+   * is consulted also keeps the forced path from ever touching it. */
+  if (forced_enc) {
+    rb_enc_associate(val, forced_enc);
+    return val;
+  }
+
   /* if binary flag is set, respect its wishes */
   if (field.flags & BINARY_FLAG && field.charsetnr == MYSQL2_BINARY_CHARSET) {
     rb_enc_associate(val, binaryEncoding);
@@ -1120,7 +1140,7 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
         case MYSQL_TYPE_GEOMETRY:     // char[]
         default:
           val = rb_str_new(result_buffer->buffer, *(result_buffer->length));
-          val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc);
+          val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc, wrapper->forced_enc);
           break;
       }
     }
@@ -1228,7 +1248,7 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
 
       if (row[i] && fields[i].type != MYSQL_TYPE_NULL) {
         val = rb_str_new(row[i], fieldLengths[i]);
-        val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc);
+        val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc, wrapper->forced_enc);
       } else {
         val = Qnil;
       }
@@ -1285,7 +1305,7 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
            * repeats in the temporal cases below. */
           if (args->cast == MYSQL2_CAST_FAST) {
             val = rb_str_new(row[i], fieldLengths[i]);
-            val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc);
+            val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc, wrapper->forced_enc);
             break;
           }
           if (fields[i].decimals == 0) {
@@ -1315,7 +1335,7 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
 
           if (args->cast == MYSQL2_CAST_FAST) {
             val = rb_str_new(row[i], fieldLengths[i]);
-            val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc);
+            val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc, wrapper->forced_enc);
             break;
           }
 
@@ -1345,7 +1365,7 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
 
           if (args->cast == MYSQL2_CAST_FAST) {
             val = rb_str_new(row[i], fieldLengths[i]);
-            val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc);
+            val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc, wrapper->forced_enc);
             break;
           }
 
@@ -1420,7 +1440,7 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
           unsigned int year=0, month=0, day=0;
           if (args->cast == MYSQL2_CAST_FAST) {
             val = rb_str_new(row[i], fieldLengths[i]);
-            val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc);
+            val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc, wrapper->forced_enc);
             break;
           }
           if (!mysql2_parse_date(row[i], fieldLengths[i], &year, &month, &day)) {
@@ -1454,7 +1474,7 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
         case MYSQL_TYPE_GEOMETRY:   /* Spatial fielda */
         default:
           val = rb_str_new(row[i], fieldLengths[i]);
-          val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc);
+          val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc, wrapper->forced_enc);
           break;
       }
       if (args->asArray) {
@@ -1699,6 +1719,17 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
   // A block can be passed to this method, but since we don't call the block directly from C,
   // we don't need to capture it into a variable here with the "&" scan arg.
   perEachOpts = rb_scan_args(argc, argv, "01", &opts) == 1;
+
+  /* :force_encoding is resolved when the query/execute command is issued
+   * and is fixed for the life of the Result: non-streaming
+   * Statement#execute materializes every row by calling #each itself, so
+   * a value passed here could never be honored consistently. Reject it
+   * outright rather than silently ignoring it. (The merged defaults
+   * below legitimately carry the query-time value; only the per-#each
+   * hash is checked.) */
+  if (perEachOpts && RB_TYPE_P(opts, T_HASH) && rb_hash_lookup2(opts, sym_force_encoding, Qundef) != Qundef) {
+    rb_raise(cMysql2Error, ":force_encoding is a query option and cannot be set on Result#each");
+  }
 
   if (!perEachOpts && wrapper->each_opts.parsed) {
     /* Argument-less #each over the already-parsed @query_options: reuse the
@@ -1994,6 +2025,15 @@ VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_
    * should be processed here. */
   wrapper->is_streaming = (rb_hash_aref(options, sym_stream) == Qtrue ? 1 : 0);
 
+  /* :force_encoding was canonicalized to an Encoding object at the
+   * query/execute entry point (mysql2_canonicalize_force_encoding), so
+   * rb_to_encoding here is a plain data unwrap with no exception path --
+   * required in this function, see conn_enc above. */
+  {
+    VALUE forced = rb_hash_aref(options, sym_force_encoding);
+    wrapper->forced_enc = NIL_P(forced) ? NULL : rb_to_encoding(forced);
+  }
+
   return obj;
 }
 
@@ -2044,6 +2084,7 @@ void init_mysql2_result(void) {
   sym_no_good_index_used = ID2SYM(rb_intern("no_good_index_used"));
   sym_no_index_used      = ID2SYM(rb_intern("no_index_used"));
   sym_query_was_slow     = ID2SYM(rb_intern("query_was_slow"));
+  sym_force_encoding = ID2SYM(rb_intern("force_encoding"));
 
   opt_decimal_zero = rb_str_new2("0.0");
   rb_global_variable(&opt_decimal_zero); /*never GC */

--- a/ext/mysql2/result.h
+++ b/ext/mysql2/result.h
@@ -4,6 +4,18 @@
 void init_mysql2_result(void);
 VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_RES *r, VALUE statement);
 
+/* Resolve a :force_encoding query option (an Encoding object or an encoding
+ * name) to its Encoding object, in place in the given options hash, raising
+ * ArgumentError/TypeError for invalid values. Called at the query/execute
+ * entry points (client.c, statement.c) BEFORE the command is sent, for two
+ * reasons: rb_mysql_result_to_obj must not raise between taking ownership of
+ * the MYSQL_RES and returning (the streaming lifecycle depends on it), so
+ * validation cannot wait until then; and raising pre-send leaves the
+ * connection untouched and immediately reusable. Storing the resolved
+ * Encoding back into the per-query options snapshot also insulates the
+ * Result from later mutation of the value the caller passed. */
+void mysql2_canonicalize_force_encoding(VALUE opts);
+
 /* Force-free a Result's underlying MYSQL_RES/MYSQL_STMT result right now,
  * from ordinary Ruby-level code (not a dfree callback) -- so this performs
  * the real mysql_free_result()/mysql_stmt_free_result() call directly
@@ -51,6 +63,12 @@ typedef struct {
    * runs charset_name=), so this never goes stale; caching it avoids a
    * rb_to_encoding() call per row fetch. */
   rb_encoding *conn_enc;
+  /* The :force_encoding query option, unwrapped once at Result creation;
+   * NULL when the option wasn't given. When set, string values are retagged
+   * with this encoding -- bytes unchanged -- instead of taking the
+   * per-charset lookup, the binary branch, or the default_internal
+   * conversion. */
+  rb_encoding *forced_enc;
   my_ulonglong numberOfFields;
   my_ulonglong numberOfRows;
   unsigned long lastRowProcessed;

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -378,6 +378,26 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
     }
   }
 
+  // Duplicate the options hash, merge! extra opts, put the copy into the
+  // Result object. Deliberately ahead of the bind buffer setup below:
+  // canonicalizing :force_encoding raises for invalid values, and raising
+  // here -- before any bind buffers are xmalloc'd and before anything is
+  // written to the wire -- leaks nothing and leaves the connection
+  // untouched and reusable. Nothing downstream of the execute may raise
+  // for this option; rb_mysql_result_to_obj in particular must not.
+  current = rb_hash_dup(rb_ivar_get(stmt_wrapper->client, intern_query_options));
+  (void)RB_GC_GUARD(current);
+  Check_Type(current, T_HASH);
+
+  // Merge in hash opts/keyword arguments
+  if (!NIL_P(opts)) {
+    rb_funcall(current, intern_merge_bang, 1, opts);
+  }
+
+  mysql2_canonicalize_force_encoding(current);
+
+  is_streaming = (Qtrue == rb_hash_aref(current, sym_stream));
+
   // setup any bind variables in the query
   if (bind_count > 0) {
     // Scratch space for string encoding exports, allocate on the stack
@@ -510,18 +530,6 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
       rb_raise_mysql2_stmt_error(stmt_wrapper);
     }
   }
-
-  // Duplicate the options hash, merge! extra opts, put the copy into the Result object
-  current = rb_hash_dup(rb_ivar_get(stmt_wrapper->client, intern_query_options));
-  (void)RB_GC_GUARD(current);
-  Check_Type(current, T_HASH);
-
-  // Merge in hash opts/keyword arguments
-  if (!NIL_P(opts)) {
-    rb_funcall(current, intern_merge_bang, 1, opts);
-  }
-
-  is_streaming = (Qtrue == rb_hash_aref(current, sym_stream));
 
   // From stmt_execute to mysql_stmt_result_metadata to stmt_store_result, no
   // Ruby API calls are allowed so that GC is not invoked. If the connection is

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -1287,6 +1287,104 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
     end
   end
 
+  context "with the :force_encoding query option" do
+    # 0x68C3A96C6C6F is "héllo" in UTF-8.
+    let(:sql) { "SELECT _utf8mb4 0x68C3A96C6C6F AS utf8_val, UNHEX('DEADBEEF') AS binary_val" }
+
+    it "retags string values with the forced encoding, bytes unchanged" do
+      plain = @client.query(sql).first
+      forced = @client.query(sql, force_encoding: Encoding::ISO_8859_1).first
+      expect(forced['utf8_val'].encoding).to eql(Encoding::ISO_8859_1)
+      expect(forced['utf8_val'].bytes).to eql(plain['utf8_val'].bytes)
+    end
+
+    it "accepts an encoding name as a String" do
+      row = @client.query(sql, force_encoding: 'ISO-8859-1').first
+      expect(row['utf8_val'].encoding).to eql(Encoding::ISO_8859_1)
+    end
+
+    it "retags BLOB/binary values instead of leaving them ASCII-8BIT" do
+      row = @client.query(sql, force_encoding: 'utf-8').first
+      expect(row['binary_val'].encoding).to eql(Encoding::UTF_8)
+      expect(row['binary_val'].bytes).to eql([0xDE, 0xAD, 0xBE, 0xEF])
+    end
+
+    it "wins over Encoding.default_internal: retag only, no transcode" do
+      with_internal_encoding Encoding::UTF_8 do
+        row = @client.query(sql, force_encoding: Encoding::ISO_8859_1).first
+        expect(row['utf8_val'].encoding).to eql(Encoding::ISO_8859_1)
+        expect(row['utf8_val'].bytes).to eql("h\xC3\xA9llo".bytes)
+      end
+    end
+
+    it "applies to streaming results" do
+      rows = @client.query(sql, stream: true, cache_rows: false, force_encoding: 'binary').to_a
+      expect(rows.first['utf8_val'].encoding).to eql(Encoding::BINARY)
+      expect(rows.first['binary_val'].encoding).to eql(Encoding::BINARY)
+    end
+
+    it "retags every value under cast: false, where numbers arrive as strings" do
+      row = @client.query("SELECT 1 AS int_val", cast: false, force_encoding: 'binary').first
+      expect(row['int_val']).to eql("1")
+      expect(row['int_val'].encoding).to eql(Encoding::BINARY)
+    end
+
+    it "does not affect values cast to non-string types" do
+      row = @client.query("SELECT 1 AS int_val, DATE'2026-08-11' AS date_val", force_encoding: 'binary').first
+      expect(row['int_val']).to eql(1)
+      expect(row['date_val']).to eql(Date.new(2026, 8, 11))
+    end
+
+    it "does not affect field names" do
+      result = @client.query(sql, symbolize_keys: true, force_encoding: 'binary')
+      expect(result.first.keys).to eql(%i[utf8_val binary_val])
+
+      result = @client.query(sql, force_encoding: 'binary')
+      expect(result.fields).to eql(%w[utf8_val binary_val])
+      expect(result.fields.first.encoding).to eql(Encoding::UTF_8)
+    end
+
+    it "raises for an unknown encoding name before the command is sent" do
+      @client.query("CREATE TEMPORARY TABLE mysql2_force_encoding_probe (id INT)")
+      expect { @client.query("INSERT INTO mysql2_force_encoding_probe VALUES (1)", force_encoding: 'not-an-encoding') }
+        .to raise_error(ArgumentError, /unknown encoding name.*not-an-encoding/)
+      # Nothing hit the wire: the INSERT never ran and the connection is
+      # still usable.
+      expect(@client.query("SELECT COUNT(*) AS n FROM mysql2_force_encoding_probe").first['n']).to eql(0)
+    end
+
+    it "raises for values that are not encodings" do
+      expect { @client.query(sql, force_encoding: 42) }.to raise_error(TypeError)
+    end
+
+    it "snapshots the option at query time, immune to later mutation of the caller's hash" do
+      name = +'binary'
+      opts = { force_encoding: name }
+      result = @client.query(sql, opts)
+      name.replace('utf-8')
+      opts[:force_encoding] = 'utf-8'
+      expect(result.first['utf8_val'].encoding).to eql(Encoding::BINARY)
+    end
+
+    it "cannot be set per Result#each call" do
+      result = @client.query(sql)
+      expect { result.each(force_encoding: 'utf-8') {} }
+        .to raise_error(Mysql2::Error, ":force_encoding is a query option and cannot be set on Result#each")
+      # Presence of the key is the error, even with a nil value.
+      expect { result.each(force_encoding: nil) {} }
+        .to raise_error(Mysql2::Error, ":force_encoding is a query option and cannot be set on Result#each")
+      # The result is still iterable, including with other per-each options.
+      expect(result.each(as: :array).first.first.encoding).to eql(Encoding::UTF_8)
+    end
+
+    it "carries through re-iteration with per-each options" do
+      result = @client.query(sql, force_encoding: 'binary', cache_rows: false)
+      rows = []
+      result.each(as: :array) { |row| rows << row }
+      expect(rows.first.first.encoding).to eql(Encoding::BINARY)
+    end
+  end
+
   context "cast: false raw string rows" do
     # Pins the text-protocol cast: false fast path in rb_mysql_result_fetch_row
     # (ext/mysql2/result.c) to the exact output of the casting loop's raw-string

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -812,6 +812,53 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
     end
   end
 
+  context "with the :force_encoding execute option" do
+    # 0x68C3A96C6C6F is "héllo" in UTF-8.
+    let(:sql) { "SELECT _utf8mb4 0x68C3A96C6C6F AS utf8_val, UNHEX('DEADBEEF') AS binary_val" }
+
+    it "retags string values with the forced encoding, bytes unchanged" do
+      row = @client.prepare(sql).execute(force_encoding: 'ISO-8859-1').first
+      expect(row['utf8_val'].encoding).to eql(Encoding::ISO_8859_1)
+      expect(row['utf8_val'].bytes).to eql("h\xC3\xA9llo".bytes)
+    end
+
+    it "accepts an Encoding object and retags BLOB/binary values too" do
+      row = @client.prepare(sql).execute(force_encoding: Encoding::UTF_8).first
+      expect(row['binary_val'].encoding).to eql(Encoding::UTF_8)
+      expect(row['binary_val'].bytes).to eql([0xDE, 0xAD, 0xBE, 0xEF])
+    end
+
+    it "combines with bind parameters and leaves NULL and non-string values alone" do
+      row = @client.prepare("SELECT ? AS str_val, NULL AS null_val, 1 AS int_val").execute("abc", force_encoding: 'binary').first
+      expect(row['str_val'].encoding).to eql(Encoding::BINARY)
+      expect(row['null_val']).to be_nil
+      expect(row['int_val']).to eql(1)
+    end
+
+    it "passes through streaming execution" do
+      # Streaming prepared statements cannot return string values at all,
+      # with or without this option: statement streaming skips
+      # mysql_stmt_store_result, leaving max_length 0, and string fetches
+      # die with MYSQL_DATA_TRUNCATED ("IMPLBUG..."). So there is nothing to
+      # retag here; pin that the option at least threads through the
+      # streaming execute path unharmed.
+      rows = @client.prepare("SELECT 1 UNION SELECT 2").execute(stream: true, cache_rows: false, as: :array, force_encoding: 'binary').to_a
+      expect(rows).to eql([[1], [2]])
+    end
+
+    it "raises for an unknown encoding name before the statement executes" do
+      @client.query("CREATE TEMPORARY TABLE mysql2_stmt_force_encoding_probe (id INT)")
+      stmt = @client.prepare("INSERT INTO mysql2_stmt_force_encoding_probe VALUES (1)")
+      expect { stmt.execute(force_encoding: 'not-an-encoding') }
+        .to raise_error(ArgumentError, /unknown encoding name.*not-an-encoding/)
+      # Nothing hit the wire: the INSERT never ran, and both the connection
+      # and the statement are still usable.
+      expect(@client.query("SELECT COUNT(*) AS n FROM mysql2_stmt_force_encoding_probe").first['n']).to eql(0)
+      stmt.execute
+      expect(@client.query("SELECT COUNT(*) AS n FROM mysql2_stmt_force_encoding_probe").first['n']).to eql(1)
+    end
+  end
+
   context 'last_id' do
     before(:example) do
       @client.query 'USE test'


### PR DESCRIPTION
Callers who know better than the column charset need a way to say so: legacy schemas that store UTF-8 bytes in latin1 columns hand back strings tagged ISO-8859-1 that break the moment they meet the rest of the app, and code that hashes or byte-compares values wants raw binary without a `dup.force_encoding` per value. `Client#query` and `Statement#execute` now accept `force_encoding:` with an Encoding object or an encoding name (anything Encoding.find accepts):

    client.query("SELECT * FROM legacy", force_encoding: Encoding::UTF_8)
    stmt.execute(force_encoding: "binary")

Semantics, precisely:

* **Retag, not transcode.** Values keep their bytes; only the encoding tag changes. Force means force: the forced encoding overrides the BLOB/BINARY branch (binary columns get retagged too, instead of tagged ASCII-8BIT) and skips the Encoding.default_internal conversion entirely.
* **String values only.** With cast: true (the default), values cast to Integer/Date/Time and friends are untouched. With cast: false, every non-NULL value arrives as a string and all of them are retagged. Field names and field_types are unaffected.
* **Resolved at query/execute time, fixed for the life of the Result.** The value is canonicalized to an Encoding object via rb_to_encoding at the two command entry points (rb_mysql_query in client.c, rb_mysql_stmt_execute in statement.c) before anything is written to the wire. Invalid values raise ArgumentError/TypeError with the connection untouched and immediately reusable. Nothing may raise once the command is sent -- rb_mysql_result_to_obj in particular must not raise between taking ownership of the MYSQL_RES and returning (the streaming lifecycle, #1463) -- and by then only a plain Encoding unwrap remains. Storing the resolved Encoding back into the per-query options snapshot also makes the Result immune to the caller mutating their options hash, or the encoding-name string itself, after the call.
* **Rejected on Result#each.** `result.each(force_encoding: ...)` raises Mysql2::Error. Non-streaming Statement#execute materializes every row internally by calling #each itself, so a per-#each value could never be honored consistently; rejecting beats silently ignoring. Key presence is the error, even with a nil value. The option is query/execute-only, and the README section documents all of the above.

On the statement path, the options dup/merge moved ahead of bind-buffer setup so canonicalization raises before any bind buffers are xmalloc'd -- an error there now leaks nothing and leaves the connection untouched.

Interaction with the encoding caches underneath (#1485): the forced path returns before the per-process charsetnr cache is consulted, so it never reads or writes it; the non-forced path is unchanged.

This PR is deliberately stacked on #1485: both change mysql2_set_field_string_encoding, and sodabrew's triage of #1422 suggested the two could travel together -- split into two reviewable pieces, second riding on the first. The first commit here is #1485's; review the second commit.

Specs (result_spec, statement_spec):

* Retags string values, bytes unchanged: text protocol, prepared statements, and text-protocol streaming.
* BLOB/binary values retagged under force_encoding: "utf-8" instead of left ASCII-8BIT.
* Wins over Encoding.default_internal: tag forced, bytes untranscoded.
* Accepts an Encoding object and a String name; non-encoding values (integers) raise TypeError.
* Unknown encoding name raises ArgumentError before the command is sent, pinned with an INSERT probe on both paths: the row never lands, and the connection (and the prepared statement handle) stay usable.
* Snapshot immunity: mutating the caller's options hash or the encoding-name string after query returns does not affect the lazily materialized rows.
* `each(force_encoding: ...)` raises, message pinned; nil value included; re-iteration with other per-each options still works, and the merged defaults carrying the query-time value do not re-trip the check.
* Non-string casts (INTEGER, DATE) untouched; cast: false retags everything; plain and symbolized field names unaffected.
* Prepared statements: NULL values and bind parameters combined with the keyword option.
* Streaming prepared statements cannot return string values at all, with or without this option: statement streaming skips mysql_stmt_store_result, so string fetches die with MYSQL_DATA_TRUNCATED ("IMPLBUG...") -- pre-existing upstream behavior, which is why the existing streaming-statement specs only use integers. A spec pins that the option at least threads through that path unharmed.

Verified the specs bite: against the base build (specs applied, extension changes reverted), 15 of 18 fail. The three survivors are the deliberate invariance pins (non-string casts, field names) plus one strengthened after proving vacuous -- String#eql? ignores encoding for ASCII-only strings, so the cast: false spec now asserts the encoding directly.

This is a feature PR, not a performance one: no benchmarks, no performance claims. The forced path costs one pointer test per string value.

Environment: base 82f9e18 + #1485, Ruby 4.0.6, MySQL 9.6 (Homebrew, libmysqlclient.24), macOS arm64.

Full suite: 430 examples, 0 failures, 10 pending (SSL-gated). RuboCop clean.
