### PR TITLE
Array-mode results: materialize field names once, not per cell

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -334,36 +334,19 @@ static VALUE rb_mysql_result_fetch_field(VALUE self, unsigned int idx, int symbo
 }
 
 /* Materialize every field name into wrapper->fields at once, honoring the
- * given symbolize_keys.
+ * given symbolize_keys. Array mode calls this once per result set, on the
+ * first fetched row, before converting any of that row's values.
  *
- * Array-mode rows never consult field names during value conversion, so the
- * per-cell rb_mysql_result_fetch_field call the hash path makes is pure
- * overhead there: (rows x columns) calls to produce names that are read
- * (columns) times at most. But those per-cell calls were also what populated
- * wrapper->fields as a side effect, and #fields leans on that in two ways:
+ * The first-row, before-any-values timing is load-bearing, not just a fast
+ * path: #fields on an abandoned streaming result (force-freed by the next
+ * query, skipping rb_mysql_result_cache_metadata_and_free) can only return
+ * names already materialized, and a per-each :symbolize_keys caches names
+ * first-call-wins. Filling the whole array here preserves both.
  *
- * - An abandoned streaming result is force-freed by the next query
- *   (mysql2_result_force_free) without the natural-completion metadata
- *   caching that rb_mysql_result_cache_metadata_and_free performs, so
- *   whatever was materialized during iteration is the only copy of the
- *   names that survives. Master materialized all of them on the first row
- *   (per-cell, ascending); #fields after a force-free depends on it.
- * - #each accepts a per-call :symbolize_keys that can differ from the
- *   query options #fields reads, and the per-cell calls cached names under
- *   the per-each setting. First-each wins; this keeps that.
- *
- * So the array path calls this once per result set, on the first fetched
- * row, before any of that row's values are converted -- same coverage and
- * symbolization as master's per-cell calls, minus the redundant re-fetches.
- * Later parcels rely on the ordering guarantee that names are fully
- * materialized before any value conversion happens.
- *
- * All fills run ascending from 0, here and in the per-cell hash path, so
- * RARRAY_LEN == numberOfFields iff every name is cached; this is the same
- * done-check rb_mysql_result_fetch_fields uses. It also makes the
- * materialization all-or-nothing: a raise mid-fill is healed by the next
- * row's call, and array mode can no longer leave the partially-filled
- * wrapper->fields that a mid-row raise left behind on master.
+ * Fills run ascending from 0, as in the per-cell hash path, so
+ * RARRAY_LEN == numberOfFields exactly when every name is cached -- the
+ * same done-check rb_mysql_result_fetch_fields uses -- and a raise
+ * mid-fill is healed by the next row's call.
  *
  * The caller must ensure wrapper->fields is allocated and the result is not
  * freed. */

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -333,6 +333,59 @@ static VALUE rb_mysql_result_fetch_field(VALUE self, unsigned int idx, int symbo
   return rb_field;
 }
 
+/* Materialize every field name into wrapper->fields at once, honoring the
+ * given symbolize_keys.
+ *
+ * Array-mode rows never consult field names during value conversion, so the
+ * per-cell rb_mysql_result_fetch_field call the hash path makes is pure
+ * overhead there: (rows x columns) calls to produce names that are read
+ * (columns) times at most. But those per-cell calls were also what populated
+ * wrapper->fields as a side effect, and #fields leans on that in two ways:
+ *
+ * - An abandoned streaming result is force-freed by the next query
+ *   (mysql2_result_force_free) without the natural-completion metadata
+ *   caching that rb_mysql_result_cache_metadata_and_free performs, so
+ *   whatever was materialized during iteration is the only copy of the
+ *   names that survives. Master materialized all of them on the first row
+ *   (per-cell, ascending); #fields after a force-free depends on it.
+ * - #each accepts a per-call :symbolize_keys that can differ from the
+ *   query options #fields reads, and the per-cell calls cached names under
+ *   the per-each setting. First-each wins; this keeps that.
+ *
+ * So the array path calls this once per result set, on the first fetched
+ * row, before any of that row's values are converted -- same coverage and
+ * symbolization as master's per-cell calls, minus the redundant re-fetches.
+ * Later parcels rely on the ordering guarantee that names are fully
+ * materialized before any value conversion happens.
+ *
+ * All fills run ascending from 0, here and in the per-cell hash path, so
+ * RARRAY_LEN == numberOfFields iff every name is cached; this is the same
+ * done-check rb_mysql_result_fetch_fields uses. It also makes the
+ * materialization all-or-nothing: a raise mid-fill is healed by the next
+ * row's call, and array mode can no longer leave the partially-filled
+ * wrapper->fields that a mid-row raise left behind on master.
+ *
+ * The caller must ensure wrapper->fields is allocated and the result is not
+ * freed. */
+static void rb_mysql_result_materialize_field_names(VALUE self, int symbolize_keys) {
+  unsigned int i;
+  VALUE fields;
+  GET_RESULT(self);
+
+  /* See the identical guard in rb_mysql_result_fetch_fields: keep a
+   * stack-local reference alive across the fill loop so conservative stack
+   * scanning finds the array too, independent of GC generation timing. */
+  fields = wrapper->fields;
+
+  if ((my_ulonglong)RARRAY_LEN(fields) != wrapper->numberOfFields) {
+    for (i = 0; i < wrapper->numberOfFields; i++) {
+      rb_mysql_result_fetch_field(self, i, symbolize_keys);
+    }
+  }
+
+  RB_GC_GUARD(fields);
+}
+
 static int rb_mariadb_json_type(const MYSQL_FIELD *field) {
 #if defined(MARIADB_PACKAGE_VERSION)
     MARIADB_CONST_STRING field_attr;
@@ -834,8 +887,16 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
     }
   }
 
+  /* Placed after the fetch above rather than with the wrapper->fields
+   * allocation so an empty result set stays untouched, exactly as it was
+   * when the (never-entered) cell loop did the materializing. */
+  if (args->asArray) {
+    rb_mysql_result_materialize_field_names(self, args->symbolizeKeys);
+  }
+
   for (i = 0; i < wrapper->numberOfFields; i++) {
-    VALUE field = rb_mysql_result_fetch_field(self, i, args->symbolizeKeys);
+    /* Hash keys only; array-mode names were batch-materialized above. */
+    VALUE field = args->asArray ? Qnil : rb_mysql_result_fetch_field(self, i, args->symbolizeKeys);
     VALUE val = Qnil;
     MYSQL_TIME *ts;
 
@@ -1050,6 +1111,10 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
     wrapper->fields = rb_ary_new2(wrapper->numberOfFields);
   }
   if (args->asArray) {
+    /* This runs after the NULL-row check above, so it materializes on the
+     * first fetched row and an empty result set stays untouched, exactly
+     * as it was when the (never-entered) cell loop did the materializing. */
+    rb_mysql_result_materialize_field_names(self, args->symbolizeKeys);
     rowVal = rb_ary_new2(wrapper->numberOfFields);
   } else {
     /* Pre-size to the column count so a row with more than the default
@@ -1063,7 +1128,8 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
   fieldLengths = mysql_fetch_lengths(wrapper->result);
 
   for (i = 0; i < wrapper->numberOfFields; i++) {
-    VALUE field = rb_mysql_result_fetch_field(self, i, args->symbolizeKeys);
+    /* Hash keys only; array-mode names were batch-materialized above. */
+    VALUE field = args->asArray ? Qnil : rb_mysql_result_fetch_field(self, i, args->symbolizeKeys);
     if (row[i]) {
       VALUE val = Qnil;
       enum enum_field_types type = fields[i].type;

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -259,6 +259,81 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
       expect(result.fields).to eql(["only_col"])
       expect(result.field_types.length).to eql(1)
     end
+
+    context "when iterating in array mode" do
+      # Array rows never contain field names, so names are batch-materialized
+      # on the first fetched row instead of fetched per cell. These pin that
+      # #fields behaves exactly as it did with the per-cell materialization,
+      # including after an abandoned stream is force-freed by the next query.
+      let(:sql) { "SELECT 1 AS a, 'x' AS b UNION SELECT 2, 'y' UNION SELECT 3, 'z'" }
+
+      it "should return field names after buffered iteration" do
+        result = @client.query(sql, as: :array)
+        result.to_a
+        expect(result.fields).to eql(%w[a b])
+      end
+
+      it "should return field names after streaming iteration" do
+        result = @client.query(sql, as: :array, stream: true, cache_rows: false)
+        result.each { |_| }
+        expect(result.fields).to eql(%w[a b])
+      end
+
+      it "should fully populate fields when iteration breaks after the first row" do
+        result = @client.query(sql, as: :array, cache_rows: false)
+        result.each { |_| break } # rubocop:disable Lint/UnreachableLoop
+        expect(result.fields).to eql(%w[a b])
+      end
+
+      it "should fully populate fields when the block raises mid-iteration" do
+        result = @client.query(sql, as: :array, cache_rows: false)
+        expect { result.each { |_| raise "boom" } }.to raise_error(RuntimeError, "boom") # rubocop:disable Lint/UnreachableLoop
+        expect(result.fields).to eql(%w[a b])
+      end
+
+      it "should keep fields accessible after an abandoned stream is force-freed by the next query" do
+        # The next query force-frees the abandoned stream without the
+        # natural-completion metadata caching, so the names materialized by
+        # the first fetched row are the only copy left.
+        result = @client.query(sql, as: :array, stream: true, cache_rows: false)
+        result.each { |_| break } # rubocop:disable Lint/UnreachableLoop
+        @client.query("SELECT 1")
+        expect(result.fields).to eql(%w[a b])
+      end
+
+      it "should keep raising for a never-iterated stream force-freed by the next query" do
+        # No row was ever fetched, so no names were materialized to survive
+        # the force-free.
+        result = @client.query(sql, as: :array, stream: true, cache_rows: false)
+        @client.query("SELECT 1")
+        expect { result.fields }.to raise_error(Mysql2::Error, "Result set has already been freed")
+      end
+
+      it "should honor per-each symbolize_keys in fields" do
+        result = @client.query(sql)
+        result.each(as: :array, symbolize_keys: true) { |_| }
+        expect(result.fields).to eql(%i[a b])
+      end
+
+      it "should honor per-each symbolize_keys in fields after a force-freed abandoned stream" do
+        result = @client.query(sql, stream: true, cache_rows: false)
+        result.each(as: :array, symbolize_keys: true) { |_| break } # rubocop:disable Lint/UnreachableLoop
+        @client.query("SELECT 1")
+        expect(result.fields).to eql(%i[a b])
+      end
+
+      it "should keep fields accessible for exhausted empty results" do
+        result = @client.query("SELECT 1 AS a, 'x' AS b WHERE 1 = 0", as: :array)
+        expect(result.to_a).to eql([])
+        expect(result.fields).to eql(%w[a b])
+      end
+
+      it "should keep fields accessible for exhausted empty streaming results" do
+        result = @client.query("SELECT 1 AS a, 'x' AS b WHERE 1 = 0", as: :array, stream: true, cache_rows: false)
+        expect(result.each.to_a).to eql([])
+        expect(result.fields).to eql(%w[a b])
+      end
+    end
   end
 
   context "#field_types" do

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -385,6 +385,69 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
       stmt = @client.prepare("INSERT INTO mysql2_test () VALUES ()")
       expect(stmt.fields).to eql(nil)
     end
+
+    context "on results iterated in array mode" do
+      # Array rows never contain field names, so names are batch-materialized
+      # on the first fetched row instead of fetched per cell. These pin that
+      # Result#fields behaves exactly as it did with the per-cell
+      # materialization over the binary protocol, including after an abandoned
+      # stream is force-freed by the next query.
+      #
+      # Integer-only columns: streaming prepared statements size their result
+      # buffers from fields[i].max_length, which is 0 for var-length columns
+      # without mysql_stmt_store_result -- a pre-existing limitation unrelated
+      # to field names.
+      let(:sql) { "SELECT 1 AS a, 10 AS b UNION SELECT 2, 20 UNION SELECT 3, 30" }
+
+      it "should return field names after iteration" do
+        result = @client.prepare(sql).execute(as: :array)
+        result.to_a
+        expect(result.fields).to eql(%w[a b])
+      end
+
+      it "should honor symbolize_keys in fields" do
+        result = @client.prepare(sql).execute(as: :array, symbolize_keys: true)
+        result.to_a
+        expect(result.fields).to eql(%i[a b])
+      end
+
+      it "should keep fields accessible for exhausted empty results" do
+        result = @client.prepare("SELECT 1 AS a WHERE 1 = 0").execute(as: :array)
+        expect(result.to_a).to eql([])
+        expect(result.fields).to eql(["a"])
+      end
+
+      it "should keep fields accessible after an abandoned stream is force-freed by the next query" do
+        # The next query force-frees the abandoned stream without the
+        # natural-completion metadata caching, so the names materialized by
+        # the first fetched row are the only copy left.
+        result = @client.prepare(sql).execute(as: :array, stream: true, cache_rows: false)
+        result.each { |_| break } # rubocop:disable Lint/UnreachableLoop
+        @client.query("SELECT 1")
+        expect(result.fields).to eql(%w[a b])
+      end
+
+      it "should keep raising for a never-iterated stream force-freed by the next query" do
+        # No row was ever fetched, so no names were materialized to survive
+        # the force-free.
+        result = @client.prepare(sql).execute(as: :array, stream: true, cache_rows: false)
+        @client.query("SELECT 1")
+        expect { result.fields }.to raise_error(Mysql2::Error, "Result set has already been freed")
+      end
+
+      it "should honor symbolize_keys in fields after a force-freed abandoned stream" do
+        result = @client.prepare(sql).execute(as: :array, symbolize_keys: true, stream: true, cache_rows: false)
+        result.each { |_| break } # rubocop:disable Lint/UnreachableLoop
+        @client.query("SELECT 1")
+        expect(result.fields).to eql(%i[a b])
+      end
+
+      it "should keep fields accessible for exhausted empty streaming results" do
+        result = @client.prepare("SELECT 1 AS a WHERE 1 = 0").execute(as: :array, stream: true, cache_rows: false)
+        expect(result.each.to_a).to eql([])
+        expect(result.fields).to eql(["a"])
+      end
+    end
   end
 
   context "row data type mapping" do


### PR DESCRIPTION
`as: :array` rows never contain field names, yet `rb_mysql_result_fetch_row` and `rb_mysql_result_fetch_row_stmt` call `rb_mysql_result_fetch_field` for every cell -- rows x columns calls per result set to produce names that array rows never read. After the first row each call is a cached `rb_ary_entry` lookup, but it is still a per-cell call whose result is discarded.

Those per-cell calls cannot simply be dropped, because populating `wrapper->fields` is their side effect and `#fields` leans on it in two ways:

* An abandoned streaming result is force-freed by the next query (`mysql2_result_force_free`) *without* the metadata caching that natural completion and explicit `#free` perform (#1450 covers those paths, not the force-free one). Whatever was materialized during iteration is the only copy of the names that survives, so `#fields` after a force-free works on master precisely because the first row's per-cell calls cached every name.
* `#each` accepts a per-call `:symbolize_keys` that can differ from the query options `#fields` reads; the per-cell calls cache names under the per-each setting, and first-each wins.

So instead: on the first fetched array-mode row, materialize every name at once (`rb_mysql_result_materialize_field_names`) -- before any of that row's values are converted, honoring the per-each `:symbolize_keys` -- then skip the per-cell calls entirely. Coverage and symbolization are identical to the per-cell path; the (rows - 1) x columns redundant calls are gone. Both the text and binary protocol paths get the same treatment. An empty result set stays untouched, exactly as it was when the (never-entered) cell loop did the materializing: the binary path materializes after `mysql_stmt_fetch` reports a row, the text path after the NULL-row check.

Behavior pinned against master across {buffered, streaming} x {plain, prepared} x {full iteration, early break, mid-iteration raise, abandoned + force-freed, never-iterated + force-freed, empty result, per-each symbolize_keys}: identical output for every case, including the "Result set has already been freed" raise for a never-iterated force-freed stream.

The all-at-once fill also closes an array-mode use-after-free window on master: a mid-row raise (e.g. an invalid date) left `wrapper->fields` partially filled, and `#fields` after a subsequent force-free walks `mysql_fetch_field_direct` on the freed result. Batch materialization is all-or-nothing, so array mode can no longer produce that partial state. (The equivalent hash-mode window still exists and is untouched here.)

The naive version of this change -- skip the per-cell calls without the batch materialization -- segfaults on exactly that force-free path and returns query-option symbolization instead of per-each; the new specs catch both (a segfault in the force-free specs, `["a", "b"]` where `[:a, :b]` was expected in the symbolize spec).

Later parcels rely on the ordering guarantee this establishes: field names are fully materialized before any value conversion of the first row.

Benchmark: full iteration of `query(sql, as: :array, cache_rows: false)`, 50,000 rows x {20, 5} columns of mixed int/string data, min-of-5 per sample, 9 samples per run, three alternating base/branch pairs on a quiet machine -- AMD Ryzen 9 7950X, Arch Linux x86_64, Ruby 4.0.6, MySQL 9.6.0 (Docker, TCP loopback), client libmariadb 12.3.2, load < 0.7 before every run. Per-run medians in ms:

| shape        | base 82f9e18        | this patch          |
|--------------|---------------------|---------------------|
| 50k x 20 col | 72.01, 71.28, 71.50 | 70.07, 69.87, 69.63 |
| 50k x 5 col  | 19.84, 19.79, 20.02 | 19.43, 19.41, 19.51 |

Median of medians: 71.50 -> 69.87 ms (-2.3%) at 20 columns, ranges pairwise non-overlapping in all three pairs; 19.84 -> 19.43 ms (-2.1%) at 5 columns, directionally consistent but one pair's ranges graze. A real, modest win -- the honest headline here is the correctness fix above plus a small speedup, not a large one; the per-cell fetch_field this removes is a thin slice of array-mode materialization time.

Implemented at base 82f9e18 and benchmarked there; rebased onto 96252dcc575e8626026c1e823e06a3d25739d915 (CI-only change -- apt-key to Signed-By swap in MySQL/MariaDB setup scripts, no library code -- so the measurements remain valid). Full suite on the rebased head: 422 examples, 0 failures, 10 pending (SSL-gated), RuboCop clean, exit 0 verified unpiped.
