### PR TITLE
Guard select_db()'s string argument across the GVL-released call

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1473,6 +1473,11 @@ static VALUE rb_mysql_client_select_db(VALUE self, VALUE db)
   if (rb_thread_call_without_gvl(nogvl_select_db, &args, RUBY_UBF_IO, 0) == Qfalse)
     rb_raise_mysql2_error(wrapper);
 
+  /* This originates as a Ruby VALUE, but we're using its C pointer
+   * directly -- keep the VALUE live on the stack so GC can't collect it
+   * while we drop the GVL to make a MySQL API call. */
+  (void)RB_GC_GUARD(db);
+
   return db;
 }
 

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -1404,6 +1404,35 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     it "should return the database switched to" do
       expect(@client.select_db("test_selectdb_1")).to eq("test_selectdb_1")
     end
+
+    it "should switch databases correctly under GC.stress with a name past Ruby's embedded-string threshold" do
+      # Regression coverage for #822: rb_mysql_client_select_db extracts a
+      # raw C pointer from the `db` String argument (StringValueCStr) and
+      # hands it to nogvl_select_db with the GVL released, without an
+      # RB_GC_GUARD -- the same hazard fixed elsewhere in this file (see
+      # #1504). Names at or past MRI's embedded-string length (23 bytes on
+      # 64-bit builds) move to a separately allocated buffer, which is what
+      # a premature GC could free out from under the still-in-use pointer;
+      # shorter, embedded names don't have a separate buffer to free, which
+      # is why this was so hard to pin down originally. A freshly allocated,
+      # unfrozen String is used each iteration so nothing else roots it.
+      long_name = "test_selectdb_stress_#{'x' * 10}"
+      @client.query("DROP DATABASE IF EXISTS #{long_name}")
+      @client.query("CREATE DATABASE #{long_name}")
+
+      begin
+        GC.stress = true
+        20.times do
+          name = long_name.dup
+          @client.select_db(name)
+          expect(@client.query("SELECT DATABASE() AS d").first["d"]).to eq(long_name)
+        end
+      ensure
+        GC.stress = false
+        @client.query("USE test")
+        @client.query("DROP DATABASE IF EXISTS #{long_name}")
+      end
+    end
   end
 
   context 'database' do


### PR DESCRIPTION
## Summary

`rb_mysql_client_select_db` extracts a raw C pointer from the `db` argument (`StringValueCStr`) and hands it to `nogvl_select_db` through `rb_thread_call_without_gvl` -- which releases the GVL -- without an `RB_GC_GUARD`. Same hazard class as the one just fixed in `rb_mysql_connect` (#1504): if GC collects `db`'s String while `nogvl_select_db` is still reading through the stale pointer, that's a use-after-free.

Audited every other `StringValueCStr`/`RSTRING_PTR` call site in this file for the same pattern: this is the only other one that hands a raw pointer to a `rb_thread_call_without_gvl`-wrapped call without a guard. Everything else either already has one (the query `sql` argument) or never releases the GVL at all (`mysql_real_escape_string`, the `mysql_options`-setting code, and the SSL config calls are all called directly, synchronously, with no window for GC to run concurrently).

## Why this might be #822

This is a strong candidate for the root cause of #822, an old, never-resolved "malloc/assertion fails when db name is of length 25" report. MRI's embedded-string optimization stores strings under ~23 bytes (64-bit builds) directly inside the `RString` struct; at or past that length, a separate heap buffer is allocated -- exactly the allocation a premature GC would free out from under this function's still-in-use raw pointer, while a shorter, embedded name has no separate buffer to free. That the crash was so hard to reproduce reliably back then is also consistent with this class of bug: `db` is read again at `return db`, after the risky call, unlike the arguments fixed in #1504 that were never touched again post-extraction -- that later use can accidentally keep the VALUE alive depending on compiler optimization and register allocation, which is exactly the kind of inconsistent, hard-to-pin-down behavior #822's original investigators described.

## Changes

- `ext/mysql2/client.c`: add `RB_GC_GUARD(db)` after the GVL-released call, matching the fix and comment style used in #1504.
- `spec/mysql2/client_spec.rb`: regression spec exercising `select_db` under `GC.stress` with a freshly allocated, unfrozen database name at MRI's embedded-string length threshold, verifying every switch lands on the correct database.

## Test plan

- [x] New regression spec added and passing
- [ ] Could not get a reliable local repro of an actual crash either with or without this fix (`GC.stress` alone didn't reproduce it on the old code either) -- consistent with the original #822 thread's own experience that this needed very specific, hard-to-pin-down conditions even under valgrind. The fix follows from the established pattern in this file and the audit above, not from a reproduced crash.
- [x] Full `spec/` suite passes (501 examples, 0 failures)
- [x] rubocop clean

Possibly fixes #822.

🤖 Generated with [Claude Code](https://claude.com/claude-code)