### PR TITLE
Guard connect()'s string arguments across the GVL-released connect call

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -755,6 +755,16 @@ static VALUE rb_mysql_connect(VALUE self, VALUE user, VALUE pass, VALUE host, VA
       rb_raise_mysql2_error(wrapper);
   }
 
+  /* These originate as Ruby VALUEs, but we're using their C pointers
+   * directly -- keep the VALUEs live on the stack so GC can't collect them
+   * while we drop the GVL to make a MySQL API call. */
+  (void)RB_GC_GUARD(host);
+  (void)RB_GC_GUARD(socket);
+  (void)RB_GC_GUARD(user);
+  (void)RB_GC_GUARD(pass);
+  (void)RB_GC_GUARD(database);
+  (void)RB_GC_GUARD(tls_sni_name);
+
   wrapper->closed = 0;
   wrapper->server_version = mysql_get_server_version(wrapper->client);
   return self;


### PR DESCRIPTION
## The problem

`rb_mysql_connect` extracts raw C pointers from six Ruby Strings (`user`, `pass`, `host`, `socket`, `database`, `tls_sni_name`) via `StringValueCStr`, then hands those pointers to `nogvl_connect` through `rb_thread_call_without_gvl` -- which releases the GVL, letting another thread run and potentially trigger GC, in a loop that can call `nogvl_connect` again on `EINTR`. Nothing keeps those six Strings referenced past extracting their pointers, and the compiler is free to treat that extraction as their last use. If GC collects or moves one of those Strings' buffers while `nogvl_connect` is still reading through the now-stale pointer, that's a use-after-free.

Every other call site in this file that hands a GVL-released call a raw pointer into a Ruby String already guards it this way (`do_send_query`'s `sql`, `rb_mysql_query`'s `current`) -- `rb_mysql_connect` was the one place that didn't.

This matches the failure signature and root-cause hypothesis discussed in #1283, an intermittent connect-time segfault reported since 2022, most clearly here: "another gem doing some setup work triggers a garbage collection just at the moment where an unprotected Ruby string is being passed to a C function."

## The fix

Add `RB_GC_GUARD` for all six arguments after the last point `nogvl_connect` can read through them, matching the existing pattern in this file.

## Test plan

- [x] `bundle exec rake compile` -- clean
- [x] `bundle exec rubocop` -- clean
- [x] `bundle exec rspec` -- 500 examples, 0 failures
- [ ] Could not get a reliable local repro either with or without this fix. `GC.stress` plus fresh, unrooted argument Strings didn't reproduce the exact interleaving the original reports describe -- those needed a specific compiler optimization level and real concurrent GC pressure from other code running alongside the GVL-released window, not just GC forced synchronously at each allocation. The fix follows directly from the established pattern already used in this file for exactly this hazard, and from the failure signature/hypothesis in #1283, rather than from a reproduction of the crash itself.

Fixes #1283.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
