### PR TITLE
Document the GnuTLS caching_sha2_password RSA limitation

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,8 +378,7 @@ implements it for the OpenSSL and WinCrypt backends, not for GnuTLS.
 Debian and its derivatives ship a GnuTLS-linked `mariadb-connector-c` by
 default.
 
-Fixes:
-
+Suggested alternatives:
 * Connect over TLS: `:ssl_mode => :required`.
 * Connect over a Unix socket instead of TCP: `:socket => '/path/to/mysql.sock'`.
 * Change the server account's authentication plugin, e.g. to

--- a/README.md
+++ b/README.md
@@ -365,33 +365,27 @@ To bypass this restriction in the client, pass the option `:secure_auth => false
 
 ### `caching_sha2_password` and GnuTLS-linked client libraries
 
-MySQL 8's default authentication plugin, `caching_sha2_password`, needs to
-RSA-encrypt the password with the server's public key whenever the
-connection isn't already secure (no TLS, no Unix socket). If you see:
+MySQL 8's default authentication plugin, `caching_sha2_password`,
+RSA-encrypts the password with the server's public key on a non-encrypted
+TCP connection. If you see this error:
 
 ```
 Mysql2::Error: RSA Encryption not supported - caching_sha2_password plugin was built with GnuTLS support
 ```
 
-this is a permanent limitation of the specific MariaDB Connector/C build
-you have installed, not something mysql2 can work around. Connector/C
-implements that RSA step for its OpenSSL and WinCrypt backends, but not for
-GnuTLS -- a GnuTLS-linked build deliberately raises this error instead of
-attempting it. Some Linux distributions (Debian and its derivatives, in
-particular) ship a GnuTLS-linked `mariadb-connector-c` package for
-licensing reasons, so this shows up there even though nothing is
-misconfigured. Fixes, in order of preference:
+your MariaDB Connector/C build can't take that step. Connector/C
+implements it for the OpenSSL and WinCrypt backends, not for GnuTLS.
+Debian and its derivatives ship a GnuTLS-linked `mariadb-connector-c` by
+default.
 
-* Connect over TLS (e.g. `:ssl_mode => :required`) -- the RSA step is only
-  needed for connections that aren't already secure, so this sidesteps it
-  entirely.
-* Connect over a Unix socket (`:socket => '/path/to/mysql.sock'`) instead
-  of TCP -- also counts as secure for this check.
-* Change the server account's authentication plugin (e.g. to
-  `mysql_native_password`) if TLS isn't an option, understanding the
-  security tradeoff of doing so.
-* Use a client library actually linked against OpenSSL instead of GnuTLS,
-  if your distribution offers one.
+Fixes:
+
+* Connect over TLS: `:ssl_mode => :required`.
+* Connect over a Unix socket instead of TCP: `:socket => '/path/to/mysql.sock'`.
+* Change the server account's authentication plugin, e.g. to
+  `mysql_native_password`, if TLS isn't an option. Understand the security
+  tradeoff first.
+* Use a client library linked against OpenSSL instead of GnuTLS.
 
 ### Flags option parsing
 

--- a/README.md
+++ b/README.md
@@ -363,6 +363,36 @@ When secure_auth is enabled, the server will refuse a connection if the account 
 The MySQL 5.6.5 client library may also refuse to attempt a connection if provided an older format password.
 To bypass this restriction in the client, pass the option `:secure_auth => false` to Mysql2::Client.new().
 
+### `caching_sha2_password` and GnuTLS-linked client libraries
+
+MySQL 8's default authentication plugin, `caching_sha2_password`, needs to
+RSA-encrypt the password with the server's public key whenever the
+connection isn't already secure (no TLS, no Unix socket). If you see:
+
+```
+Mysql2::Error: RSA Encryption not supported - caching_sha2_password plugin was built with GnuTLS support
+```
+
+this is a permanent limitation of the specific MariaDB Connector/C build
+you have installed, not something mysql2 can work around. Connector/C
+implements that RSA step for its OpenSSL and WinCrypt backends, but not for
+GnuTLS -- a GnuTLS-linked build deliberately raises this error instead of
+attempting it. Some Linux distributions (Debian and its derivatives, in
+particular) ship a GnuTLS-linked `mariadb-connector-c` package for
+licensing reasons, so this shows up there even though nothing is
+misconfigured. Fixes, in order of preference:
+
+* Connect over TLS (e.g. `:ssl_mode => :required`) -- the RSA step is only
+  needed for connections that aren't already secure, so this sidesteps it
+  entirely.
+* Connect over a Unix socket (`:socket => '/path/to/mysql.sock'`) instead
+  of TCP -- also counts as secure for this check.
+* Change the server account's authentication plugin (e.g. to
+  `mysql_native_password`) if TLS isn't an option, understanding the
+  security tradeoff of doing so.
+* Use a client library actually linked against OpenSSL instead of GnuTLS,
+  if your distribution offers one.
+
 ### Flags option parsing
 
 The `:flags` parameter accepts an integer, a string, or an array. The integer


### PR DESCRIPTION
## Summary

`"RSA Encryption not supported - caching_sha2_password plugin was built with GnuTLS support"` is a permanent limitation of GnuTLS-linked MariaDB Connector/C builds, not a mysql2 bug: `caching_sha2_password` needs to RSA-encrypt the password with the server's public key on any connection that isn't already secure, and Connector/C only implements that step for its OpenSSL/WinCrypt backends -- a GnuTLS build deliberately raises this error instead of attempting it (traced to `plugins/auth/caching_sha2_pw.c`). Debian and derivatives ship a GnuTLS-linked `mariadb-connector-c` package by default, so this shows up there with no misconfiguration involved.

Came up in #1286, which bundled this together with an unrelated `"caching_sha2_password.so: cannot open shared object file"` report (a packaging/plugin-directory issue, same shape as the already-fixed #1023) under one issue. That one wasn't worth documenting here since it's distro packaging drift, not a stable, well-defined limitation -- this GnuTLS case is worth it because it's permanent and keeps recurring for anyone on a GnuTLS-linked build.

## Changes

- `README.md`: new subsection explaining the error, why it happens, and the four practical fixes (TLS, Unix socket, different server auth plugin, or an OpenSSL-linked client library).

## Test plan

- [x] Docs only, no code changes

Fixes #1286.

🤖 Generated with [Claude Code](https://claude.com/claude-code)