### PR TITLE
cast: false rows: skip the per-cell type dispatch entirely

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1199,6 +1199,38 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
   }
   fieldLengths = mysql_fetch_lengths(wrapper->result);
 
+  /* cast: false wants every non-NULL value as a raw String with the right
+   * encoding, so the per-cell type dispatch below is pure overhead for it.
+   * This loop is the cast: false arm of the general loop with the dispatch
+   * hoisted out; everything else is kept cell-for-cell identical -- the same
+   * length-based rb_str_new (embedded NULs intact), the same
+   * mysql2_set_field_string_encoding, the same MYSQL_TYPE_NULL and NULL-cell
+   * handling, and the same key-before-value evaluation order -- so rows are
+   * byte-identical with just fewer branches per cell. Runs entirely with the
+   * GVL held (the only nogvl region in this function is the streaming row
+   * fetch above). */
+  if (!args->cast) {
+    for (i = 0; i < wrapper->numberOfFields; i++) {
+      /* Hash keys only; array-mode names were batch-materialized above. */
+      VALUE field = args->asArray ? Qnil : rb_mysql_result_fetch_field(self, i, args->symbolizeKeys);
+      VALUE val;
+
+      if (row[i] && fields[i].type != MYSQL_TYPE_NULL) {
+        val = rb_str_new(row[i], fieldLengths[i]);
+        val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc);
+      } else {
+        val = Qnil;
+      }
+
+      if (args->asArray) {
+        rb_ary_push(rowVal, val);
+      } else {
+        rb_hash_aset(rowVal, field, val);
+      }
+    }
+    return rowVal;
+  }
+
   for (i = 0; i < wrapper->numberOfFields; i++) {
     /* Hash keys only; array-mode names were batch-materialized above. */
     VALUE field = args->asArray ? Qnil : rb_mysql_result_fetch_field(self, i, args->symbolizeKeys);
@@ -1206,15 +1238,7 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
       VALUE val = Qnil;
       enum enum_field_types type = fields[i].type;
 
-      if (!args->cast) {
-        if (type == MYSQL_TYPE_NULL) {
-          val = Qnil;
-        } else {
-          val = rb_str_new(row[i], fieldLengths[i]);
-          val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc);
-        }
-      } else {
-        switch(type) {
+      switch(type) {
         case MYSQL_TYPE_NULL:       /* NULL-type field */
           val = Qnil;
           break;
@@ -1390,7 +1414,6 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
           val = rb_str_new(row[i], fieldLengths[i]);
           val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc);
           break;
-        }
       }
       if (args->asArray) {
         rb_ary_push(rowVal, val);

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -1287,6 +1287,208 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
     end
   end
 
+  context "cast: false raw string rows" do
+    # Pins the text-protocol cast: false fast path in rb_mysql_result_fetch_row
+    # (ext/mysql2/result.c) to the exact output of the casting loop's raw-string
+    # arm it replaced: every non-NULL value is a String of the wire bytes,
+    # length-based (embedded NULs intact), tagged by
+    # mysql2_set_field_string_encoding; every NULL is nil. Expected values are
+    # written as literals -- bytes and encoding both -- rather than derived
+    # from another code path at runtime.
+    #
+    # Encoding notes, verified against the casting path's raw-string arm on
+    # this server: numeric fields (INT/BIGINT/DECIMAL/FLOAT/YEAR/TINYINT/BIT)
+    # arrive with charsetnr 63 but no BINARY_FLAG, so they are tagged BINARY
+    # via the charsetnr mapping and (unlike BINARY_FLAG fields) do transcode
+    # under Encoding.default_internal. Temporal fields and the true binary
+    # columns (BLOB/VARBINARY) carry BINARY_FLAG + charsetnr 63 and stay
+    # BINARY unconditionally. latin1 text arrives converted to the connection
+    # charset (utf8mb4) unless character_set_results is disabled.
+    before(:example) do
+      @client.query %[
+        CREATE TEMPORARY TABLE mysql2_cast_false_test (
+          row_id TINYINT NOT NULL,
+          int_min_col INT,
+          bigint_umax_col BIGINT UNSIGNED,
+          decimal_col DECIMAL(10,3),
+          float_col FLOAT(10,3),
+          date_col DATE,
+          datetime_col DATETIME(6),
+          time_col TIME,
+          year_col YEAR,
+          bit_col BIT(64),
+          tiny1_col TINYINT(1),
+          varchar_utf8_col VARCHAR(32) CHARACTER SET utf8mb4,
+          varchar_latin1_col VARCHAR(32) CHARACTER SET latin1,
+          blob_col BLOB,
+          varbinary_col VARBINARY(20)
+        )
+      ]
+      @client.query %[
+        INSERT INTO mysql2_cast_false_test VALUES
+          (1, -2147483648, 18446744073709551615, 10.3, 10.3, '2010-04-04',
+           '2010-04-04 11:44:00.123456', '-838:59:59', 2009, b'101', 1,
+           'héllo ☃', 'héllo', _binary X'00DEADBEEF00FF', _binary X'760062'),
+          (2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+           NULL, NULL, NULL, NULL),
+          (3, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+           '', '', '', '')
+      ]
+    end
+
+    let(:parity_select) { "SELECT * FROM mysql2_cast_false_test ORDER BY row_id" }
+
+    let(:column_names) do
+      %w[
+        row_id int_min_col bigint_umax_col decimal_col float_col date_col datetime_col time_col
+        year_col bit_col tiny1_col varchar_utf8_col varchar_latin1_col blob_col varbinary_col
+      ]
+    end
+
+    # Column name => [bytes, encoding] for values, nil for NULLs, in column
+    # order. Row 1 exercises boundary numerics, fractional and extreme
+    # temporals, embedded NUL bytes, and multibyte text; row 2 is NULL in
+    # every non-key column; row 3 pins zero-length strings as distinct from
+    # NULL.
+    let(:expected_rows) do
+      [
+        {
+          'row_id'             => ["1", Encoding::BINARY],
+          'int_min_col'        => ["-2147483648", Encoding::BINARY],
+          'bigint_umax_col'    => ["18446744073709551615", Encoding::BINARY],
+          'decimal_col'        => ["10.300", Encoding::BINARY],
+          'float_col'          => ["10.300", Encoding::BINARY],
+          'date_col'           => ["2010-04-04", Encoding::BINARY],
+          'datetime_col'       => ["2010-04-04 11:44:00.123456", Encoding::BINARY],
+          'time_col'           => ["-838:59:59", Encoding::BINARY],
+          'year_col'           => ["2009", Encoding::BINARY],
+          'bit_col'            => ["\x00\x00\x00\x00\x00\x00\x00\x05", Encoding::BINARY],
+          'tiny1_col'          => ["1", Encoding::BINARY],
+          'varchar_utf8_col'   => ["héllo ☃", Encoding::UTF_8],
+          'varchar_latin1_col' => ["héllo", Encoding::UTF_8],
+          'blob_col'           => ["\x00\xDE\xAD\xBE\xEF\x00\xFF", Encoding::BINARY],
+          'varbinary_col'      => ["v\x00b", Encoding::BINARY],
+        },
+        {
+          'row_id' => ["2", Encoding::BINARY],
+          'int_min_col' => nil, 'bigint_umax_col' => nil, 'decimal_col' => nil,
+          'float_col' => nil, 'date_col' => nil, 'datetime_col' => nil,
+          'time_col' => nil, 'year_col' => nil, 'bit_col' => nil,
+          'tiny1_col' => nil, 'varchar_utf8_col' => nil,
+          'varchar_latin1_col' => nil, 'blob_col' => nil, 'varbinary_col' => nil,
+        },
+        {
+          'row_id' => ["3", Encoding::BINARY],
+          'int_min_col' => nil, 'bigint_umax_col' => nil, 'decimal_col' => nil,
+          'float_col' => nil, 'date_col' => nil, 'datetime_col' => nil,
+          'time_col' => nil, 'year_col' => nil, 'bit_col' => nil,
+          'tiny1_col' => nil,
+          'varchar_utf8_col' => ["", Encoding::UTF_8],
+          'varchar_latin1_col' => ["", Encoding::UTF_8],
+          'blob_col' => ["", Encoding::BINARY],
+          'varbinary_col' => ["", Encoding::BINARY],
+        },
+      ]
+    end
+
+    def expect_raw_row(row, expected, keys)
+      expect(row.keys).to eql(keys) if row.is_a?(Hash)
+      expected.each_with_index do |(name, expectation), i|
+        value = row.is_a?(Hash) ? row[keys[i]] : row[i]
+        if expectation.nil?
+          expect(value).to be_nil, "#{name}: expected nil, got #{value.inspect}"
+        else
+          bytes, encoding = expectation
+          expect(value).to be_an_instance_of(String), "#{name}: expected a String, got #{value.class}"
+          expect(value.encoding).to eql(encoding), "#{name}: expected #{encoding}, got #{value.encoding}"
+          expect(value.b).to eql(bytes.b), "#{name}: expected #{bytes.b.inspect}, got #{value.b.inspect}"
+        end
+      end
+    end
+
+    def expect_raw_rows(rows, keys)
+      expect(rows.length).to eql(expected_rows.length)
+      rows.zip(expected_rows) { |row, expected| expect_raw_row(row, expected, keys) }
+    end
+
+    [false, true].each do |stream|
+      [false, true].each do |symbolize|
+        variant = "stream: #{stream}, symbolize_keys: #{symbolize}"
+
+        it "returns raw strings and nils in hash rows (#{variant})" do
+          rows = @client.query(parity_select, cast: false, stream: stream, cache_rows: !stream, symbolize_keys: symbolize).to_a
+          keys = symbolize ? column_names.map(&:to_sym) : column_names
+          expect_raw_rows(rows, keys)
+        end
+
+        it "returns raw strings and nils in array rows (#{variant})" do
+          result = @client.query(parity_select, cast: false, as: :array, stream: stream, cache_rows: !stream, symbolize_keys: symbolize)
+          expect_raw_rows(result.to_a, column_names)
+          expect(result.fields).to eql(symbolize ? column_names.map(&:to_sym) : column_names)
+        end
+      end
+    end
+
+    it "re-materializes identical rows when re-iterating with cache_rows: false" do
+      result = @client.query(parity_select, cast: false, cache_rows: false)
+      2.times { expect_raw_rows(result.to_a, column_names) }
+    end
+
+    it "preserves embedded NUL bytes: a strlen-based copy would truncate these" do
+      row = @client.query(parity_select, cast: false).first
+      expect(row['bit_col'].b).to eql("\x00\x00\x00\x00\x00\x00\x00\x05".b)
+      expect(row['varbinary_col'].b).to eql("v\x00b".b)
+      expect(row['blob_col'].bytesize).to eql(7)
+    end
+
+    it "keeps per-field charsetnr tagging when the server does not convert results" do
+      @client.query("SET character_set_results = NULL")
+      row = @client.query(parity_select, cast: false).first
+      expect(row['varchar_latin1_col'].encoding).to eql(Encoding::ISO_8859_1)
+      expect(row['varchar_latin1_col'].b).to eql("h\xE9llo".b)
+      expect(row['varchar_utf8_col']).to eql("héllo ☃")
+      expect(row['blob_col'].encoding).to eql(Encoding::BINARY)
+    end
+
+    it "applies Encoding.default_internal exactly as the casting path's raw strings do" do
+      with_internal_encoding Encoding::UTF_8 do
+        row = @client.query(parity_select, cast: false).first
+        # BINARY_FLAG + charsetnr 63 fields never transcode...
+        expect(row['blob_col'].encoding).to eql(Encoding::BINARY)
+        expect(row['blob_col'].b).to eql("\x00\xDE\xAD\xBE\xEF\x00\xFF".b)
+        expect(row['varbinary_col'].encoding).to eql(Encoding::BINARY)
+        expect(row['date_col'].encoding).to eql(Encoding::BINARY)
+        expect(row['datetime_col'].encoding).to eql(Encoding::BINARY)
+        expect(row['time_col'].encoding).to eql(Encoding::BINARY)
+        # ...while charsetnr-63-without-BINARY_FLAG numerics do,
+        expect(row['int_min_col']).to eql("-2147483648")
+        expect(row['int_min_col'].encoding).to eql(Encoding::UTF_8)
+        expect(row['bit_col']).to eql("\u0000\u0000\u0000\u0000\u0000\u0000\u0000\u0005")
+        expect(row['bit_col'].encoding).to eql(Encoding::UTF_8)
+        # ...as does text (already converted to utf8mb4 by the server).
+        expect(row['varchar_latin1_col']).to eql("héllo")
+        expect(row['varchar_latin1_col'].encoding).to eql(Encoding::UTF_8)
+      end
+    end
+
+    it "keeps #fields available after an abandoned cast: false stream is force-freed" do
+      result = @client.query(parity_select, cast: false, as: :array, stream: true, cache_rows: false)
+      result.each { |_| break } # rubocop:disable Lint/UnreachableLoop
+      @client.query("SELECT 1") # force-frees the abandoned stream
+      expect(result.fields).to eql(column_names)
+    end
+
+    it "does not fast-path prepared statements: cast: false still warns and fully casts" do
+      statement = @client.prepare("SELECT int_min_col, date_col, varchar_utf8_col FROM mysql2_cast_false_test WHERE row_id = 1")
+      row = nil
+      expect { row = statement.execute(cast: false).first }
+        .to output(/:cast is forced for prepared statements/).to_stderr
+      expect(row['int_min_col']).to eql(-2147483648)
+      expect(row['date_col']).to eql(Date.new(2010, 4, 4))
+      expect(row['varchar_utf8_col']).to eql("héllo ☃")
+    end
+  end
+
   context "server flags" do
     let(:test_result) { @client.query("SELECT * FROM mysql2_test ORDER BY null_test DESC LIMIT 1") }
 


### PR DESCRIPTION
Callers that pass cast: false -- raw pipelines, ETL jobs, proxies that re-serialize rows without ever looking inside them -- are asking for the wire bytes untouched. Yet on the text protocol every cell still walks into the full per-type dispatch machinery just to reach the raw-string arm buried inside it, paying the branch tour for a conversion that never happens.

Hoist that arm into its own tight loop at the top of rb_mysql_result_fetch_row: when args->cast is false, every non-NULL cell becomes a String via the same length-based rb_str_new (embedded NULs intact) and the same mysql2_set_field_string_encoding call, and everything else about the cell is kept identical -- MYSQL_TYPE_NULL fields and NULL cells are nil, hash keys are fetched before their value is built (so a raise mid-row leaves the same field-name cache state as before), and the shared setup above the loop is untouched, so hash rows are still pre-sized with rb_hash_new_capa and array-mode field names are still batch-materialized before any value conversion, preserving the ordering guarantee the previous parcel established. The loop runs entirely with the GVL held; the only nogvl region in the function remains the streaming row fetch above it.

The prepared-statement path (rb_mysql_result_fetch_row_stmt) is deliberately untouched: on master, cast: false there warns ":cast is forced for prepared statements" and fully casts anyway, and a spec now pins exactly that.

Stacking disclosure: the first two commits on this branch are #1485 (encoding lookup caches) and #1487 (array-mode field-name batch materialization); review the third commit. The fast path leans on both -- the cached conn_enc/default_internal_enc and the materialize-before-conversion ordering.

Parity is proven in specs, not prose (spec/mysql2/result_spec.rb, "cast: false raw string rows"): a 15-column table covering INT/BIGINT UNSIGNED boundaries, DECIMAL, FLOAT, DATE, DATETIME(6) with fractional seconds, TIME at its -838:59:59 extreme, YEAR, BIT(64) with seven leading NUL bytes, TINYINT(1), multibyte utf8mb4 VARCHAR, a latin1 column, BLOB and VARBINARY with embedded NULs, a row of NULLs in every column, and a row of zero-length strings as distinct from NULL. Expected values are literals -- bytes and encoding both -- never derived from another code path at runtime, and the matrix runs cast: false x {hash, array} x {symbolize_keys on/off} x {buffered, streaming}, plus cache_rows: false re-iteration, charsetnr tagging with character_set_results disabled (latin1 bytes arrive tagged ISO-8859-1), Encoding.default_internal semantics (BINARY_FLAG fields never transcode; charsetnr-63-without-BINARY_FLAG numerics do), and #fields after an abandoned cast: false stream is force-freed. The same 14 examples pass unchanged against the pre-parcel build, pinning that the fast path changed nothing observable.

Verified the specs bite: a strlen-based copy in the fast path fails 11 of the 14 (BIT(64) truncates to ""), and dropping the encoding tagging fails 11 of the 14 (utf8mb4 values arrive ASCII-8BIT).

Benchmark: 50,000 rows x 10 mixed columns -- ints, strings, datetimes, decimal, double, date -- cast: false in hash and array modes with cache_rows: false, min-of-5 per sample, 9 samples per run, three serial alternating control/branch pairs on a quiet machine (AMD Ryzen 9 7950X, Arch Linux x86_64, Ruby 4.0.6, MySQL 9.6.0 in Docker over TCP loopback, client libmariadb 12.3.2, load < 1.4 before every run). Control is this branch's parent commit (the #1487 tip), so the numbers isolate this change alone. Medians of medians, ms per pass:

| arm               | control | this patch | delta |
|-------------------|---------|------------|-------|
| cast:false, hash  |   56.99 |      55.52 | -2.6% |
| cast:false, array |   46.57 |      46.22 | -0.8% |
| cast:true, hash   |  101.35 |     100.82 | noise |
| cast:true, array  |   88.42 |      88.89 | noise |

Sized honestly: the hash-mode win is small but reproducible (branch medians below control minima in effectively every pair); the array-mode delta is directionally consistent but inside the noise floor -- the field-name materialization underneath this stack already removed array mode's larger per-cell cost, leaving little for this hoist to reclaim. The cast:true control arms are flat, confirming the default path is untouched. On its own this reorganization would be borderline; its real role is as the substrate for the `cast: :fast` partial-casting mode stacked directly on top of it (see that PR for the payoff: -41% to -64% vs full casting), plus the byte-exact cast:false parity suite this commit pins for both of them.

Stack base 96252dc + #1485 + #1487, Ruby 4.0.6, MySQL 9.6 (Homebrew, libmysqlclient.24), macOS arm64. Full suite on the stacked baseline before this change: 429 examples, 0 failures, 10 pending (SSL-gated). With this change: 443 examples, 0 failures, 10 pending, RuboCop clean, exit 0 verified unpiped.
