### PR TITLE
Document that MULTI_STATEMENTS only returns the first statement's result

### DIFF
--- a/README.md
+++ b/README.md
@@ -442,7 +442,7 @@ while client.next_result
 end
 ```
 
-A single call to `client.query` only ever returns the *first* statement's
+The call to `client.query` returns the *first* statement's
 result -- or `nil`, if that first statement doesn't produce one at all (e.g.
 `CREATE TABLE` or `INSERT`, same as outside of `MULTI_STATEMENTS`). This is
 still true if you pass `:async => true`: `client.async_result` also only

--- a/README.md
+++ b/README.md
@@ -446,14 +446,21 @@ A single call to `client.query` only ever returns the *first* statement's
 result -- or `nil`, if that first statement doesn't produce one at all (e.g.
 `CREATE TABLE` or `INSERT`, same as outside of `MULTI_STATEMENTS`). This is
 still true if you pass `:async => true`: `client.async_result` also only
-returns the first statement's result. The rest of the batch is not deferred
-until you ask for it -- the server runs every statement in the batch to
-completion regardless of whether you ever call `next_result` again -- but you
-do have to loop over `client.next_result`/`client.store_result`, as shown
-above, to actually retrieve each later result or find out whether any later
-statement raised an error. If you don't drain that loop, be sure to call
-`client.close` (or otherwise drain it) before reusing the connection for
-another command.
+returns the first statement's result.
+
+The rest of the batch isn't deferred. The server runs every statement
+immediately, whether or not you ever call `next_result`. But you still have
+to loop over `client.next_result`/`client.store_result`, as shown above, to
+retrieve each later result or find out if a later statement errored.
+
+Skip that loop and try to reuse the connection, and you'll get this error:
+
+```
+Mysql2::Error: Commands out of sync; you can't run this command now
+```
+
+Drain the loop to clear it. Or call `client.abandon_results!` to discard the
+remaining results without reading them.
 
 Repeated calls to `client.next_result` will return true, false, or raise an
 exception if the respective query erred. When `client.next_result` returns true,

--- a/README.md
+++ b/README.md
@@ -442,6 +442,19 @@ while client.next_result
 end
 ```
 
+A single call to `client.query` only ever returns the *first* statement's
+result -- or `nil`, if that first statement doesn't produce one at all (e.g.
+`CREATE TABLE` or `INSERT`, same as outside of `MULTI_STATEMENTS`). This is
+still true if you pass `:async => true`: `client.async_result` also only
+returns the first statement's result. The rest of the batch is not deferred
+until you ask for it -- the server runs every statement in the batch to
+completion regardless of whether you ever call `next_result` again -- but you
+do have to loop over `client.next_result`/`client.store_result`, as shown
+above, to actually retrieve each later result or find out whether any later
+statement raised an error. If you don't drain that loop, be sure to call
+`client.close` (or otherwise drain it) before reusing the connection for
+another command.
+
 Repeated calls to `client.next_result` will return true, false, or raise an
 exception if the respective query erred. When `client.next_result` returns true,
 call `client.store_result` to retrieve a result object. Exceptions are not


### PR DESCRIPTION
## Summary

`client.query()` returning `nil` for a batch that starts with `CREATE TABLE`/`INSERT` statements, while the rest of the batch keeps running, reads as async execution if you don't already know `MULTI_STATEMENTS`' shape: only the first statement's result comes back from `query()` (or `async_result`, if `:async => true` was passed) -- `nil` there just means that particular statement had no result set, same as it would outside `MULTI_STATEMENTS`. The remaining statements aren't deferred -- the server runs the whole batch regardless -- but retrieving their results, or finding out whether any of them errored, requires looping over `next_result`/`store_result`, and skipping that loop leaves the connection undrained (confirmed: reusing it without draining or closing raises `"Commands out of sync"`).

This was asked and answered in #723 back in 2016 ("the implementation is working as intended") but never made it into the README.

## Changes

- `README.md`: new paragraph in the "Multiple result sets" section explaining this.

## Test plan

- [x] Docs only, no code changes
- [x] Manually confirmed the "Commands out of sync" claim against a real connection before writing it

Fixes #723.

🤖 Generated with [Claude Code](https://claude.com/claude-code)