### PR TITLE
Fix ssl_mode: :verify_ca silently accepting any CA on MariaDB

### DIFF
--- a/README.md
+++ b/README.md
@@ -335,10 +335,14 @@ The `:ssl_mode` option will also set the appropriate MariaDB connection flags:
 | ---                | ---                                  |
 | `:disabled`        | MYSQL_OPT_SSL_ENFORCE = 0            |
 | `:required`        | MYSQL_OPT_SSL_ENFORCE = 1            |
+| `:verify_ca`       | MYSQL_OPT_SSL_VERIFY_SERVER_CERT = 1 |
 | `:verify_identity` | MYSQL_OPT_SSL_VERIFY_SERVER_CERT = 1 |
 
-MariaDB does not support the `:preferred` or `:verify_ca` options. For more
-information about SSL/TLS in MariaDB, see
+MariaDB Connector/C has no CA-only verification mode, so `:verify_ca` gets
+the same full verification (CA and hostname) that `:verify_identity` gets --
+MYSQL_OPT_SSL_VERIFY_SERVER_CERT is the only verification it offers. MariaDB
+does not support the `:preferred` option; there's no equivalent to fall back
+to. For more information about SSL/TLS in MariaDB, see
 [https://mariadb.com/kb/en/securing-connections-for-client-and-server/](https://mariadb.com/kb/en/securing-connections-for-client-and-server/)
 and [https://mariadb.com/kb/en/mysql_optionsv/#tls-options](https://mariadb.com/kb/en/mysql_optionsv/#tls-options)
 

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -76,7 +76,14 @@ static ID intern_brackets, intern_merge, intern_merge_bang, intern_new_with_args
  */
 #ifdef HAVE_CONST_MYSQL_OPT_SSL_VERIFY_SERVER_CERT
   #define SSL_MODE_VERIFY_IDENTITY 5
+  /* MYSQL_OPT_SSL_VERIFY_SERVER_CERT is the only verification this client
+   * library offers -- it checks the CA and the hostname together, with no
+   * way to ask for one without the other. SSL_MODE_VERIFY_CA maps to the
+   * same option: full verification is the closest honest behavior available,
+   * and strictly safer than the alternative of accepting any CA silently. */
+  #define SSL_MODE_VERIFY_CA 4
   #define HAVE_CONST_SSL_MODE_VERIFY_IDENTITY
+  #define HAVE_CONST_SSL_MODE_VERIFY_CA
 #endif
 #ifdef HAVE_CONST_MYSQL_OPT_SSL_ENFORCE
   #define SSL_MODE_DISABLED 1
@@ -153,7 +160,10 @@ static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
     || (version >= 50703 && version < 50711)    // Workaround for MySQL 5.7.3 - 5.7.10
     || (version >= 60103 && version < 60200)) { // Workaround for MySQL Connector/C 6.1.3 - 6.1.x
 #ifdef HAVE_CONST_MYSQL_OPT_SSL_VERIFY_SERVER_CERT
-    if (val == SSL_MODE_VERIFY_IDENTITY) {
+    /* This client library has no CA-only verification mode -- verify_ca
+     * gets the same full verification as verify_identity, since that's the
+     * only real verification MYSQL_OPT_SSL_VERIFY_SERVER_CERT offers. */
+    if (val == SSL_MODE_VERIFY_IDENTITY || val == SSL_MODE_VERIFY_CA) {
       my_bool b = 1;
       int result = mysql_options(wrapper->client, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &b);
       return INT2NUM(result);
@@ -2138,6 +2148,7 @@ void init_mysql2_client(void) {
 #else
 #ifdef HAVE_CONST_MYSQL_OPT_SSL_VERIFY_SERVER_CERT // MySQL 5.7.3 - 5.7.10 & MariaDB 10.x and later
   rb_const_set(cMysql2Client, rb_intern("SSL_MODE_VERIFY_IDENTITY"), INT2NUM(SSL_MODE_VERIFY_IDENTITY));
+  rb_const_set(cMysql2Client, rb_intern("SSL_MODE_VERIFY_CA"), INT2NUM(SSL_MODE_VERIFY_CA));
 #endif
 #ifdef HAVE_CONST_MYSQL_OPT_SSL_ENFORCE // MySQL 5.7.3 - 5.7.10 & MariaDB 10.x and later
   rb_const_set(cMysql2Client, rb_intern("SSL_MODE_DISABLED"), INT2NUM(SSL_MODE_DISABLED));

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -176,18 +176,24 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       new_client(option_overrides)
     end
 
-    # 'preferred' or 'verify_ca' are only in MySQL 5.6.36+, 5.7.11+, 8.0+.
-    # The upper bound stops at 100000 (not left unbounded) because MariaDB's
-    # client version numbering starts there (10.x = 100000+, 11.x = 110000+,
-    # 12.x = 120000+) and MariaDB has never implemented the 5-value ssl_mode
-    # API this branch is testing -- see FULL_SSL_MODE_SUPPORT in extconf.rb
-    # and rb_set_ssl_mode_option's own version >= 100000 MariaDB check.
+    # 'preferred' is only in MySQL 5.6.36+, 5.7.11+, 8.0+ -- MariaDB Connector/C
+    # has no equivalent option, so mysql2 can't do anything for it there.
+    # 'verify_ca' works everywhere: MariaDB Connector/C has no CA-only
+    # verification mode, so rb_set_ssl_mode_option maps it to the same full
+    # verification 'verify_identity' uses (MYSQL_OPT_SSL_VERIFY_SERVER_CERT).
+    #
+    # The upper bound on the first range stops at 100000 (not left unbounded)
+    # because MariaDB's client version numbering starts there (10.x =
+    # 100000+, 11.x = 110000+, 12.x = 120000+) and MariaDB has never
+    # implemented the 5-value ssl_mode API that range is testing -- see
+    # FULL_SSL_MODE_SUPPORT in extconf.rb and rb_set_ssl_mode_option's own
+    # version >= 100000 MariaDB check.
     version = Mysql2::Client.info[:id]
     ssl_modes = case version
     when 50636...50700, 50711...50800, 80000...100000
       %i[disabled preferred required verify_ca verify_identity]
     else
-      %i[disabled required verify_identity]
+      %i[disabled required verify_ca verify_identity]
     end
 
     # MySQL and MariaDB and all versions of Connector/C
@@ -202,6 +208,30 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
             new_client(options)
           end.not_to output(/does not support ssl_mode/).to_stderr
         end.not_to raise_error
+      end
+    end
+
+    it "should reject a connection when ssl_mode is verify_ca and the CA doesn't match the server's" do
+      require 'openssl'
+      require 'tempfile'
+
+      wrong_ca_key = OpenSSL::PKey::RSA.new(2048)
+      wrong_ca_cert = OpenSSL::X509::Certificate.new
+      wrong_ca_cert.version = 2
+      wrong_ca_cert.serial = 1
+      wrong_ca_cert.subject = OpenSSL::X509::Name.parse('/CN=wrong-ca')
+      wrong_ca_cert.issuer = wrong_ca_cert.subject
+      wrong_ca_cert.public_key = wrong_ca_key.public_key
+      wrong_ca_cert.not_before = Time.now
+      wrong_ca_cert.not_after = Time.now + 3600
+      wrong_ca_cert.sign(wrong_ca_key, OpenSSL::Digest.new('SHA256'))
+
+      Tempfile.create(['wrong-ca', '.pem']) do |f|
+        f.write(wrong_ca_cert.to_pem)
+        f.flush
+
+        options = option_overrides.merge(ssl_mode: :verify_ca, sslca: f.path)
+        expect { new_client(options) }.to raise_error(Mysql2::Error)
       end
     end
 


### PR DESCRIPTION
## The problem

`ssl_mode: :verify_ca` silently accepts a connection with a wrong CA on MariaDB Connector/C. Traced to `client.c`'s compatibility shim: MariaDB Connector/C has no `SSL_MODE_VERIFY_CA` enum, so `SSL_MODE_VERIFY_CA` never got a real value distinct from `SSL_MODE_PREFERRED` -- both fell through to the same `INT2NUM(0)` fallback used for any `SSL_MODE_*` constant the shim doesn't explicitly define. `ssl_mode: :verify_ca` therefore resolves to `0`, which `rb_set_ssl_mode_option`'s MariaDB branch doesn't recognize (it only handles `DISABLED=1`, `REQUIRED=3`, `VERIFY_IDENTITY=5`), so it prints a warning and configures no SSL option at all -- the connection proceeds over opportunistic TLS with the CA never checked.

Confirmed live against a real MariaDB 11.8 server: a self-signed, completely unrelated CA is accepted without error under `ssl_mode: :verify_ca`.

This is #936, open since 2018.

## The fix

- Give `SSL_MODE_VERIFY_CA` its own value (`4`, matching real MySQL's own enum ordering) in the compatibility shim, instead of falling through to the shared `0` fallback.
- Map `SSL_MODE_VERIFY_CA` alongside `SSL_MODE_VERIFY_IDENTITY` to `MYSQL_OPT_SSL_VERIFY_SERVER_CERT` in `rb_set_ssl_mode_option`. MariaDB Connector/C has no CA-only verification mode -- `MYSQL_OPT_SSL_VERIFY_SERVER_CERT` is the only verification it offers, checking CA and hostname together. Mapping `verify_ca` to the same full verification `verify_identity` gets is the closest honest behavior available, and strictly safer than the previous silent no-op.
- Extends `#879`'s finding too: `verify_identity` was already correctly wired to this same option, which is why that issue is separately resolved -- this PR only closes the `verify_ca` gap.

## Verification

Built and tested against a real MariaDB 11.8 server (MacPorts `mariadb-11.8`, which self-reports as MariaDB Connector/C 3.4.9 via `mysql_get_client_version()` -- the version numbering this code path actually branches on):

```
Before fix:
  SSL_MODE_VERIFY_CA = 0, SSL_MODE_PREFERRED = 0  (collision)
  ssl_mode: :verify_ca + wrong CA -> CONNECTED (bug)

After fix:
  SSL_MODE_VERIFY_CA = 4  (distinct)
  ssl_mode: :verify_ca + wrong CA   -> Mysql2::Error::ConnectionError: TLS/SSL error: self-signed certificate
  ssl_mode: :verify_ca + correct CA -> connects normally, ssl_cipher=TLS_AES_256_GCM_SHA384
```

## Test plan

- [x] `bundle exec rake compile` -- clean (both MySQL and MariaDB Connector/C)
- [x] `bundle exec rubocop` -- clean
- [x] `bundle exec rspec` -- 501 examples, 0 failures
- [x] Extended the existing per-`ssl_mode` coverage loop to include `verify_ca` on the non-`FULL_SSL_MODE_SUPPORT` (MariaDB) code path, so CI's MariaDB matrix jobs exercise this directly
- [x] Added a new regression spec that generates a throwaway self-signed CA at runtime and asserts `ssl_mode: :verify_ca` rejects it
- [x] Manually verified against a real MariaDB 11.8 server (see above) since this repo's local dev setup here links MySQL by default

Fixes #936.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
