### PR TITLE
Clarify that the :flags example isn't an exhaustive list

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ Mysql2::Client.new(
   :port,
   :database,
   :socket = '/path/to/mysql.sock',
-  :flags = REMEMBER_OPTIONS | LONG_PASSWORD | LONG_FLAG | TRANSACTIONS | PROTOCOL_41 | SECURE_CONNECTION | MULTI_STATEMENTS,
+  :flags = REMEMBER_OPTIONS | LONG_PASSWORD | LONG_FLAG | ..., # not exhaustive, see "Flags option parsing" below
   :encoding = 'utf8mb4',
   :read_timeout = seconds,
   :write_timeout = seconds,


### PR DESCRIPTION
The Connection options example has shown the same seven flags since 2019, with nothing indicating more exist -- even though the very next section, "Flags option parsing", already explains how to look up and combine the rest via `Mysql2::Client::` constants.

Fixes #1087.