### PR TITLE
CI: Add Ubuntu 26.04 and the MySQL innovation release

### DIFF
--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -4,16 +4,19 @@ on:
 jobs:
   build:
     name: >-
-      ${{ matrix.os }} ruby ${{ matrix.ruby }} ${{ matrix.db }}
+      ${{ matrix.os }} ruby ${{ matrix.ruby }} ${{ matrix.db }}${{ matrix.allow_failure && ' (allow failure)' || '' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 30
+    # allow_failure entries track something that moves outside this repository,
+    # so their failures are informational and must not block unrelated PRs.
+    continue-on-error: ${{ matrix.allow_failure || false }}
     strategy:
       matrix:
         include:
           # Ruby 4.x on Ubuntu 26.04 LTS
           # db: mysql-innovation tracks the newest MySQL innovation release, not an LTS.
-          - {os: ubuntu-26.04, ruby: '4.0', db: mysql-innovation}
-          - {os: ubuntu-26.04, ruby: 'head', db: mysql97}
+          - {os: ubuntu-26.04, ruby: '4.0', db: mysql-innovation, allow_failure: true}
+          - {os: ubuntu-26.04, ruby: 'head', db: mysql97, allow_failure: true}
 
           # Ruby 3.x / 4.x on Ubuntu 24.04 LTS
           - {os: ubuntu-24.04, ruby: '4.0', db: mysql97}

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -10,8 +10,12 @@ jobs:
     strategy:
       matrix:
         include:
+          # Ruby 4.x on Ubuntu 26.04 LTS
+          # db: mysql-innovation tracks the newest MySQL innovation release, not an LTS.
+          - {os: ubuntu-26.04, ruby: '4.0', db: mysql-innovation}
+          - {os: ubuntu-26.04, ruby: 'head', db: mysql97}
+
           # Ruby 3.x / 4.x on Ubuntu 24.04 LTS
-          - {os: ubuntu-24.04, ruby: 'head', db: mysql97}
           - {os: ubuntu-24.04, ruby: '4.0', db: mysql97}
           - {os: ubuntu-24.04, ruby: '4.0', db: mysql84}
           - {os: ubuntu-24.04, ruby: '3.4', db: mysql84}

--- a/ci/mysql-innovation.sh
+++ b/ci/mysql-innovation.sh
@@ -1,0 +1,29 @@
+#!/usr/bin/env bash
+
+set -eux
+
+apt-get purge -qq '^mysql*' '^libmysql*'
+rm -fr /etc/mysql
+rm -fr /var/lib/mysql
+
+RELEASE=$(lsb_release -cs)
+# Innovation releases get no version-specific component of their own.
+COMPONENT=mysql-innovation
+
+# Verify the component exists, as apt-get update only warns when it is missing.
+wget -q --spider "https://repo.mysql.com/apt/ubuntu/dists/$RELEASE/$COMPONENT"
+
+install -d -m 0755 /etc/apt/keyrings
+install -m 0644 support/B7B3B788A8D3785C.asc /etc/apt/keyrings/mysql-keyring.asc
+
+tee /etc/apt/sources.list.d/mysql.sources <<- EOF
+	X-Repolib-Name: MySQL
+	Types: deb
+	URIs: https://repo.mysql.com/apt/ubuntu
+	Suites: $RELEASE
+	Components: $COMPONENT
+	Signed-By: /etc/apt/keyrings/mysql-keyring.asc
+EOF
+
+apt-get update -qq
+apt-get install -qq mysql-server libmysqlclient-dev

--- a/ci/setup.sh
+++ b/ci/setup.sh
@@ -27,6 +27,12 @@ if [[ -n ${DB-} && x$DB =~ ^xmysql97 ]]; then
   CHANGED_PASSWORD_SHA2=true
 fi
 
+# Install the newest MySQL innovation release if DB=mysql-innovation
+if [[ -n ${DB-} && x$DB =~ ^xmysql-innovation ]]; then
+  sudo bash ci/mysql-innovation.sh
+  CHANGED_PASSWORD_SHA2=true
+fi
+
 # Install MariaDB 10.6 if DB=mariadb10.6
 if [[ -n ${GITHUB_ACTIONS-} && -n ${DB-} && x$DB =~ ^xmariadb10.6 ]]; then
   sudo bash ci/mariadb106.sh


### PR DESCRIPTION
This adds two Ubuntu 26.04 jobs to the matrix.

The part I would like a second opinion on is the MySQL innovation release. Innovation releases lead the next LTS, so testing against one surfaces libmysqlclient changes a cycle before they reach it. The cost is that the job moves on its own -- there is no version-specific APT component for innovation releases, so it follows `mysql-innovation` and picks up whatever is newest, 26.7 today. If a future release breaks something, the matrix goes red on pull requests that have nothing to do with it.

Refs:
- https://dev.mysql.com/doc/relnotes/mysql/26.7/en/news-26-7-0.html
- https://dev.mysql.com/blog-archive/introducing-mysql-innovation-and-long-term-support-lts-versions/