### PR TITLE
cast: :fast rows: cast cheap types, defer expensive ones as strings

### DIFF
--- a/README.md
+++ b/README.md
@@ -576,6 +576,22 @@ do_mysql               0.520000   0.010000   0.530000 (  0.574619)
 
 Although Mysql2 performs reasonably well at retrieving uncasted data, it (currently) is not as fast as the Mysql gem.  In spite of this small disadvantage, Mysql2 still sports a friendlier interface and doesn't block the entire ruby process when querying.
 
+### Partial casting
+
+Between `:cast => true` and `:cast => false` sits `:cast => :fast`: cheap conversions still happen in C, while the expensive ones are skipped and their values returned as encoding-tagged Strings of the raw wire bytes.
+
+* Cast, exactly as `:cast => true` does: `NULL` (`nil`), the integer types (TINYINT through BIGINT, YEAR), FLOAT/DOUBLE, BIT, and TINYINT(1)/BIT(1) booleans when `:cast_booleans` is enabled.
+* Returned as Strings, exactly as `:cast => false` returns them: DECIMAL, DATE, DATETIME, TIMESTAMP, and TIME -- the types whose casting dominates the cost of materializing a row (BigDecimal, Date, and Time construction).
+* Everything else (CHAR/VARCHAR/TEXT, blobs, ENUM, SET, JSON, ...) is already a String and is identical to `:cast => true`.
+
+``` ruby
+result = client.query("SELECT * FROM table", :cast => :fast)
+```
+
+This is for callers that consume mysql2 results directly -- raw-mysql2 pipelines, ETL jobs, and applications that do their own value parsing -- where DECIMAL and temporal columns are often passed through or parsed lazily, and paying BigDecimal/Time construction for every cell up front is waste. Your code must be prepared to receive Strings for those columns. Note that Active Record does not use this option.
+
+Any `:cast` value other than the exact symbol `:fast` (or `false`/`nil`) keeps meaning full casting. Prepared statement results are always fully cast, as with `:cast => false`.
+
 ### Async
 
 NOTE: Not supported on Windows.

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -58,12 +58,23 @@ static int mysql2_enc_index_cache[MYSQL2_CHARSETNR_SIZE];
   mysql2_result_wrapper *wrapper; \
   TypedData_Get_Struct(self, mysql2_result_wrapper, &rb_mysql_result_type, wrapper);
 
+/* How much per-cell casting #each performs, parsed from the :cast option:
+ * false/nil is MYSQL2_CAST_NONE, :fast is MYSQL2_CAST_FAST, and any other
+ * truthy value -- not just true -- is MYSQL2_CAST_ALL, so an unrecognized
+ * value keeps meaning full casting (as every truthy value always has)
+ * instead of silently opting into partial casting. */
+typedef enum {
+  MYSQL2_CAST_NONE = 0, /* cast: false -- every non-NULL value is a raw String */
+  MYSQL2_CAST_ALL  = 1, /* cast: true -- full type casting */
+  MYSQL2_CAST_FAST = 2  /* cast: :fast -- cast cheap types; defer expensive ones as Strings */
+} mysql2_cast_mode;
+
 typedef struct {
   int symbolizeKeys;
   int asArray;
   int castBool;
   int cacheRows;
-  int cast;
+  mysql2_cast_mode cast;
   int streaming;
   unsigned long rowsPerGvlYield;
   ID db_timezone;
@@ -83,7 +94,7 @@ static ID intern_new, intern_utc, intern_local, intern_localtime, intern_local_o
   intern_query_options;
 static VALUE sym_symbolize_keys, sym_as, sym_array, sym_database_timezone,
   sym_application_timezone, sym_local, sym_utc, sym_cast_booleans,
-  sym_cache_rows, sym_cast, sym_stream, sym_name, sym_rows_per_gvl_yield,
+  sym_cache_rows, sym_cast, sym_fast, sym_stream, sym_name, sym_rows_per_gvl_yield,
   sym_no_good_index_used, sym_no_index_used, sym_query_was_slow;
 
 /* Mark any VALUEs that are only referenced in C, so the GC won't get them. */
@@ -1209,7 +1220,7 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
    * byte-identical with just fewer branches per cell. Runs entirely with the
    * GVL held (the only nogvl region in this function is the streaming row
    * fetch above). */
-  if (!args->cast) {
+  if (args->cast == MYSQL2_CAST_NONE) {
     for (i = 0; i < wrapper->numberOfFields; i++) {
       /* Hash keys only; array-mode names were batch-materialized above. */
       VALUE field = args->asArray ? Qnil : rb_mysql_result_fetch_field(self, i, args->symbolizeKeys);
@@ -1254,6 +1265,9 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
             val = *row[i] != '0' ? Qtrue : Qfalse;
             break;
           }
+          /* Deliberate fallthrough into the integer cases: cast: true and
+           * cast: :fast share this dispatch, so :cast_booleans still wins
+           * for TINYINT(1) under both, and any other TINYINT is an Integer. */
         case MYSQL_TYPE_SHORT:      /* SMALLINT field */
         case MYSQL_TYPE_LONG:       /* INTEGER field */
         case MYSQL_TYPE_INT24:      /* MEDIUMINT field */
@@ -1263,6 +1277,17 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
           break;
         case MYSQL_TYPE_DECIMAL:    /* DECIMAL or NUMERIC field */
         case MYSQL_TYPE_NEWDECIMAL: /* Precision math DECIMAL or NUMERIC field (MySQL 5.0.3 and up) */
+          /* cast: :fast defers BigDecimal construction to the caller: the
+           * raw wire bytes as a String, tagged exactly like the
+           * MYSQL2_CAST_NONE loop above tags them. Scale-0 DECIMALs (an
+           * Integer under cast: true) stay Strings too -- the mode is a
+           * per-type contract, not a per-value one. The same deferral
+           * repeats in the temporal cases below. */
+          if (args->cast == MYSQL2_CAST_FAST) {
+            val = rb_str_new(row[i], fieldLengths[i]);
+            val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc);
+            break;
+          }
           if (fields[i].decimals == 0) {
             val = rb_cstr2inum(row[i], 10);
           } else if (decimal_str_is_zero(row[i])) {
@@ -1288,6 +1313,12 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
           unsigned int hour=0, min=0, sec=0, msec=0;
           char msec_char[7] = {'0','0','0','0','0','0','\0'};
 
+          if (args->cast == MYSQL2_CAST_FAST) {
+            val = rb_str_new(row[i], fieldLengths[i]);
+            val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc);
+            break;
+          }
+
           tokens = sscanf(row[i], "%2u:%2u:%2u.%6s", &hour, &min, &sec, msec_char);
           if (tokens < 3) {
             val = Qnil;
@@ -1311,6 +1342,12 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
           unsigned int year=0, month=0, day=0, hour=0, min=0, sec=0, msec=0;
           char msec_char[7] = {'0','0','0','0','0','0','\0'};
           uint64_t seconds;
+
+          if (args->cast == MYSQL2_CAST_FAST) {
+            val = rb_str_new(row[i], fieldLengths[i]);
+            val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc);
+            break;
+          }
 
           if (mysql2_parse_datetime(row[i], fieldLengths[i], &year, &month, &day, &hour, &min, &sec, &msec)) {
             parsed_msec = 1;
@@ -1381,6 +1418,11 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
         case MYSQL_TYPE_NEWDATE: {  /* Newer const used > 5.0 */
           int tokens;
           unsigned int year=0, month=0, day=0;
+          if (args->cast == MYSQL2_CAST_FAST) {
+            val = rb_str_new(row[i], fieldLengths[i]);
+            val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc);
+            break;
+          }
           if (!mysql2_parse_date(row[i], fieldLengths[i], &year, &month, &day)) {
             tokens = sscanf(row[i], "%4u-%2u-%2u", &year, &month, &day);
             if (tokens < 3) {
@@ -1643,7 +1685,8 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
   result_each_args args;
   VALUE opts, (*fetch_row_func)(VALUE, MYSQL_FIELD *fields, const result_each_args *args);
   ID db_timezone, app_timezone;
-  int symbolizeKeys, asArray, castBool, cacheRows, cast;
+  int symbolizeKeys, asArray, castBool, cacheRows;
+  mysql2_cast_mode cast;
   int warnDbTimezone, perEachOpts;
   unsigned long rowsPerGvlYield;
 
@@ -1672,7 +1715,7 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
     db_timezone     = wrapper->each_opts.db_timezone;
     app_timezone    = wrapper->each_opts.app_timezone;
   } else {
-    VALUE dbTz, appTz, rowsPerGvlYieldOpt;
+    VALUE dbTz, appTz, rowsPerGvlYieldOpt, castOpt;
     VALUE defaults = rb_ivar_get(self, intern_query_options);
     Check_Type(defaults, T_HASH);
 
@@ -1682,7 +1725,17 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
     asArray       = rb_hash_aref(opts, sym_as) == sym_array;
     castBool      = RTEST(rb_hash_aref(opts, sym_cast_booleans));
     cacheRows     = RTEST(rb_hash_aref(opts, sym_cache_rows));
-    cast          = RTEST(rb_hash_aref(opts, sym_cast));
+
+    /* See mysql2_cast_mode: only the exact symbol :fast selects partial
+     * casting; any other truthy value stays full casting. */
+    castOpt = rb_hash_aref(opts, sym_cast);
+    if (castOpt == sym_fast) {
+      cast = MYSQL2_CAST_FAST;
+    } else if (RTEST(castOpt)) {
+      cast = MYSQL2_CAST_ALL;
+    } else {
+      cast = MYSQL2_CAST_NONE;
+    }
 
     /* :rows_per_gvl_yield -- 0 disables yielding; nil uses the default. */
     rowsPerGvlYield = MYSQL2_ROWS_PER_GVL_YIELD_DEFAULT;
@@ -1748,7 +1801,10 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
     cacheRows = 1;
   }
 
-  if (wrapper->stmt_wrapper && !cast) {
+  /* The binary-protocol row fetch (rb_mysql_result_fetch_row_stmt) always
+   * fully casts; the existing warning already reads as "any non-true :cast
+   * is overridden here", so cast: :fast reuses it verbatim. */
+  if (wrapper->stmt_wrapper && cast != MYSQL2_CAST_ALL) {
     rb_warn(":cast is forced for prepared statements");
   }
 
@@ -1982,6 +2038,7 @@ void init_mysql2_result(void) {
   sym_cache_rows     = ID2SYM(rb_intern("cache_rows"));
   sym_rows_per_gvl_yield = ID2SYM(rb_intern("rows_per_gvl_yield"));
   sym_cast           = ID2SYM(rb_intern("cast"));
+  sym_fast           = ID2SYM(rb_intern("fast"));
   sym_stream         = ID2SYM(rb_intern("stream"));
   sym_name           = ID2SYM(rb_intern("name"));
   sym_no_good_index_used = ID2SYM(rb_intern("no_good_index_used"));

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -1489,6 +1489,257 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
     end
   end
 
+  context "cast: :fast partially-cast rows" do
+    # Pins the text-protocol cast: :fast mode in rb_mysql_result_fetch_row
+    # (ext/mysql2/result.c) column by column:
+    #
+    # - Cast exactly as cast: true does: NULL, the integer family
+    #   (TINYINT/SMALLINT/MEDIUMINT/INT/BIGINT/YEAR, signed and unsigned,
+    #   ZEROFILL included), FLOAT/DOUBLE (via the same locale-independent
+    #   Kernel#Float mechanism), BIT, and TINYINT(1)/BIT(1) booleans when
+    #   :cast_booleans is on.
+    # - Deferred as Strings of the wire bytes, tagged by
+    #   mysql2_set_field_string_encoding exactly as cast: false tags them:
+    #   DECIMAL/NEWDECIMAL (scale-0 included, an Integer under cast: true),
+    #   DATE, DATETIME, TIMESTAMP, TIME.
+    # - Everything else (text, blobs, enum, set, ...) is a String under
+    #   cast: true already and is byte- and encoding-identical here.
+    #
+    # Expected values are literals -- bytes and encoding both -- rather than
+    # derived from another code path at runtime.
+    before(:example) do
+      @client.query %[
+        CREATE TEMPORARY TABLE mysql2_cast_fast_test (
+          row_id TINYINT NOT NULL,
+          bigint_min_col BIGINT,
+          bigint_umax_col BIGINT UNSIGNED,
+          int_zerofill_col INT UNSIGNED ZEROFILL,
+          decimal_col DECIMAL(10,3),
+          decimal_scale0_col DECIMAL(10,0),
+          float_col FLOAT(10,3),
+          double_col DOUBLE,
+          date_col DATE,
+          datetime_col DATETIME(6),
+          timestamp_col TIMESTAMP(6) NULL,
+          time_col TIME,
+          year_col YEAR,
+          bit_col BIT(64),
+          single_bit_col BIT(1),
+          tiny1_col TINYINT(1),
+          varchar_utf8_col VARCHAR(32) CHARACTER SET utf8mb4,
+          varchar_latin1_col VARCHAR(32) CHARACTER SET latin1,
+          blob_col BLOB,
+          varbinary_col VARBINARY(20)
+        )
+      ]
+      @client.query %[
+        INSERT INTO mysql2_cast_fast_test VALUES
+          (1, -9223372036854775808, 18446744073709551615, 10, 10.3, 42,
+           10.3, 10.3, '2010-04-04', '2010-04-04 11:44:00.123456',
+           '2010-04-04 11:44:00.123456', '-838:59:59', 2009, b'101', b'1', 1,
+           'héllo ☃', 'héllo', _binary X'00DEADBEEF00FF', _binary X'760062'),
+          (2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+           NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL),
+          (3, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+           NULL, NULL, NULL, NULL, NULL, '', '', '', '')
+      ]
+    end
+
+    let(:fast_select) { "SELECT * FROM mysql2_cast_fast_test ORDER BY row_id" }
+
+    let(:column_names) do
+      %w[
+        row_id bigint_min_col bigint_umax_col int_zerofill_col decimal_col decimal_scale0_col
+        float_col double_col date_col datetime_col timestamp_col time_col year_col bit_col
+        single_bit_col tiny1_col varchar_utf8_col varchar_latin1_col blob_col varbinary_col
+      ]
+    end
+
+    # Column name => expectation, in column order. A two-element [bytes,
+    # encoding] Array expects a String; nil expects nil; anything else is
+    # compared with eql (class-sensitive, so 10 never passes for "10" or
+    # 10.0). Row 1 exercises BIGINT boundaries (LLONG_MIN/ULLONG_MAX),
+    # ZEROFILL padding, scale-0 DECIMAL, fractional and extreme temporals,
+    # BIT with embedded NULs, and multibyte text; row 2 is NULL in every
+    # non-key column; row 3 pins zero-length strings as distinct from NULL.
+    let(:expected_rows) do
+      [
+        {
+          'row_id'             => 1,
+          'bigint_min_col'     => -9_223_372_036_854_775_808,
+          'bigint_umax_col'    => 18_446_744_073_709_551_615,
+          'int_zerofill_col'   => 10,
+          'decimal_col'        => ["10.300", Encoding::BINARY],
+          'decimal_scale0_col' => ["42", Encoding::BINARY],
+          'float_col'          => 10.3,
+          'double_col'         => 10.3,
+          'date_col'           => ["2010-04-04", Encoding::BINARY],
+          'datetime_col'       => ["2010-04-04 11:44:00.123456", Encoding::BINARY],
+          'timestamp_col'      => ["2010-04-04 11:44:00.123456", Encoding::BINARY],
+          'time_col'           => ["-838:59:59", Encoding::BINARY],
+          'year_col'           => 2009,
+          'bit_col'            => ["\x00\x00\x00\x00\x00\x00\x00\x05", Encoding::BINARY],
+          'single_bit_col'     => ["\x01", Encoding::BINARY],
+          'tiny1_col'          => 1,
+          'varchar_utf8_col'   => ["héllo ☃", Encoding::UTF_8],
+          'varchar_latin1_col' => ["héllo", Encoding::UTF_8],
+          'blob_col'           => ["\x00\xDE\xAD\xBE\xEF\x00\xFF", Encoding::BINARY],
+          'varbinary_col'      => ["v\x00b", Encoding::BINARY],
+        },
+        {
+          'row_id' => 2,
+          'bigint_min_col' => nil, 'bigint_umax_col' => nil, 'int_zerofill_col' => nil,
+          'decimal_col' => nil, 'decimal_scale0_col' => nil, 'float_col' => nil,
+          'double_col' => nil, 'date_col' => nil, 'datetime_col' => nil,
+          'timestamp_col' => nil, 'time_col' => nil, 'year_col' => nil,
+          'bit_col' => nil, 'single_bit_col' => nil, 'tiny1_col' => nil,
+          'varchar_utf8_col' => nil, 'varchar_latin1_col' => nil,
+          'blob_col' => nil, 'varbinary_col' => nil,
+        },
+        {
+          'row_id' => 3,
+          'bigint_min_col' => nil, 'bigint_umax_col' => nil, 'int_zerofill_col' => nil,
+          'decimal_col' => nil, 'decimal_scale0_col' => nil, 'float_col' => nil,
+          'double_col' => nil, 'date_col' => nil, 'datetime_col' => nil,
+          'timestamp_col' => nil, 'time_col' => nil, 'year_col' => nil,
+          'bit_col' => nil, 'single_bit_col' => nil, 'tiny1_col' => nil,
+          'varchar_utf8_col' => ["", Encoding::UTF_8],
+          'varchar_latin1_col' => ["", Encoding::UTF_8],
+          'blob_col' => ["", Encoding::BINARY],
+          'varbinary_col' => ["", Encoding::BINARY],
+        },
+      ]
+    end
+
+    def expect_fast_row(row, expected, keys)
+      expect(row.keys).to eql(keys) if row.is_a?(Hash)
+      expected.each_with_index do |(name, expectation), i|
+        value = row.is_a?(Hash) ? row[keys[i]] : row[i]
+        case expectation
+        when nil
+          expect(value).to be_nil, "#{name}: expected nil, got #{value.inspect}"
+        when Array
+          bytes, encoding = expectation
+          expect(value).to be_an_instance_of(String), "#{name}: expected a String, got #{value.class}"
+          expect(value.encoding).to eql(encoding), "#{name}: expected #{encoding}, got #{value.encoding}"
+          expect(value.b).to eql(bytes.b), "#{name}: expected #{bytes.b.inspect}, got #{value.b.inspect}"
+        else
+          expect(value).to eql(expectation), "#{name}: expected #{expectation.inspect}, got #{value.inspect} (#{value.class})"
+        end
+      end
+    end
+
+    def expect_fast_rows(rows, keys)
+      expect(rows.length).to eql(expected_rows.length)
+      rows.zip(expected_rows) { |row, expected| expect_fast_row(row, expected, keys) }
+    end
+
+    [false, true].each do |stream|
+      variant = "stream: #{stream}"
+
+      it "casts cheap types and defers expensive ones in hash rows (#{variant})" do
+        rows = @client.query(fast_select, cast: :fast, stream: stream, cache_rows: !stream).to_a
+        expect_fast_rows(rows, column_names)
+      end
+
+      it "casts cheap types and defers expensive ones in array rows (#{variant})" do
+        result = @client.query(fast_select, cast: :fast, as: :array, stream: stream, cache_rows: !stream)
+        expect_fast_rows(result.to_a, column_names)
+        expect(result.fields).to eql(column_names)
+      end
+    end
+
+    it "re-materializes identical rows when re-iterating with cache_rows: false" do
+      result = @client.query(fast_select, cast: :fast, cache_rows: false)
+      2.times { expect_fast_rows(result.to_a, column_names) }
+    end
+
+    it "works as a per-each option the same way cast: false does" do
+      result = @client.query(fast_select, cache_rows: false)
+      rows = []
+      result.each(cast: :fast) { |row| rows << row }
+      expect_fast_rows(rows, column_names)
+    end
+
+    it "casts TINYINT(1) and BIT(1) as booleans when :cast_booleans is enabled" do
+      row = @client.query(fast_select, cast: :fast, cast_booleans: true).first
+      expect(row['tiny1_col']).to be true
+      expect(row['single_bit_col']).to be true
+      # The other cheap and deferred columns are unaffected.
+      expect(row['bigint_min_col']).to eql(-9_223_372_036_854_775_808)
+      expect(row['decimal_col']).to eql("10.300")
+    end
+
+    it "does not treat unrecognized truthy :cast values as :fast" do
+      row = @client.query(fast_select, cast: :bogus).first
+      expect(row['decimal_col']).to eql(BigDecimal("10.3"))
+      expect(row['date_col']).to eql(Date.new(2010, 4, 4))
+    end
+
+    context "under a locale that uses a comma as the decimal separator" do
+      before(:example) do
+        @original_locale = CLocale.setlocale(CLocale::LC_NUMERIC, nil)
+        begin
+          CLocale.setlocale(CLocale::LC_NUMERIC, "de_DE.UTF-8")
+        rescue RuntimeError
+          skip "de_DE.UTF-8 locale not installed on this system"
+        end
+      end
+
+      after(:example) do
+        CLocale.setlocale(CLocale::LC_NUMERIC, @original_locale) if @original_locale
+      end
+
+      it "still parses FLOAT and DOUBLE locale-independently" do
+        row = @client.query("SELECT CAST(2.7 AS FLOAT) AS f, CAST(2.7 AS DOUBLE) AS d", cast: :fast).first
+        expect(row['f']).to eql(2.7)
+        expect(row['d']).to eql(2.7)
+      end
+    end
+
+    it "keeps per-field charsetnr tagging when the server does not convert results" do
+      @client.query("SET character_set_results = NULL")
+      row = @client.query(fast_select, cast: :fast).first
+      expect(row['varchar_latin1_col'].encoding).to eql(Encoding::ISO_8859_1)
+      expect(row['varchar_latin1_col'].b).to eql("h\xE9llo".b)
+      expect(row['decimal_col'].encoding).to eql(Encoding::BINARY)
+      expect(row['date_col'].encoding).to eql(Encoding::BINARY)
+    end
+
+    it "applies Encoding.default_internal to deferred strings exactly as cast: false does" do
+      with_internal_encoding Encoding::UTF_8 do
+        row = @client.query(fast_select, cast: :fast).first
+        # Temporal fields carry BINARY_FLAG + charsetnr 63 and never transcode...
+        expect(row['date_col'].encoding).to eql(Encoding::BINARY)
+        expect(row['datetime_col'].encoding).to eql(Encoding::BINARY)
+        expect(row['time_col'].encoding).to eql(Encoding::BINARY)
+        # ...while DECIMAL (charsetnr 63 without BINARY_FLAG) does,
+        expect(row['decimal_col']).to eql("10.300")
+        expect(row['decimal_col'].encoding).to eql(Encoding::UTF_8)
+        # ...and BIT stays untagged raw bytes, exactly as under cast: true.
+        expect(row['bit_col'].encoding).to eql(Encoding::BINARY)
+        expect(row['bit_col'].b).to eql("\x00\x00\x00\x00\x00\x00\x00\x05".b)
+      end
+    end
+
+    it "keeps #fields available after an abandoned cast: :fast stream is force-freed" do
+      result = @client.query(fast_select, cast: :fast, as: :array, stream: true, cache_rows: false)
+      result.each { |_| break } # rubocop:disable Lint/UnreachableLoop
+      @client.query("SELECT 1") # force-frees the abandoned stream
+      expect(result.fields).to eql(column_names)
+    end
+
+    it "does not fast-path prepared statements: cast: :fast still warns and fully casts" do
+      statement = @client.prepare("SELECT decimal_col, date_col, bigint_min_col FROM mysql2_cast_fast_test WHERE row_id = 1")
+      row = nil
+      expect { row = statement.execute(cast: :fast).first }
+        .to output(/:cast is forced for prepared statements/).to_stderr
+      expect(row['decimal_col']).to eql(BigDecimal("10.3"))
+      expect(row['date_col']).to eql(Date.new(2010, 4, 4))
+      expect(row['bigint_min_col']).to eql(-9_223_372_036_854_775_808)
+    end
+  end
+
   context "server flags" do
     let(:test_result) { @client.query("SELECT * FROM mysql2_test ORDER BY null_test DESC LIMIT 1") }
 


### PR DESCRIPTION
On a casting-dominated shape (50,000 rows x 10 columns: 4 temporal, 2 decimal, 1 float, 3 int), cast: true costs 152ms where cast: false costs 73ms -- a 51.8% ceiling for partial casting, measured on a quiet Linux x86_64 box (Ryzen 9 7950X, Ruby 4.0.6, MySQL 9.6.0, libmariadb 12.3.2, base 82f9e18; the ceiling is a property of casting cost, not of this stack). Nearly all of that cost is BigDecimal, Date, and Time construction for cells many callers never parse eagerly: raw-mysql2 pipelines, ETL jobs, and applications that pass DECIMAL and temporal values through or parse them lazily. cast: false recovers the whole ceiling but throws away the cheap casts too, forcing those callers to re-parse every integer themselves.

cast: :fast sits between the two, as a third arm of the existing cast dispatch in rb_mysql_result_fetch_row (text protocol only):

- Cast exactly as cast: true casts them: NULL (nil); the integer family
  TINY/SHORT/LONG/INT24/LONGLONG/YEAR via the same rb_cstr2inum arm
  (with an explicit comment on the TINY fallthrough: :cast_booleans
  still wins for TINYINT(1)); FLOAT/DOUBLE via the same
  locale-independent Kernel#Float mechanism (never strtod, whose '.'
  handling follows LC_NUMERIC); BIT, including its :cast_booleans BIT(1)
  arm. - Deferred as Strings of the raw wire bytes, tagged by
  mysql2_set_field_string_encoding exactly as the cast: false loop tags
  them: DECIMAL/NEWDECIMAL (scale-0 included -- the mode is a per-type
  contract, not a per-value one), DATE/NEWDATE, DATETIME, TIMESTAMP,
  TIME. - Everything else (text, blobs, enum, set, json, geometry, ...) is
  already a String under cast: true and is byte- and encoding-identical
  here.

The mode is selected only by the exact symbol :fast, as a query option or per-#each, either place cast: false is accepted today. Any other truthy :cast value keeps meaning full casting, as every truthy value always has -- an unrecognized value must not silently opt into partial casting; a spec pins cast: :bogus to full casting. The cast: false fast path and the shared row setup above it (rb_hash_new_capa pre-sizing, array-mode field names batch-materialized before any value conversion) are untouched; :fast rides the existing casting loop, so cheap types cannot drift from cast: true by construction. Prepared statements keep their cast: false precedent: the binary-protocol fetch always fully casts, and the existing generic ":cast is forced for prepared statements" warning now also fires for :fast (condition widened from !cast to cast != MYSQL2_CAST_ALL; the text already reads as "any non-true :cast is overridden here").

Stacking disclosure: this branch is a 4-commit stack -- #1485 (encoding lookup caches), #1487 (array-mode field-name batch materialization), the cast: false fast-path parcel, then this; review the fourth commit. The deferred-string arm leans on the first and third: the cached conn_enc/default_internal_enc and the hoisted raw-string loop whose tagging it mirrors.

Specs (spec/mysql2/result_spec.rb, "cast: :fast partially-cast rows"): a 20-column table -- BIGINT at LLONG_MIN and BIGINT UNSIGNED at ULLONG_MAX, INT UNSIGNED ZEROFILL, DECIMAL(10,3) and scale-0 DECIMAL(10,0), FLOAT/DOUBLE asserted for exact value, DATE, DATETIME(6) and TIMESTAMP(6) with fractional seconds, TIME at -838:59:59, YEAR, BIT(64) with embedded NULs, BIT(1), TINYINT(1), multibyte utf8mb4 and latin1 VARCHARs, BLOB and VARBINARY with embedded NULs, a row of NULLs, and a row of zero-length strings as distinct from NULL. Expected values are literals -- bytes and encoding both -- never derived from another code path at runtime. The matrix runs cast: :fast x {hash, array} x {buffered, streaming}, plus cache_rows: false re-iteration, per-#each cast: :fast, :cast_booleans interplay, comma-decimal locale (de_DE.UTF-8) float parsing, charsetnr tagging with character_set_results disabled, Encoding.default_internal semantics (temporal BINARY_FLAG fields never transcode; DECIMAL's charsetnr-63-without-BINARY_FLAG does; BIT stays untagged as under cast: true), #fields after an abandoned :fast stream is force-freed, cast: :bogus, and prepared + :fast warning with fully-cast values.

Verified the specs bite: dropping the encoding tagging on the deferred DECIMAL arm fails the default_internal example; parsing :fast floats with strtod fails the comma-locale example (2.7 arrives as 2.0). Both restored and re-verified green.

Benchmark: the prescreen shape above plus a realistic-dilution shape -- 50,000 rows x 10 columns: 2 temporal, 1 decimal, 4 string, 3 int -- each under cast: true, cast: :fast, and cast: false, hash mode, cache_rows: false, min-of-5 per sample, 9 samples per run, three serial alternating control/branch pairs on a quiet machine (AMD Ryzen 9 7950X, Arch Linux x86_64, Ruby 4.0.6, MySQL 9.6.0 in Docker over TCP loopback, client libmariadb 12.3.2, load < 1.0 before every run). Control is this branch's parent commit (the #1489 tip), isolating this change alone; on the control build `cast: :fast` falls through to full casting by the exact-symbol rule, and its :fast arm indeed matched its cast:true arm within 1% -- the fall-through contract, measured. Medians of medians, ms per pass:

| arm         | prescreen ctrl | prescreen this | diluted ctrl | diluted this |
|-------------|----------------|----------------|--------------|--------------|
| cast: true  |         147.82 |         147.90 |        93.66 |        93.05 |
| cast: :fast |  148.61 (=true)|          52.77 |94.38 (=true) |        54.69 |
| cast: false |          52.56 |          52.97 |        54.57 |        54.67 |

Headline: cast: :fast vs cast: true is -64.3% on the temporal/decimal- heavy shape and -41.2% on the diluted one, with distributions separated by ~95 ms and ~38 ms against sub-2 ms ranges. Against cast: false -- the ceiling -- :fast is a statistical tie (-0.4% / +0.04%, fully overlapping ranges): partial casting captures effectively all of the ceiling while still returning real Integers and Floats. Both untouched paths are flat: cast:true within +/-0.7% with overlapping ranges (the new per-expensive-cell guard costs nothing measurable) and cast:false within +0.8% inside its own run-to-run spread.

Two honest bounds on those numbers. The win is definitionally shape-dependent: an all-int/string result set has nothing to defer. And this measures driver-side materialization only -- a caller that immediately converts every deferred string to Time/BigDecimal in Ruby pays the cost back with interest; the option exists for callers that filter, forward, or parse selectively.

Stack base 96252dc + #1485 + #1487 + #1489, Ruby 4.0.6, MySQL 9.6 (Homebrew, libmysqlclient.24), macOS arm64. Full suite on the stacked baseline before this change: 443 examples, 0 failures, 10 pending (SSL-gated), exit 0. With this change: 456 examples, 0 failures, 10 pending, RuboCop clean, exit 0 verified unpiped.
