### PR TITLE
Fixes #1033: next_result no longer holds the GVL or blocks Thread#raise

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1616,6 +1616,142 @@ static VALUE rb_mysql_client_more_results(VALUE self)
     return Qtrue;
 }
 
+#ifndef _WIN32
+/* Waits for the connection's fd to become readable, honoring @read_timeout
+ * the same way do_query does for the initial query. rb_wait_for_single_fd
+ * itself releases the GVL and is interruptible (Thread#raise,
+ * Timeout.timeout), unlike a raw blocking read inside libmysqlclient. */
+static void wait_for_next_result_fd(VALUE self, mysql_client_wrapper *wrapper) {
+  struct timeval tv;
+  struct timeval *tvp;
+  long int sec;
+  int retval;
+  VALUE read_timeout;
+
+  read_timeout = rb_ivar_get(self, intern_read_timeout);
+
+  tvp = NULL;
+  if (!NIL_P(read_timeout)) {
+    Check_Type(read_timeout, T_FIXNUM);
+    tvp = &tv;
+    sec = FIX2INT(read_timeout);
+    if (sec >= 0) {
+      tvp->tv_sec = sec;
+    } else {
+      rb_raise(cMysql2Error, "read_timeout must be a positive integer, you passed %ld", sec);
+    }
+    tvp->tv_usec = 0;
+  }
+
+  retval = rb_wait_for_single_fd(wrapper->client->net.fd, RB_WAITFD_IN, tvp);
+
+  if (retval == 0) {
+    rb_raise(cMysql2TimeoutError, "Timeout waiting for a response from the last query. (waited %d seconds)", FIX2INT(read_timeout));
+  }
+  if (retval < 0) {
+    rb_sys_fail(0);
+  }
+}
+#endif
+
+#if defined(HAVE_MYSQL_NEXT_RESULT_NONBLOCKING) && !defined(_WIN32)
+/* Polls mysql_next_result_nonblocking() (added in MySQL 8.0.16) instead of
+ * calling the blocking mysql_next_result() directly. Unlike the blocking
+ * call, this never holds the GVL for a real network wait: each iteration
+ * either returns immediately (never blocks, by the function's own
+ * contract) or reports NET_ASYNC_NOT_READY, in which case
+ * wait_for_next_result_fd -- not this function -- is what actually waits,
+ * and it does so interruptibly.
+ *
+ * Mixing this with the ordinary blocking API on the same connection is
+ * explicitly documented as supported, so nothing else in this file needs
+ * to change:
+ * https://dev.mysql.com/doc/c-api/8.0/en/c-api-asynchronous-interface-usage.html
+ */
+static enum net_async_status next_result_nonblocking(VALUE self, mysql_client_wrapper *wrapper) {
+  enum net_async_status status;
+
+  for (;;) {
+    status = mysql_next_result_nonblocking(wrapper->client);
+    if (status != NET_ASYNC_NOT_READY) {
+      return status;
+    }
+    wait_for_next_result_fd(self, wrapper);
+  }
+}
+#else
+/* Fallback for MariaDB (mysql_next_result_nonblocking doesn't exist there
+ * under this name -- MariaDB Connector/C has its own mysql_next_result_start
+ * / _cont pair instead, not yet wired up here) and for MySQL builds older
+ * than 8.0.16. Releasing the GVL around the still-blocking call at least
+ * lets other Ruby threads run during the wait; it does not make the call
+ * interruptible via Thread#raise/Timeout.timeout the way the nonblocking
+ * path above is, since libmysqlclient's own blocking read loop may retry
+ * internally on the signal RUBY_UBF_IO sends. */
+static void *nogvl_next_result(void *ptr) {
+  mysql_client_wrapper *wrapper = ptr;
+  /* Cast through intptr_t, not straight through void*, to round-trip a
+   * signed int (including -1 for "no more results") intact. */
+  return (void *)(intptr_t)mysql_next_result(wrapper->client);
+}
+#endif
+
+static VALUE mysql2_next_result_reset_state(VALUE self) {
+  GET_CLIENT(self);
+
+  if (wrapper->state != MYSQL2_CLIENT_IDLE) {
+    wrapper->state = MYSQL2_CLIENT_IDLE;
+    mysql2_reap_pending_result_frees(wrapper);
+    mysql2_reap_pending_stmt_closes(wrapper);
+  }
+
+  return Qnil;
+}
+
+static VALUE mysql2_next_result_body(VALUE self) {
+  GET_CLIENT(self);
+
+  /* Mark the connection busy for the duration of the wait: on the fast
+   * path above, the GVL is no longer held for the whole call the way the
+   * old blocking mysql_next_result() incidentally held it, so a Statement
+   * on another thread getting GC'd during that window must not be allowed
+   * to enqueue-and-flush a close over this same socket mid-command. See
+   * the QUERYING/IDLE bracket rb_mysql_query uses for the same reason. */
+  wrapper->state = MYSQL2_CLIENT_QUERYING;
+
+#if defined(HAVE_MYSQL_NEXT_RESULT_NONBLOCKING) && !defined(_WIN32)
+  {
+    enum net_async_status status = next_result_nonblocking(self, wrapper);
+    wrapper->affected_rows = mysql_affected_rows(wrapper->client);
+
+    switch (status) {
+      case NET_ASYNC_ERROR:
+        rb_raise_mysql2_error(wrapper);
+        return Qfalse; /* unreached */
+      case NET_ASYNC_COMPLETE_NO_MORE_RESULTS:
+        return Qfalse;
+      case NET_ASYNC_COMPLETE:
+      default:
+        return Qtrue;
+    }
+  }
+#else
+  {
+    int ret = (int)(intptr_t)rb_thread_call_without_gvl(nogvl_next_result, wrapper, RUBY_UBF_IO, 0);
+    wrapper->affected_rows = mysql_affected_rows(wrapper->client);
+
+    if (ret > 0) {
+      rb_raise_mysql2_error(wrapper);
+      return Qfalse; /* unreached */
+    } else if (ret == 0) {
+      return Qtrue;
+    } else {
+      return Qfalse;
+    }
+  }
+#endif
+}
+
 /* call-seq:
  *    client.next_result
  *
@@ -1624,18 +1760,10 @@ static VALUE rb_mysql_client_more_results(VALUE self)
  */
 static VALUE rb_mysql_client_next_result(VALUE self)
 {
-    int ret;
-    GET_CLIENT(self);
-    ret = mysql_next_result(wrapper->client);
-    wrapper->affected_rows = mysql_affected_rows(wrapper->client);
-    if (ret > 0) {
-      rb_raise_mysql2_error(wrapper);
-      return Qfalse;
-    } else if (ret == 0) {
-      return Qtrue;
-    } else {
-      return Qfalse;
-    }
+  GET_CLIENT(self);
+  REQUIRE_CONNECTED(wrapper);
+
+  return rb_ensure(mysql2_next_result_body, self, mysql2_next_result_reset_state, self);
 }
 
 /* call-seq:

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1013,15 +1013,19 @@ static VALUE disconnect_query_if_incomplete(VALUE completionval) {
   return Qnil;
 }
 
-static VALUE do_query(VALUE args) {
-  struct async_query_args *async_args = (void *)args;
+/* Waits for fd to become readable, honoring @read_timeout. Shared by
+ * do_query below and next_result_nonblocking further down in this file.
+ * rb_wait_for_single_fd itself releases the GVL and is interruptible
+ * (Thread#raise, Timeout.timeout), unlike a raw blocking read inside
+ * libmysqlclient. */
+static void wait_for_readable_with_timeout(VALUE self, int fd) {
   struct timeval tv;
   struct timeval *tvp;
   long int sec;
   int retval;
   VALUE read_timeout;
 
-  read_timeout = rb_ivar_get(async_args->self, intern_read_timeout);
+  read_timeout = rb_ivar_get(self, intern_read_timeout);
 
   tvp = NULL;
   if (!NIL_P(read_timeout)) {
@@ -1038,21 +1042,20 @@ static VALUE do_query(VALUE args) {
     tvp->tv_usec = 0;
   }
 
-  for(;;) {
-    retval = rb_wait_for_single_fd(async_args->fd, RB_WAITFD_IN, tvp);
+  retval = rb_wait_for_single_fd(fd, RB_WAITFD_IN, tvp);
 
-    if (retval == 0) {
-      rb_raise(cMysql2TimeoutError, "Timeout waiting for a response from the last query. (waited %d seconds)", FIX2INT(read_timeout));
-    }
-
-    if (retval < 0) {
-      rb_sys_fail(0);
-    }
-
-    if (retval > 0) {
-      break;
-    }
+  if (retval == 0) {
+    rb_raise(cMysql2TimeoutError, "Timeout waiting for a response from the last query. (waited %d seconds)", FIX2INT(read_timeout));
   }
+  if (retval < 0) {
+    rb_sys_fail(0);
+  }
+}
+
+static VALUE do_query(VALUE args) {
+  struct async_query_args *async_args = (void *)args;
+
+  wait_for_readable_with_timeout(async_args->self, async_args->fd);
 
   async_args->completion.completed = 1;
   return Qnil;
@@ -1616,56 +1619,12 @@ static VALUE rb_mysql_client_more_results(VALUE self)
     return Qtrue;
 }
 
-#ifndef _WIN32
-/* Waits for the connection's fd to become readable, honoring @read_timeout
- * the same way do_query does for the initial query. rb_wait_for_single_fd
- * itself releases the GVL and is interruptible (Thread#raise,
- * Timeout.timeout), unlike a raw blocking read inside libmysqlclient. */
-static void wait_for_next_result_fd(VALUE self, mysql_client_wrapper *wrapper) {
-  struct timeval tv;
-  struct timeval *tvp;
-  long int sec;
-  int retval;
-  VALUE read_timeout;
-
-  read_timeout = rb_ivar_get(self, intern_read_timeout);
-
-  tvp = NULL;
-  if (!NIL_P(read_timeout)) {
-    Check_Type(read_timeout, T_FIXNUM);
-    tvp = &tv;
-    sec = FIX2INT(read_timeout);
-    if (sec >= 0) {
-      tvp->tv_sec = sec;
-    } else {
-      rb_raise(cMysql2Error, "read_timeout must be a positive integer, you passed %ld", sec);
-    }
-    tvp->tv_usec = 0;
-  }
-
-  retval = rb_wait_for_single_fd(wrapper->client->net.fd, RB_WAITFD_IN, tvp);
-
-  if (retval == 0) {
-    rb_raise(cMysql2TimeoutError, "Timeout waiting for a response from the last query. (waited %d seconds)", FIX2INT(read_timeout));
-  }
-  if (retval < 0) {
-    rb_sys_fail(0);
-  }
-}
-#endif
-
 #if defined(HAVE_MYSQL_NEXT_RESULT_NONBLOCKING) && !defined(_WIN32)
-/* Polls mysql_next_result_nonblocking() (added in MySQL 8.0.16) instead of
- * calling the blocking mysql_next_result() directly. Unlike the blocking
- * call, this never holds the GVL for a real network wait: each iteration
- * either returns immediately (never blocks, by the function's own
- * contract) or reports NET_ASYNC_NOT_READY, in which case
- * wait_for_next_result_fd -- not this function -- is what actually waits,
- * and it does so interruptibly.
- *
- * Mixing this with the ordinary blocking API on the same connection is
- * explicitly documented as supported, so nothing else in this file needs
- * to change:
+/* Polls mysql_next_result_nonblocking() (added in MySQL 8.0.16), which
+ * never blocks by its own contract, instead of calling the blocking
+ * mysql_next_result() directly. Mixing this with the ordinary blocking
+ * API on the same connection is explicitly documented as supported, so
+ * nothing else in this file needs to change:
  * https://dev.mysql.com/doc/c-api/8.0/en/c-api-asynchronous-interface-usage.html
  */
 static enum net_async_status next_result_nonblocking(VALUE self, mysql_client_wrapper *wrapper) {
@@ -1676,7 +1635,7 @@ static enum net_async_status next_result_nonblocking(VALUE self, mysql_client_wr
     if (status != NET_ASYNC_NOT_READY) {
       return status;
     }
-    wait_for_next_result_fd(self, wrapper);
+    wait_for_readable_with_timeout(self, wrapper->client->net.fd);
   }
 }
 #else

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -187,6 +187,7 @@ have_type('my_bool', mysql_h)
 
 # detect mysql functions
 have_func('mysql_ssl_set', mysql_h)
+have_func('mysql_next_result_nonblocking', mysql_h) # Added in MySQL 8.0.16; no MariaDB Connector/C equivalent under this name (see mysql_next_result_start/_cont)
 
 ### Compiler flags to help catch errors
 

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -1028,6 +1028,41 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
         end.not_to raise_error
       end
 
+      # Regression coverage for #807 / #962 / #1033: #next_result calls
+      # mysql_next_result() directly, which can make a real blocking network
+      # read when the next statement in the batch isn't ready yet. Unlike
+      # the initial query (see do_query/wait_for_fd in client.c), this read
+      # is neither GVL-released nor interruptible.
+      it "should not hold the GVL while #next_result waits on a slow next statement" do
+        @multi_client.query("SELECT 1 AS a; SELECT SLEEP(1) AS b")
+
+        ticks = 0
+        stop = false
+        counter = new_thread do
+          until stop
+            ticks += 1
+            sleep 0.01
+          end
+        end
+
+        @multi_client.next_result
+        stop = true
+        counter.join
+
+        # ~100 ticks in 1s if the GVL was free to schedule the counter
+        # thread; the bug holds the GVL for the entire wait, so ticks stays
+        # at (or near) 0.
+        expect(ticks).to be > 50
+      end
+
+      it "should be interruptible via Thread#raise while #next_result waits on a slow next statement" do
+        @multi_client.query("SELECT 1 AS a; SELECT SLEEP(2) AS b")
+
+        expect do
+          Timeout.timeout(0.3) { @multi_client.next_result }
+        end.to raise_error(Timeout::Error)
+      end
+
       it "#more_results? should work" do
         @multi_client.query("SELECT 1 AS 'set_1'; SELECT 2 AS 'set_2'")
         expect(@multi_client.more_results?).to be true

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -1050,9 +1050,12 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
         counter.join
 
         # ~100 ticks in 1s if the GVL was free to schedule the counter
-        # thread; the bug holds the GVL for the entire wait, so ticks stays
-        # at (or near) 0.
-        expect(ticks).to be > 50
+        # thread on an idle machine; the bug holds the GVL for the entire
+        # wait, so ticks stays at exactly 0. GitHub's macOS runners are
+        # slow/oversubscribed enough to only deliver ~18-24 in practice
+        # (observed in CI), so the threshold has real margin above 0
+        # without assuming a well-scheduled machine.
+        expect(ticks).to be > 5
       end
 
       it "should be interruptible via Thread#raise while #next_result waits on a slow next statement" do


### PR DESCRIPTION
Fixes #1033. Also closes out #807 and #962, two earlier attempts at the same fix that never merged (see my comment on #1033 for the full history).

## Problem

`client.next_result` calls `mysql_next_result()` directly. When the next statement in a multi-statement batch (`SELECT 1; SELECT SLEEP(3)`) isn't ready yet, that's a real blocking network read -- unlike the initial query, which already releases the GVL and polls an interruptible fd wait (`do_query`/`wait_for_fd`), `next_result` did neither.

## Fix

- On MySQL 8.0.16+, poll `mysql_next_result_nonblocking()` -- a real libmysqlclient API added years after #807/#962 were written -- instead of calling `mysql_next_result()` directly. Each iteration either completes immediately or reports `NET_ASYNC_NOT_READY`, in which case the *wait*, not the poll, is what actually blocks, via the same `rb_wait_for_single_fd` machinery `do_query` already uses, so it's interruptible the same way. Mixing this with the ordinary blocking API elsewhere on the same connection is [explicitly documented as supported by MySQL](https://dev.mysql.com/doc/c-api/8.0/en/c-api-asynchronous-interface-usage.html), so nothing else in `client.c` needed to change -- and #962's `vio_priv.h` detection for already-buffered data isn't needed at all anymore, since the nonblocking function itself reports that.
- Falls back to releasing the GVL around the still-blocking call (`rb_thread_call_without_gvl`) on MariaDB and on MySQL older than 8.0.16, guarded by `have_func('mysql_next_result_nonblocking')`. This fixes the GVL-holding half of the bug unconditionally; the interruptibility half depends on whether the linked libmysqlclient retries internally on the signal `RUBY_UBF_IO` sends on `EINTR`, which this fallback can't control -- verified empirically on MySQL 8.0.34 (macOS) with the fast path force-disabled that both problems actually resolve here too, but that isn't guaranteed on every platform/library build.

## Testing

Two new specs in `spec/mysql2/client_spec.rb`, under "Multiple results sets":
- Measures GVL availability during the wait via a counter thread ticking on `sleep 0.01` -- fails on unfixed code (0 ticks during a 1s block, ~100 expected), passes now.
- Asserts `Timeout.timeout` around a slow `next_result` actually raises `Timeout::Error` -- fails on unfixed code (silently absorbed, returns after the full wait), passes now.

Full suite: 450 examples, 0 failures.

## Known gap

MariaDB Connector/C has its own non-blocking pair for this (`mysql_next_result_start`/`_cont`), not wired up here -- it uses a different `MYSQL_OPT_NONBLOCK`-gated pattern than MySQL's freely-mixable one, and I want to verify it's actually safe to mix with the rest of this codebase's blocking calls before extending the fix to that path rather than guess. MariaDB gets the GVL-release fallback in the meantime, same as older MySQL. If CI turns up a MariaDB-specific issue, will iterate from there.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
