### PR TITLE
Raise instead of reading freed metadata for an uncached field

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -331,6 +331,18 @@ static VALUE rb_mysql_result_fetch_field(VALUE self, unsigned int idx, int symbo
     rb_encoding *default_internal_enc = rb_default_internal_encoding();
     rb_encoding *conn_enc = wrapper->conn_enc;
 
+    /* A name that was never cached has to be read from the result, which the
+     * force-free of an abandoned stream has already released. Hash-mode rows
+     * cache names one cell at a time, so a raise between cells leaves the tail
+     * of the set uncached and still reachable through #fields.
+     *
+     * Checked per name rather than over the set as a whole, so that names
+     * cached before the free still answer, as callers after an ordinary free
+     * expect. */
+    if (wrapper->resultFreed) {
+      rb_raise(cMysql2Error, "Result set has already been freed");
+    }
+
     field = mysql_fetch_field_direct(wrapper->result, idx);
     if (symbolize_keys) {
       rb_field = rb_intern3(field->name, field->name_length, rb_utf8_encoding());
@@ -418,6 +430,13 @@ static VALUE rb_mysql_result_fetch_field_type(VALUE self, unsigned int idx) {
     rb_encoding *default_internal_enc = rb_default_internal_encoding();
     rb_encoding *conn_enc = wrapper->conn_enc;
     int precision;
+
+    /* See the matching check in rb_mysql_result_fetch_field. #field_types
+     * hands back the internal array, so a caller can shorten it and send the
+     * next lookup back here after the result is gone. */
+    if (wrapper->resultFreed) {
+      rb_raise(cMysql2Error, "Result set has already been freed");
+    }
 
     field = mysql_fetch_field_direct(wrapper->result, idx);
 

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -330,6 +330,62 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
       expect(result.field_types.length).to eql(1)
     end
 
+    context "when a hash row raises part way through" do
+      # Hash rows materialize field names one cell at a time, so a raise between
+      # cells leaves only part of the set cached. Filling the rest reads field
+      # metadata out of the result, which the next query has already released
+      # for an abandoned stream.
+      before do
+        @client.query("SET SESSION sql_mode = ''")
+        @client.query("DROP TABLE IF EXISTS mysql2_partial_fields")
+        @client.query("CREATE TABLE mysql2_partial_fields (a INT, bad_date DATE, c INT)")
+        @client.query("INSERT INTO mysql2_partial_fields VALUES (1, '1972-00-27', 3)")
+      end
+
+      after do
+        @client.query("DROP TABLE IF EXISTS mysql2_partial_fields")
+      end
+
+      let(:sql) { "SELECT a, bad_date, c FROM mysql2_partial_fields" }
+
+      it "should fill the remaining field names while the result is live" do
+        result = @client.query(sql, stream: true, cache_rows: false)
+        expect { result.each { |_| } }.to raise_error(Mysql2::Error, /Invalid date in field/)
+        expect(result.fields).to eql(%w[a bad_date c])
+      end
+
+      it "should raise instead of reading metadata freed by the next query" do
+        result = @client.query(sql, stream: true, cache_rows: false)
+        expect { result.each { |_| } }.to raise_error(Mysql2::Error, /Invalid date in field/)
+        @client.query("SELECT 1") # force-frees the abandoned stream
+        expect { result.fields }.to raise_error(Mysql2::Error, "Result set has already been freed")
+      end
+
+      it "should raise the same way for a prepared statement result" do
+        result = @client.prepare(sql).execute(stream: true, cache_rows: false)
+        expect { result.each { |_| } }.to raise_error(Mysql2::Error, /Invalid date in field/)
+        @client.query("SELECT 1") # force-frees the abandoned stream
+        expect { result.fields }.to raise_error(Mysql2::Error, "Result set has already been freed")
+      end
+
+      it "should raise rather than refill a caller-shortened field_types after free" do
+        result = @client.query(sql, stream: true, cache_rows: false)
+        expect { result.each { |_| } }.to raise_error(Mysql2::Error, /Invalid date in field/)
+        result.field_types.pop # #field_types hands back the internal array
+        @client.query("SELECT 1") # force-frees the abandoned stream
+        expect { result.field_types }.to raise_error(Mysql2::Error, "Result set has already been freed")
+      end
+
+      it "should not raise after free when every name is cached but the array was appended to" do
+        # #fields returns the internal array, so its length is not a reliable
+        # stand-in for whether a name still has to be read from the result.
+        result = @client.query("SELECT 1 AS a, 2 AS b")
+        result.fields << "added by caller"
+        result.free
+        expect(result.fields).to eql(["a", "b", "added by caller"])
+      end
+    end
+
     context "when iterating in array mode" do
       # Array rows never contain field names, so names are batch-materialized
       # on the first fetched row instead of fetched per cell. These pin that


### PR DESCRIPTION
Follow-up to #1487, which closed the array-mode form of this and noted the hash-mode window was still open.

Hash-mode rows materialize field names one cell at a time, so a raise between cells leaves only part of the set cached. `#fields` then fills the rest, which reads field metadata out of the result — and for a streaming query abandoned mid-iteration, the next query has already force-freed it.

### Repro

This is a read of freed memory, so the symptom is allocator- and platform-dependent; on this build of master (466a9ae) it segfaults 3 runs out of 3:

```ruby
client.query("SET SESSION sql_mode = ''")
client.query("CREATE TABLE t (a INT, bad DATE, c INT)")
client.query("INSERT INTO t VALUES (1, '1972-00-27', 3)")

result = client.query("SELECT a, bad, c FROM t", stream: true, cache_rows: false)
result.each { } rescue nil  # raises mid-row; caches 'a' and 'bad' only
client.query("SELECT 1")    # force-frees the abandoned stream
result.fields               # [BUG] Segmentation fault
```

```
-- C level backtrace information -------------------------------------------
mysql2.bundle(rb_mysql_result_fetch_field+0xac)
mysql2.bundle(rb_mysql_result_fetch_fields+0xe4)
```

### The fix

The freed check goes where the name is actually read. `mysql_fetch_field_direct` runs only for a name that is not already cached, so a check there covers exactly the case that needs the result alive, and leaves cached names answering as they do after an ordinary free. It raises the same `Mysql2::Error` and message this file already uses for a freed result.

Checking the set as a whole instead — comparing its length against the field count before the fill loop — looked equivalent and is not: `#fields` hands back the internal array, so a caller that appends to it makes the length differ while every name is still cached and no read is needed. That version raised where master returns the names.

`#field_types` needs the same check, reached a different way. Its array is never filled per cell, so a mid-row raise cannot truncate it — but both accessors hand back the internal array, so a caller can shorten it directly:

```ruby
result.field_types.pop      # public API, nothing unsafe
client.query("SELECT 1")    # force-frees the abandoned stream
result.field_types          # [BUG] Segmentation fault
```

So the guard goes in front of that read too. `#fields` is already covered by the same placement.

I also considered having the force-free cache metadata the way the other free paths do, which would let `#fields` keep working rather than raise. It materializes field names, which can raise during encoding conversion, and it runs from `close` and from the start of the next query — putting work that can raise into a cleanup path seemed like the worse trade. Happy to go that way instead if you prefer.

### Tests

Five specs alongside the array-mode ones from #1487:

- `#fields` still completes the partial set while the result is live — pins the behavior the check must not break
- `#fields` raises rather than reading freed metadata after the next query force-frees it
- the same over the binary protocol, whose force-free path differs
- `#field_types` raises rather than refilling after a caller shortened the returned array and the result was freed
- `#fields` after free does not raise when every name is cached and a caller has appended to the returned array — pins the placement; drop it if you would rather not pin that

Regression check: with the `result.c` change reverted and the specs kept, the run dies rather than fails — `[BUG] Segmentation fault` at whichever of the three crashing specs (`result_spec.rb:361`, `:368`, `:376`) the random order reaches first. The two specs that pin what the check must not break pass either way by design.

### Tested on

macOS 26.5.2 (arm64, Apple Silicon), Ruby 3.3.10, MySQL 9.6.0 server and libmysqlclient 9.6.0, Unix socket, Apple clang 21.0.0. Full suite 474 examples / 0 failures / 10 pending (pre-existing SSL-cert skips), RuboCop clean, no new compiler warnings.

Not exercised here: Linux, MariaDB, other Ruby versions, TCP transport. The change adds no API, no dependency, and no build-flag change — it is a `wrapper->resultFreed` check plus an `rb_raise` already used a few lines above. Nothing in it is platform-specific, though I have not run the other platforms to say so from evidence.
