### PR TITLE
Cache the parsed query options on the result wrapper

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1480,11 +1480,11 @@ static VALUE rb_mysql_result_each_(VALUE self,
 
 static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
   result_each_args args;
-  VALUE defaults, opts, (*fetch_row_func)(VALUE, MYSQL_FIELD *fields, const result_each_args *args);
-  ID db_timezone, app_timezone, dbTz, appTz;
+  VALUE opts, (*fetch_row_func)(VALUE, MYSQL_FIELD *fields, const result_each_args *args);
+  ID db_timezone, app_timezone;
   int symbolizeKeys, asArray, castBool, cacheRows, cast;
+  int warnDbTimezone, perEachOpts;
   unsigned long rowsPerGvlYield;
-  VALUE rowsPerGvlYieldOpt;
 
   GET_RESULT(self);
 
@@ -1492,32 +1492,90 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
     rb_raise(cMysql2Error, "Statement handle already closed");
   }
 
-  defaults = rb_ivar_get(self, intern_query_options);
-  Check_Type(defaults, T_HASH);
-
   // A block can be passed to this method, but since we don't call the block directly from C,
   // we don't need to capture it into a variable here with the "&" scan arg.
-  if (rb_scan_args(argc, argv, "01", &opts) == 1) {
-    opts = rb_funcall(defaults, intern_merge, 1, opts);
+  perEachOpts = rb_scan_args(argc, argv, "01", &opts) == 1;
+
+  if (!perEachOpts && wrapper->each_opts.parsed) {
+    /* Argument-less #each over the already-parsed @query_options: reuse the
+     * parse. Warnings are deliberately not part of the cache -- their
+     * conditions are recomputed from the cached (pre-forcing) values below,
+     * so they fire on every call exactly as an uncached parse would. */
+    symbolizeKeys   = wrapper->each_opts.symbolizeKeys;
+    asArray         = wrapper->each_opts.asArray;
+    castBool        = wrapper->each_opts.castBool;
+    cacheRows       = wrapper->each_opts.cacheRows;
+    cast            = wrapper->each_opts.cast;
+    warnDbTimezone  = wrapper->each_opts.warnDbTimezone;
+    rowsPerGvlYield = wrapper->each_opts.rowsPerGvlYield;
+    db_timezone     = wrapper->each_opts.db_timezone;
+    app_timezone    = wrapper->each_opts.app_timezone;
   } else {
-    opts = defaults;
-  }
+    VALUE dbTz, appTz, rowsPerGvlYieldOpt;
+    VALUE defaults = rb_ivar_get(self, intern_query_options);
+    Check_Type(defaults, T_HASH);
 
-  symbolizeKeys = RTEST(rb_hash_aref(opts, sym_symbolize_keys));
-  asArray       = rb_hash_aref(opts, sym_as) == sym_array;
-  castBool      = RTEST(rb_hash_aref(opts, sym_cast_booleans));
-  cacheRows     = RTEST(rb_hash_aref(opts, sym_cache_rows));
-  cast          = RTEST(rb_hash_aref(opts, sym_cast));
+    opts = perEachOpts ? rb_funcall(defaults, intern_merge, 1, opts) : defaults;
 
-  /* :rows_per_gvl_yield -- 0 disables yielding; nil uses the default. */
-  rowsPerGvlYield = MYSQL2_ROWS_PER_GVL_YIELD_DEFAULT;
-  rowsPerGvlYieldOpt = rb_hash_aref(opts, sym_rows_per_gvl_yield);
-  if (!NIL_P(rowsPerGvlYieldOpt)) {
-    long requested = NUM2LONG(rowsPerGvlYieldOpt);
-    if (requested < 0) {
-      rb_raise(cMysql2Error, ":rows_per_gvl_yield must not be negative");
+    symbolizeKeys = RTEST(rb_hash_aref(opts, sym_symbolize_keys));
+    asArray       = rb_hash_aref(opts, sym_as) == sym_array;
+    castBool      = RTEST(rb_hash_aref(opts, sym_cast_booleans));
+    cacheRows     = RTEST(rb_hash_aref(opts, sym_cache_rows));
+    cast          = RTEST(rb_hash_aref(opts, sym_cast));
+
+    /* :rows_per_gvl_yield -- 0 disables yielding; nil uses the default. */
+    rowsPerGvlYield = MYSQL2_ROWS_PER_GVL_YIELD_DEFAULT;
+    rowsPerGvlYieldOpt = rb_hash_aref(opts, sym_rows_per_gvl_yield);
+    if (!NIL_P(rowsPerGvlYieldOpt)) {
+      long requested = NUM2LONG(rowsPerGvlYieldOpt);
+      if (requested < 0) {
+        rb_raise(cMysql2Error, ":rows_per_gvl_yield must not be negative");
+      }
+      rowsPerGvlYield = (unsigned long)requested;
     }
-    rowsPerGvlYield = (unsigned long)requested;
+
+    /* The timezone lookups are hoisted from their historical spot below the
+     * freed-result guard so a complete parse exists to cache; the lookups
+     * themselves are side-effect free, and the invalid-:database_timezone
+     * warning is deferred (warnDbTimezone) to its historical point, after
+     * that guard. */
+    dbTz = rb_hash_aref(opts, sym_database_timezone);
+    warnDbTimezone = 0;
+    if (dbTz == sym_local) {
+      db_timezone = intern_local;
+    } else if (dbTz == sym_utc) {
+      db_timezone = intern_utc;
+    } else {
+      warnDbTimezone = !NIL_P(dbTz);
+      db_timezone = intern_local;
+    }
+
+    appTz = rb_hash_aref(opts, sym_application_timezone);
+    if (appTz == sym_local) {
+      app_timezone = intern_local;
+    } else if (appTz == sym_utc) {
+      app_timezone = intern_utc;
+    } else {
+      app_timezone = Qnil;
+    }
+
+    if (!perEachOpts) {
+      /* Nothing above raised, so this parse of @query_options is complete
+       * and can serve every later argument-less call. An invalid
+       * :rows_per_gvl_yield raises before this point, leaving the cache
+       * unset so the next call re-parses and re-raises just as an uncached
+       * one would. */
+      wrapper->each_opts.symbolizeKeys   = symbolizeKeys;
+      wrapper->each_opts.asArray         = asArray;
+      wrapper->each_opts.castBool        = castBool;
+      wrapper->each_opts.cacheRows       = cacheRows;
+      wrapper->each_opts.cast            = cast;
+      wrapper->each_opts.warnDbTimezone  = warnDbTimezone;
+      wrapper->each_opts.rowsPerGvlYield = rowsPerGvlYield;
+      wrapper->each_opts.db_timezone     = db_timezone;
+      wrapper->each_opts.app_timezone    = app_timezone;
+      wrapper->each_opts.parsed          = 1;
+    }
   }
 
   if (wrapper->is_streaming && cacheRows) {
@@ -1548,25 +1606,8 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
     }
   }
 
-  dbTz = rb_hash_aref(opts, sym_database_timezone);
-  if (dbTz == sym_local) {
-    db_timezone = intern_local;
-  } else if (dbTz == sym_utc) {
-    db_timezone = intern_utc;
-  } else {
-    if (!NIL_P(dbTz)) {
-      rb_warn(":database_timezone option must be :utc or :local - defaulting to :local");
-    }
-    db_timezone = intern_local;
-  }
-
-  appTz = rb_hash_aref(opts, sym_application_timezone);
-  if (appTz == sym_local) {
-    app_timezone = intern_local;
-  } else if (appTz == sym_utc) {
-    app_timezone = intern_utc;
-  } else {
-    app_timezone = Qnil;
+  if (warnDbTimezone) {
+    rb_warn(":database_timezone option must be :utc or :local - defaulting to :local");
   }
 
   if (wrapper->rows == Qnil && !wrapper->is_streaming) {
@@ -1653,6 +1694,10 @@ VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_
   wrapper->is_null = NULL;
   wrapper->error = NULL;
   wrapper->length = NULL;
+  /* Plain assignment only: nothing in this function may raise (post-#1463
+   * streaming lifecycle). The parse itself happens in the first
+   * argument-less #each. */
+  wrapper->each_opts.parsed = 0;
 
   /* Keep a handle to the Statement to ensure it doesn't get garbage collected first */
   wrapper->statement = statement;

--- a/ext/mysql2/result.h
+++ b/ext/mysql2/result.h
@@ -12,6 +12,30 @@ VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_
  * see mysql2_abandon_active_stream in client.c. No-op if already freed. */
 void mysql2_result_force_free(VALUE self);
 
+/* Parsed form of the stored @query_options hash, filled in by the first
+ * argument-less #each and reused by later argument-less calls so they skip
+ * the per-call hash lookups. Plain C scalars and static symbol IDs only --
+ * nothing here is a heap VALUE, so no GC marking is needed. A call that
+ * passes per-each options neither reads nor writes this cache.
+ *
+ * cacheRows and cast are stored as parsed, before the prepared-statement
+ * forcing in #each, so the warnings and forcing replay identically on every
+ * call whether the parse was cached or not. warnDbTimezone records that the
+ * invalid-:database_timezone warning must be re-issued (each warns every
+ * call, and the warning point is after the freed-result guard). */
+typedef struct {
+  int parsed;
+  int symbolizeKeys;
+  int asArray;
+  int castBool;
+  int cacheRows;
+  int cast;
+  int warnDbTimezone;
+  unsigned long rowsPerGvlYield;
+  ID db_timezone;
+  ID app_timezone; /* Qnil when no conversion applies, as in result_each_args */
+} mysql2_each_opts_cache;
+
 typedef struct {
   VALUE fields;
   VALUE fieldTypes;
@@ -34,6 +58,7 @@ typedef struct {
   my_bool *is_null;
   my_bool *error;
   unsigned long *length;
+  mysql2_each_opts_cache each_opts;
 } mysql2_result_wrapper;
 
 #endif

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -218,6 +218,76 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
         result.each.to_a
       end.to raise_exception(Mysql2::Error)
     end
+
+    context "when iterated repeatedly" do
+      def collect_rows(result, **overrides)
+        [].tap { |rows| result.each(**overrides) { |row| rows << row } }
+      end
+
+      it "should replay identical row objects when cache_rows is enabled" do
+        result = @client.query "SELECT 1 AS a UNION SELECT 2"
+        first = collect_rows(result)
+        second = collect_rows(result)
+        expect(second).to eql(first)
+        expect(second.map(&:object_id)).to eql(first.map(&:object_id))
+      end
+
+      it "should build fresh row objects each time when cache_rows is disabled" do
+        result = @client.query "SELECT 1 AS a UNION SELECT 2", cache_rows: false
+        first = collect_rows(result)
+        second = collect_rows(result)
+        expect(second).to eql(first)
+        expect(second.map(&:object_id)).not_to eql(first.map(&:object_id))
+      end
+
+      it "should apply the original query options to a plain #each after a per-each override" do
+        result = @client.query "SELECT 1 AS a", cache_rows: false
+        expect(collect_rows(result)).to eql([{ "a" => 1 }])
+        expect(collect_rows(result, as: :array)).to eql([[1]])
+        expect(collect_rows(result, cast: false)).to eql([{ "a" => "1" }])
+        expect(collect_rows(result)).to eql([{ "a" => 1 }])
+      end
+
+      it "should apply the original query options to a plain #each when a per-each override came first" do
+        result = @client.query "SELECT 1 AS a", cache_rows: false
+        expect(collect_rows(result, as: :array)).to eql([[1]])
+        expect(collect_rows(result)).to eql([{ "a" => 1 }])
+      end
+
+      it "should keep the key style chosen by the first iteration regardless of later overrides" do
+        # Field-name VALUEs are cached per result by the first iteration
+        # (rb_mysql_result_fetch_field), so a later per-each :symbolize_keys
+        # override never re-keys rows: the first iteration's key style wins.
+        # Longstanding upstream behavior, pinned so the parsed-options cache
+        # cannot change it in either direction.
+        result = @client.query "SELECT 1 AS a", cache_rows: false
+        expect(collect_rows(result)).to eql([{ "a" => 1 }])
+        expect(collect_rows(result, symbolize_keys: true)).to eql([{ "a" => 1 }])
+
+        result = @client.query "SELECT 1 AS a", cache_rows: false
+        expect(collect_rows(result, symbolize_keys: true)).to eql([{ a: 1 }])
+        expect(collect_rows(result)).to eql([{ a: 1 }])
+      end
+
+      it "should replay cached rows built with the original options even when a later #each passes overrides" do
+        result = @client.query "SELECT 1 AS a"
+        expect(collect_rows(result)).to eql([{ "a" => 1 }])
+        expect(collect_rows(result, symbolize_keys: true)).to eql([{ "a" => 1 }])
+      end
+
+      it "should reject a negative :rows_per_gvl_yield on every #each, not just the first" do
+        result = @client.query "SELECT 1", rows_per_gvl_yield: -1
+        2.times do
+          expect { result.each { |_| } }.to raise_error(Mysql2::Error, /rows_per_gvl_yield/)
+        end
+      end
+
+      it "should reject a negative per-each :rows_per_gvl_yield even after a successful plain #each" do
+        result = @client.query "SELECT 1"
+        result.each { |_| }
+        expect { result.each(rows_per_gvl_yield: -1) { |_| } }.to raise_error(Mysql2::Error, /rows_per_gvl_yield/)
+      end
+    end
   end
 
   context "#fields" do

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -225,6 +225,15 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
     expect(result.length).to eq(1)
   end
 
+  it "should warn that cache_rows is forced on every #each, not only the first" do
+    statement = @client.prepare 'SELECT 1'
+    result = nil
+    expect { result = statement.execute(cache_rows: false) }.to output(/:cache_rows is forced for prepared statements/).to_stderr
+    2.times do
+      expect { result.each { |_| } }.to output(/:cache_rows is forced for prepared statements/).to_stderr
+    end
+  end
+
   context "utf8_db" do
     before(:example) do
       @client.query("DROP DATABASE IF EXISTS test_mysql2_stmt_utf8")


### PR DESCRIPTION
Mysql2::Result#each parses the stored @query_options hash on every call: five rb_hash_aref lookups, the :rows_per_gvl_yield conversion, and the timezone symbol comparisons. This commit parses once, on the first argument-less #each, and caches the parsed representation -- plain C scalars and static symbol IDs, no heap VALUEs, so no GC exposure -- on the result wrapper. Later argument-less calls reuse it; a call with per-each options neither reads nor writes the cache.

An honest framing first: the original version of this change assumed the options were parsed per ROW, which they are not -- master parses them once per #each CALL. What's left is narrow:

  * repeat #each over a fully cached result, where the parse is the only
    per-call work besides replaying rows;
  * prepared statements, where #execute runs one internal #each to
    materialize the rows, so the first user-level #each is a second
    parse;
  * results that are never iterated gain nothing: no #each, no parse, on
    master or here.

Behavior kept identical, pinned by specs:

  * Per-each overrides (each(as: :array, ...)) bypass the cache
    entirely, and a later plain #each behaves per the original query
    options. A naive cache that ignores per-each args fails three of the
    new specs: both override pins and the per-each :rows_per_gvl_yield
    rejection.
  * The first iteration's key style wins regardless of later
    :symbolize_keys overrides -- longstanding upstream behavior caused
    by the per-result field-name cache, pinned so this change cannot
    alter it in either direction.
  * Warnings are not cached: their conditions are recomputed from the
    cached pre-forcing values, so the :cache_rows-forced, :cast-forced,
    and invalid-:database_timezone warnings fire on every call, at the
    same points, exactly as master. cacheRows and cast are stored as
    parsed (before the prepared-statement forcing) for this reason.
  * An invalid :rows_per_gvl_yield raises before the cache is populated,
    so every subsequent call re-parses and re-raises; its validation
    stays in #each, not result construction.
  * The freed-result guard, cache_rows: false re-materialization, and
    the streaming re-iteration error run unchanged on every call.
  * rb_mysql_result_to_obj gains only a flag clear -- nothing that can
    raise (post-#1463 streaming lifecycle).

Two knowingly-accepted observability deltas, both requiring the caller to reach into the Result's internals between #each calls: mutating or replacing @query_options after a successful argument-less #each is no longer observed by later argument-less calls, and the timezone hash lookups moved above the freed-result guard (observable only via e.g. a Hash default proc). The invalid-timezone warning itself still fires at its historical point, after the guard.

Benchmark -- four arms, quiet machine (AMD Ryzen 9 7950X, Arch Linux x86_64, Ruby 4.0.6, MySQL 9.6.0 in Docker over TCP loopback, client libmariadb 12.3.2, load < 0.8 before every run), min-of-5 per sample, 7 samples per run, serial alternating base/branch runs, medians in us (one base run was discarded for a bimodal low outlier on the stmt arm and replaced by a rerun; base medians below use the three clean runs):

| arm                  | base           | this patch     | delta  |
|----------------------|----------------|----------------|--------|
| first iteration, 1k  | 550, 548, 551  | 548, 532, 536  | noise  |
| construct only       | 69, 92, 69     | 71, 71, 71     | noise  |
| re-#each, 10-row     | 298, 310, 298  | 241, 235, 239  | -19.8% |
| stmt execute + #each | 62, 66, 63     | 45, 44, 42     | -30%   |

The arm this parcel exists for -- argument-less re-iteration of a cached result -- is pure CPU with no round trip to hide behind, and its distributions barely touch: ~59 ns saved per re-#each, -19.8%. The prepared execute-plus-#each arm (the double-parse case) shows -30% nominally, but one discarded control run sat in branch territory, so treat that number as corroboration rather than independent proof. The two predicted no-op arms measured as no-ops, evidence the cache adds no cost where it cannot win.

This is a narrow win: it helps callers that re-iterate cached results or use prepared statements' execute-then-each pattern, and does nothing for the single-pass query-and-materialize flow that dominates most applications. Sized honestly against that, it still carries its weight: the mechanism is a struct of plain C scalars, no new GC edges, and the observability deltas above are the whole cost.

Implemented and measured at 82f9e18, rebased onto 96252dcc575e8626026c1e823e06a3d25739d915 (CI-only change, no library code -- measurements remain valid). Full suite on the rebased head: 414 examples, 0 failures, 10 pending (SSL-gated), RuboCop clean, exit 0 verified unpiped. macOS arm64 + MySQL 9.6/libmysqlclient.24 was the development platform; timing above is from the quiet Linux box.
