### PR TITLE
Add Result#tables and Result#dbs (rebase of #1267)

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -104,6 +104,8 @@ static void rb_mysql_result_mark(void * wrapper) {
   if (w) {
     rb_gc_mark_movable(w->fields);
     rb_gc_mark_movable(w->fieldTypes);
+    rb_gc_mark_movable(w->tables);
+    rb_gc_mark_movable(w->dbs);
     rb_gc_mark_movable(w->rows);
     rb_gc_mark_movable(w->encoding);
     rb_gc_mark_movable(w->client);
@@ -250,6 +252,8 @@ static void rb_mysql_result_compact(void * wrapper) {
   if (w) {
     rb_mysql2_gc_location(w->fields);
     rb_mysql2_gc_location(w->fieldTypes);
+    rb_mysql2_gc_location(w->tables);
+    rb_mysql2_gc_location(w->dbs);
     rb_mysql2_gc_location(w->rows);
     rb_mysql2_gc_location(w->encoding);
     rb_mysql2_gc_location(w->client);
@@ -365,6 +369,74 @@ static VALUE rb_mysql_result_fetch_field(VALUE self, unsigned int idx, int symbo
   }
 
   return rb_field;
+}
+
+static VALUE rb_mysql_result_fetch_table(VALUE self, unsigned int idx) {
+  VALUE rb_table;
+  GET_RESULT(self);
+
+  if (wrapper->tables == Qnil) {
+    wrapper->numberOfFields = mysql_num_fields(wrapper->result);
+    wrapper->tables = rb_ary_new2(wrapper->numberOfFields);
+  }
+
+  rb_table = rb_ary_entry(wrapper->tables, idx);
+  if (rb_table == Qnil) {
+    MYSQL_FIELD *field = NULL;
+    rb_encoding *default_internal_enc = rb_default_internal_encoding();
+    rb_encoding *conn_enc = rb_to_encoding(wrapper->encoding);
+
+    field = mysql_fetch_field_direct(wrapper->result, idx);
+#ifdef HAVE_RB_ENC_INTERNED_STR
+    rb_table = rb_enc_interned_str(field->table, field->table_length, conn_enc);
+    if (default_internal_enc && default_internal_enc != conn_enc) {
+      rb_table = rb_str_to_interned_str(rb_str_export_to_enc(rb_table, default_internal_enc));
+    }
+#else
+    rb_table = rb_enc_str_new(field->table, field->table_length, conn_enc);
+    if (default_internal_enc && default_internal_enc != conn_enc) {
+      rb_table = rb_str_export_to_enc(rb_table, default_internal_enc);
+    }
+    rb_obj_freeze(rb_table);
+#endif
+    rb_ary_store(wrapper->tables, idx, rb_table);
+  }
+
+  return rb_table;
+}
+
+static VALUE rb_mysql_result_fetch_db(VALUE self, unsigned int idx) {
+  VALUE rb_db;
+  GET_RESULT(self);
+
+  if (wrapper->dbs == Qnil) {
+    wrapper->numberOfFields = mysql_num_fields(wrapper->result);
+    wrapper->dbs = rb_ary_new2(wrapper->numberOfFields);
+  }
+
+  rb_db = rb_ary_entry(wrapper->dbs, idx);
+  if (rb_db == Qnil) {
+    MYSQL_FIELD *field = NULL;
+    rb_encoding *default_internal_enc = rb_default_internal_encoding();
+    rb_encoding *conn_enc = rb_to_encoding(wrapper->encoding);
+
+    field = mysql_fetch_field_direct(wrapper->result, idx);
+#ifdef HAVE_RB_ENC_INTERNED_STR
+    rb_db = rb_enc_interned_str(field->db, field->db_length, conn_enc);
+    if (default_internal_enc && default_internal_enc != conn_enc) {
+      rb_db = rb_str_to_interned_str(rb_str_export_to_enc(rb_db, default_internal_enc));
+    }
+#else
+    rb_db = rb_enc_str_new(field->db, field->db_length, conn_enc);
+    if (default_internal_enc && default_internal_enc != conn_enc) {
+      rb_db = rb_str_export_to_enc(rb_db, default_internal_enc);
+    }
+    rb_obj_freeze(rb_db);
+#endif
+    rb_ary_store(wrapper->dbs, idx, rb_db);
+  }
+
+  return rb_db;
 }
 
 /* Materialize every field name into wrapper->fields at once, honoring the
@@ -1530,6 +1602,44 @@ static VALUE rb_mysql_result_fetch_fields(VALUE self) {
   return wrapper->fields;
 }
 
+static VALUE rb_mysql_result_fetch_tables(VALUE self) {
+  unsigned int i = 0;
+
+  GET_RESULT(self);
+
+  if (wrapper->tables == Qnil) {
+    wrapper->numberOfFields = mysql_num_fields(wrapper->result);
+    wrapper->tables = rb_ary_new2(wrapper->numberOfFields);
+  }
+
+  if ((my_ulonglong)RARRAY_LEN(wrapper->tables) != wrapper->numberOfFields) {
+    for (i=0; i<wrapper->numberOfFields; i++) {
+      rb_mysql_result_fetch_table(self, i);
+    }
+  }
+
+  return wrapper->tables;
+}
+
+static VALUE rb_mysql_result_fetch_dbs(VALUE self) {
+  unsigned int i = 0;
+
+  GET_RESULT(self);
+
+  if (wrapper->dbs == Qnil) {
+    wrapper->numberOfFields = mysql_num_fields(wrapper->result);
+    wrapper->dbs = rb_ary_new2(wrapper->numberOfFields);
+  }
+
+  if ((my_ulonglong)RARRAY_LEN(wrapper->dbs) != wrapper->numberOfFields) {
+    for (i=0; i<wrapper->numberOfFields; i++) {
+      rb_mysql_result_fetch_db(self, i);
+    }
+  }
+
+  return wrapper->dbs;
+}
+
 static VALUE rb_mysql_result_fetch_field_types(VALUE self) {
   unsigned int i = 0;
   VALUE field_types;
@@ -1981,6 +2091,8 @@ VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_
   wrapper->result = r;
   wrapper->fields = Qnil;
   wrapper->fieldTypes = Qnil;
+  wrapper->tables = Qnil;
+  wrapper->dbs = Qnil;
   wrapper->rows = Qnil;
   wrapper->server_flags = Qnil;
   wrapper->encoding = encoding;
@@ -2049,6 +2161,8 @@ void init_mysql2_result(void) {
 
   rb_define_method(cMysql2Result, "each", rb_mysql_result_each, -1);
   rb_define_method(cMysql2Result, "fields", rb_mysql_result_fetch_fields, 0);
+  rb_define_method(cMysql2Result, "tables", rb_mysql_result_fetch_tables, 0);
+  rb_define_method(cMysql2Result, "dbs", rb_mysql_result_fetch_dbs, 0);
   rb_define_method(cMysql2Result, "field_types", rb_mysql_result_fetch_field_types, 0);
   rb_define_method(cMysql2Result, "free", rb_mysql_result_free_, 0);
   rb_define_method(cMysql2Result, "count", rb_mysql_result_count, 0);

--- a/ext/mysql2/result.h
+++ b/ext/mysql2/result.h
@@ -51,6 +51,8 @@ typedef struct {
 typedef struct {
   VALUE fields;
   VALUE fieldTypes;
+  VALUE tables;
+  VALUE dbs;
   VALUE rows;
   VALUE client;
   VALUE encoding;

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -502,7 +502,7 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
 
     it "should return an array of frozen strings" do
       result = @client.query "SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1"
-      result.fields.each do |f|
+      result.tables.each do |f|
         expect(f).to be_frozen
       end
     end

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -517,8 +517,8 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
 
     it "should return an array of database names in proper order" do
       db = DatabaseCredentials['root']['database']
-      result = @client.query( "SELECT id, bit_test, single_bit_test FROM mysql2_test ORDER BY id DESC LIMIT 1" )
-      expect(result.dbs).to eql([db,db,db])
+      result = @client.query("SELECT id, bit_test, single_bit_test FROM mysql2_test ORDER BY id DESC LIMIT 1")
+      expect(result.dbs).to eql([db, db, db])
     end
 
     it "should return an array of frozen strings" do

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -488,6 +488,47 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
     end
   end
 
+  context "#tables" do
+    let(:test_result) { @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1") }
+
+    it "method should exist" do
+      expect(test_result).to respond_to(:tables)
+    end
+
+    it "should return an array of table names in proper order" do
+      result = @client.query("SELECT id, bit_test, single_bit_test FROM mysql2_test ORDER BY id DESC LIMIT 1")
+      expect(result.tables).to eql(%w[mysql2_test mysql2_test mysql2_test])
+    end
+
+    it "should return an array of frozen strings" do
+      result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1")
+      result.tables.each do |f|
+        expect(f).to be_frozen
+      end
+    end
+  end
+
+  context "#dbs" do
+    let(:test_result) { @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1") }
+
+    it "method should exist" do
+      expect(test_result).to respond_to(:dbs)
+    end
+
+    it "should return an array of database names in proper order" do
+      db = DatabaseCredentials['root']['database']
+      result = @client.query( "SELECT id, bit_test, single_bit_test FROM mysql2_test ORDER BY id DESC LIMIT 1" )
+      expect(result.dbs).to eql([db,db,db])
+    end
+
+    it "should return an array of frozen strings" do
+      result = @client.query ""SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1""
+      result.dbs.each do |f|
+        expect(f).to be_frozen
+      end
+    end
+  end
+
   context "streaming" do
     it "should maintain a count while streaming" do
       result = @client.query('SELECT 1', stream: true, cache_rows: false)

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -501,8 +501,8 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
     end
 
     it "should return an array of frozen strings" do
-      result = @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1")
-      result.tables.each do |f|
+      result = @client.query "SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1"
+      result.fields.each do |f|
         expect(f).to be_frozen
       end
     end
@@ -522,7 +522,7 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
     end
 
     it "should return an array of frozen strings" do
-      result = @client.query ""SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1""
+      result = @client.query "SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1"
       result.dbs.each do |f|
         expect(f).to be_frozen
       end


### PR DESCRIPTION
Rebase of #1267 onto current master, all authorship preserved (original author: @rbur004 / robertburrowes). No functional changes from the original PR -- this is a mechanical rebase to resolve the merge conflicts that had accumulated against master.

## What it does

Adds `Result#tables` and `Result#dbs`: arrays parallel to `#fields`, giving the source table/database for each column at the same index (`MYSQL_FIELD.table`/`MYSQL_FIELD.db`, which mysql2 doesn't otherwise surface). This disambiguates same-named columns from different tables in a join -- e.g. a self-join (`FROM atable AS t1, atable AS t2`) -- without requiring every column to be aliased into a flat namespace.

```ruby
result = client.query("SELECT a.id AS a_id, b.id AS b_id FROM mysql2_test a JOIN mysql2_test b ON a.id = b.id")
result.fields # => ["a_id", "b_id"]
result.tables # => ["a", "b"]
```

## What changed in the rebase

Three non-overlapping conflict spots in `result.c`, all just line-adjacent additions from unrelated work merged since the original PR was opened (2022) -- nothing in this PR's own logic needed to change:

- `rb_mysql_result_mark`/`rb_mysql_result_compact`: added `w->tables`/`w->dbs` to the GC mark-movable/compact pair alongside `w->fields`, `w->fieldTypes`, etc. -- the compaction callback (`rb_mysql_result_compact`) didn't exist yet when this PR was written, so the two new fields needed adding there too, matching how the sibling `fields`/`fieldTypes` slots are already handled.
- Placement: the new `rb_mysql_result_fetch_table`/`_db` functions now sit before `rb_mysql_result_materialize_field_names`, which didn't exist in 2022 either.
- An unrelated encoding-cache optimization (charset->index lookup caching) landed nearby in `rb_mysql_result_fetch_field`; kept that version as-is, no interaction with this PR's code.

## Verified

- `bundle exec rake compile` -- clean
- `bundle exec rubocop` -- clean
- `bundle exec rspec` -- 506 examples, 0 failures (includes the 6 tests from this PR's own commit, all passing)
- Manually confirmed the two edge cases worth checking for a "table/db per column" feature:
  - Computed/unaliased expressions (`SELECT 1+1, NOW()`) -- `tables`/`dbs` come back as empty strings (matches `MYSQL_FIELD`'s own behavior), no crash.
  - Self-join with aliased tables -- `tables` correctly returns `["a", "b"]`, resolving the ambiguity `#fields` alone can't.

Original discussion: #1267
