### PR TITLE
Document that automatic_close cannot protect a TLS connection across fork()

### DIFF
--- a/README.md
+++ b/README.md
@@ -363,6 +363,30 @@ When secure_auth is enabled, the server will refuse a connection if the account 
 The MySQL 5.6.5 client library may also refuse to attempt a connection if provided an older format password.
 To bypass this restriction in the client, pass the option `:secure_auth => false` to Mysql2::Client.new().
 
+### Fork safety and `automatic_close`
+
+By default (`automatic_close = true`), a `Client` closes its connection when
+garbage collected. Set `:automatic_close => false` (or `client.automatic_close
+= false`) to leave the connection open instead -- the classic reason is a
+pre-forking app server that opens a connection before `fork()` and wants the
+parent to go on using it after a forked child's copy of the same `Client` is
+garbage collected.
+
+This only works for a **plaintext** connection. A TLS connection's OpenSSL
+session state -- record-layer sequence numbers -- is duplicated by `fork()`
+right along with the socket, as two independent copies that both believe they
+alone own the connection. If the child performs any real query on its copy,
+that advances the encryption sequence counters on the server and in the
+child's copy, but not in the parent's now-desynced copy; the parent's next
+query on that connection will be encrypted with stale sequence numbers, and
+the server will reject it and drop the connection (`Aborted_clients` +1,
+`Mysql2::Error::ConnectionError: Lost connection to MySQL server during
+query` on the client's next attempt). `automatic_close = false` and
+`invalidate_fd()` (the fd-redirection this relies on) only ever touch file
+descriptors, not TLS session state, so there is no client-side fix for this --
+if you rely on `automatic_close = false` surviving a `fork()`, connect with
+`:ssl_mode => :disabled`.
+
 ### Flags option parsing
 
 The `:flags` parameter accepts an integer, a string, or an array. The integer

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1640,6 +1640,11 @@ static VALUE get_automatic_close(VALUE self) {
  * collected. To avoid "Aborted connection" errors on the server, explicitly
  * call +close+ when the connection is no longer needed.
  *
+ * This only protects a plaintext connection across fork(); a TLS
+ * connection's OpenSSL session state is duplicated (not shared) by fork()
+ * and will desync between parent and child the moment either side performs
+ * a real query, regardless of this setting. See the README for details.
+ *
  * @see http://dev.mysql.com/doc/en/communication-errors.html
  */
 static VALUE set_automatic_close(VALUE self, VALUE value) {


### PR DESCRIPTION
## Summary

The `fd`-invalidation trick `automatic_close = false` relies on (`invalidate_fd()` in `client.c`) only patches up the raw socket fd -- it says nothing about a TLS connection's OpenSSL session/record-layer state, which `fork()` duplicates right along with the fd as two independent copies. The moment either side performs a real query, that copy's sequence counters advance independently of the other's, permanently desyncing them; the next query on the stale side gets rejected by the server (`Aborted_clients` +1, `Lost connection to MySQL server during query`). There's no client-side fix -- `invalidate_fd()` can't repair TLS state it never touches in the first place.

The regression spec covering this (child process + `automatic_close`) was already pinned to `ssl_mode: disabled` in #1468, with the same reasoning written in as a comment. This documents the same finding for API consumers, since nothing previously said `automatic_close` only works for plaintext connections.

## Changes

- `README.md`: new "Fork safety and `automatic_close`" section explaining the mechanism and the fix (`ssl_mode: :disabled`).
- `ext/mysql2/client.c`: same caveat added to the `automatic_close=` docstring.

## Test plan

- [x] `spec/mysql2/client_spec.rb`'s `#automatic_close` context passes (151 examples, 0 failures overall)
- [x] No code behavior changes -- docs only

Fixes #1467.

🤖 Generated with [Claude Code](https://claude.com/claude-code)