### PR TITLE
Build array rows with one rb_ary_new4 instead of per-cell pushes

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -84,6 +84,12 @@ typedef struct {
    * per row. Changing it mid-iteration therefore no longer affects later rows
    * of that same call; the next #each call observes the new value. */
   rb_encoding *default_internal_enc;
+  /* Array-mode cell scratch: one slot per field, ALLOCV-allocated (so the
+   * VALUEs written into it are GC-visible) once per #each call and reused for
+   * every row. Each row's cells are cast into it and the row is built with a
+   * single rb_ary_new4 instead of one rb_ary_push per cell. NULL in hash mode
+   * and when the fetch functions can never run (freed result). */
+  VALUE *rowScratch;
 } result_each_args;
 
 extern VALUE mMysql2, cMysql2Client, cMysql2Error;
@@ -904,7 +910,7 @@ static void rb_mysql_result_alloc_result_buffers(VALUE self, MYSQL_FIELD *fields
 
 static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, const result_each_args *args)
 {
-  VALUE rowVal;
+  VALUE rowVal = Qnil;
   unsigned int i = 0;
 
   rb_encoding *default_internal_enc;
@@ -926,9 +932,7 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
     wrapper->numberOfFields = mysql_num_fields(wrapper->result);
     wrapper->fields = rb_ary_new2(wrapper->numberOfFields);
   }
-  if (args->asArray) {
-    rowVal = rb_ary_new2(wrapper->numberOfFields);
-  } else {
+  if (!args->asArray) {
 #ifdef HAVE_RB_HASH_NEW_CAPA
     rowVal = rb_hash_new_capa(wrapper->numberOfFields);
 #else
@@ -1146,10 +1150,14 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
     }
 
     if (args->asArray) {
-      rb_ary_push(rowVal, val);
+      args->rowScratch[i] = val;
     } else {
       rb_hash_aset(rowVal, field, val);
     }
+  }
+
+  if (args->asArray) {
+    rowVal = rb_ary_new4(wrapper->numberOfFields, args->rowScratch);
   }
 
   return rowVal;
@@ -1174,7 +1182,7 @@ static int decimal_str_is_zero(const char *str) {
 
 static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const result_each_args *args)
 {
-  VALUE rowVal;
+  VALUE rowVal = Qnil;
   MYSQL_ROW row;
   unsigned int i = 0;
   unsigned long * fieldLengths;
@@ -1218,7 +1226,6 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
      * first fetched row and an empty result set stays untouched, exactly
      * as it was when the (never-entered) cell loop did the materializing. */
     rb_mysql_result_materialize_field_names(self, args->symbolizeKeys);
-    rowVal = rb_ary_new2(wrapper->numberOfFields);
   } else {
     /* Pre-size to the column count so a row with more than the default
      * number of entries does not have to rehash while being built. */
@@ -1254,10 +1261,13 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
       }
 
       if (args->asArray) {
-        rb_ary_push(rowVal, val);
+        args->rowScratch[i] = val;
       } else {
         rb_hash_aset(rowVal, field, val);
       }
+    }
+    if (args->asArray) {
+      rowVal = rb_ary_new4(wrapper->numberOfFields, args->rowScratch);
     }
     return rowVal;
   }
@@ -1478,17 +1488,20 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
           break;
       }
       if (args->asArray) {
-        rb_ary_push(rowVal, val);
+        args->rowScratch[i] = val;
       } else {
         rb_hash_aset(rowVal, field, val);
       }
     } else {
       if (args->asArray) {
-        rb_ary_push(rowVal, Qnil);
+        args->rowScratch[i] = Qnil;
       } else {
         rb_hash_aset(rowVal, field, Qnil);
       }
     }
+  }
+  if (args->asArray) {
+    rowVal = rb_ary_new4(wrapper->numberOfFields, args->rowScratch);
   }
   return rowVal;
 }
@@ -1704,6 +1717,8 @@ static VALUE rb_mysql_result_each_(VALUE self,
 
 static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
   result_each_args args;
+  VALUE scratch_holder = 0;
+  VALUE rows;
   VALUE opts, (*fetch_row_func)(VALUE, MYSQL_FIELD *fields, const result_each_args *args);
   ID db_timezone, app_timezone;
   int symbolizeKeys, asArray, castBool, cacheRows;
@@ -1888,13 +1903,29 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
    * result_each_args. */
   args.default_internal_enc = rb_default_internal_encoding();
 
+  /* See the field's comment in result_each_args. A freed result only
+   * replays cached rows (or raises), never fetches, so wrapper->result is
+   * valid whenever the scratch is allocated -- and the fetch functions only
+   * touch the scratch after their own freed-result guards pass. A raise or
+   * break during iteration skips the ALLOCV_END below and leaks the
+   * heap-allocated form of the buffer until GC reclaims scratch_holder;
+   * that is the standard ALLOCV trade, bounded to one buffer per raised
+   * iteration because the allocation is per-#each, not per-row. */
+  args.rowScratch = NULL;
+  if (asArray && !wrapper->resultFreed) {
+    args.rowScratch = ALLOCV_N(VALUE, scratch_holder, mysql_num_fields(wrapper->result));
+  }
+
   if (wrapper->stmt_wrapper) {
     fetch_row_func = rb_mysql_result_fetch_row_stmt;
   } else {
     fetch_row_func = rb_mysql_result_fetch_row;
   }
 
-  return rb_mysql_result_each_(self, fetch_row_func, &args);
+  rows = rb_mysql_result_each_(self, fetch_row_func, &args);
+  ALLOCV_END(scratch_holder);
+
+  return rows;
 }
 
 /* call-seq:

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -186,6 +186,45 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
       end
     end
 
+    context "when building array rows" do
+      # Array rows are assembled from a per-#each scratch buffer, one slot
+      # per field, rather than pushed cell by cell. These pin the scratch
+      # bookkeeping: every slot lands in field order, NULL slots are written
+      # (not carried over from the previous row), and a mid-row cast raise
+      # leaves the connection usable.
+      let(:width) { 40 }
+      let(:wide_sql) { "SELECT #{Array.new(width) { |i| "#{i} AS c#{i}" }.join(', ')}" }
+
+      it "should yield every cell in field order for wide rows" do
+        expect(@client.query(wide_sql, as: :array).first).to eql((0...width).to_a)
+      end
+
+      it "should yield every cell in field order for wide rows without casting" do
+        expect(@client.query(wide_sql, as: :array, cast: false).first).to eql((0...width).map(&:to_s))
+      end
+
+      it "should yield every cell in field order for wide streaming rows" do
+        rows = []
+        @client.query(wide_sql, as: :array, stream: true, cache_rows: false).each { |row| rows << row }
+        expect(rows).to eql([(0...width).to_a])
+      end
+
+      it "should not carry cells over between rows" do
+        rows = @client.query("SELECT 1 AS a, NULL AS b UNION SELECT NULL, 2", as: :array).to_a
+        expect(rows).to eql([[1, nil], [nil, 2]])
+      end
+
+      it "should leave the connection usable after a cast error raised mid-row" do
+        client = new_client
+        client.query("SET SESSION sql_mode = ''")
+        client.query("CREATE TEMPORARY TABLE mysql2_batched_row_test (d DATETIME)")
+        client.query("INSERT INTO mysql2_batched_row_test VALUES ('1972-00-27 00:00:00')")
+        expect { client.query("SELECT 1 AS a, d FROM mysql2_batched_row_test", as: :array).each }.to \
+          raise_error(Mysql2::Error, "Invalid date in field 'd': 1972-00-27 00:00:00")
+        expect(client.query("SELECT 1", as: :array).first).to eql([1])
+      end
+    end
+
     it "should cache previously yielded results by default" do
       expect(@result.first.object_id).to eql(@result.first.object_id)
     end

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -129,6 +129,7 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
     stmt = @client.prepare 'SELECT 1 AS a, NULL AS b UNION SELECT NULL, 2'
     expect(stmt.execute(as: :array).to_a).to eq([[1, nil], [nil, 2]])
   end
+
   it "should raise TypeError naming the parameter index, class, and value for an unsupported bind type" do
     stmt = @client.prepare 'SELECT ?, ?'
 

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -119,6 +119,17 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
     expect(stmt.execute(1, as: :array).first).to eq([1])
   end
 
+  it "should yield every cell in field order for wide array rows" do
+    width = 40
+    stmt = @client.prepare "SELECT #{Array.new(width) { |i| "#{i} AS c#{i}" }.join(', ')}"
+    expect(stmt.execute(as: :array).first).to eq((0...width).to_a)
+  end
+
+  it "should not carry array row cells over between rows" do
+    stmt = @client.prepare 'SELECT 1 AS a, NULL AS b UNION SELECT NULL, 2'
+    expect(stmt.execute(as: :array).to_a).to eq([[1, nil], [nil, 2]])
+  end
+
   it "should keep its result after other query" do
     @client.query 'USE test'
     @client.query 'CREATE TABLE IF NOT EXISTS mysql2_stmt_q(a int)'

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -129,7 +129,6 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
     stmt = @client.prepare 'SELECT 1 AS a, NULL AS b UNION SELECT NULL, 2'
     expect(stmt.execute(as: :array).to_a).to eq([[1, nil], [nil, 2]])
   end
-  
   it "should raise TypeError naming the parameter index, class, and value for an unsupported bind type" do
     stmt = @client.prepare 'SELECT ?, ?'
 


### PR DESCRIPTION
Proposed in #1514.

Array-mode rows were built cell by cell: rb_ary_new2(numberOfFields) up front, then one rb_ary_push per cell, in all three fetch loops (the text cast-none loop, the text general loop, and the binary-protocol stmt loop). Each push re-pays a capacity check, a frozen check, and a per-element write barrier, N times per row, even though the final length is known before the first cell is cast.

Now each row's cells are cast into a VALUE scratch buffer and the row is built with a single rb_ary_new4(numberOfFields, scratch): exact-capacity allocation, one bulk copy, one write-barrier pass. rb_ary_new4 is the long-stable alias of rb_ary_new_from_values -- the modern name only exists on Ruby 2.1+ while the gemspec floor is 2.0.0, so the alias is the one spelling that compiles across the entire supported range; it matches the rb_ary_new2 spelling already used throughout this file, and it carries no deprecation attribute on any current Ruby or on ruby/ruby master (it is a plain macro alias, same status as rb_ary_new2). trilogy made precisely this change in trilogy#280, and pg builds its rows the same way (pg_result.c, VALUE scratch + rb_ary_new4).

The scratch is allocated once per #each call, not per row, in rb_mysql_result_each -- ALLOCV_N(VALUE, holder, mysql_num_fields(...)), so it is alloca for narrow results and a GC-visible imemo_tmpbuf beyond that; either way the VALUEs parked in it between construction and the row build are conservatively marked and survive (and are pinned across) a mid-row GC. Hash mode is untouched: rb_hash_aset has no batch equivalent, and the rb_hash_new_capa pre-sizing already took the hash-side win. Nothing in the scratch outlives the call: the buffer is released with ALLOCV_END when rb_mysql_result_each_ returns.

Safety cases, called out explicitly:

* Freed results: the scratch is only allocated when !wrapper->resultFreed, so mysql_num_fields never touches a freed MYSQL_RES; a result freed from inside the iteration block is caught by the fetch functions' existing freed-result guards before any scratch write.
* Mid-row raises (invalid DATETIME/DATE cast, stmt fetch error) and a `break` from the block skip ALLOCV_END and leak the heap form of the buffer until GC reclaims the holder. That is the standard ALLOCV trade, and it is the trade trilogy shipped in trilogy#280: its merged loops raise Trilogy::CastError mid-row (cast.c invalid date/double arms) and return early past three ALLOCV buffers with no ALLOCV_END and no rb_ensure. pg sidesteps the question structurally -- its scratch is a per-row stack VLA (PG_VARIABLE_LENGTH_ARRAY), which unwinds for free but re-pays the allocation every row. Here the leak is bounded to one buffer per raised iteration precisely because the allocation is per-#each rather than per-row, and is disclosed rather than armored with rb_ensure.
* Rows are byte-identical: every slot is written on every row (including explicit Qnil for NULL cells), so nothing bleeds between rows.

Specs: wide-row (40-column) field-order parity through the text-cast, text-cast:false, streaming, and prepared-statement paths; a NULL-interleave pin that catches stale scratch slots; and a mid-row cast raise (invalid date via sql_mode='') followed by a live query on the same connection. Verified the specs bite: reversing the scratch fill order fails all six parity/interleave pins (the mid-row-raise spec is a regression guard for the leak path and passes on master too, as expected).

Benchmark: wide array-mode rows (20,000 rows x 40 columns: 20 INT + 20 VARCHAR(16)), `each {}` in array mode, three runs per arm alternating base/branch, min of 5 timings per sample, 15 samples per run, per-run median (range) in ms per pass. AMD Ryzen 9 7950X, Arch Linux x86_64, Ruby 4.0.6, MySQL 9.6.0 (Docker, TCP loopback), client libmariadb 12.3.2, machine load < 1.5 for every run:

| mode        | arm          | run 1               | run 2               | run 3               |
|-------------|--------------|---------------------|---------------------|---------------------|
| text cast   | base b4aff39 | 45.98 (45.63-46.40) | 45.93 (45.47-46.66) | 45.65 (45.33-45.97) |
| text cast   | this patch   | 42.46 (42.27-42.75) | 41.67 (41.49-42.35) | 41.85 (41.59-42.24) |
| cast: false | base b4aff39 | 50.02 (49.74-51.71) | 49.82 (49.45-50.39) | 49.76 (49.32-50.19) |
| cast: false | this patch   | 45.50 (45.23-45.85) | 45.41 (44.84-45.78) | 45.26 (45.04-46.09) |
| prepared    | base b4aff39 | 46.35 (45.98-47.23) | 45.47 (44.72-46.21) | 40.87 (40.50-41.19) |
| prepared    | this patch   | 42.09 (41.92-42.35) | 41.41 (41.01-42.22) | 38.89 (38.73-39.67) |

Median of medians: text cast 45.93 -> 41.85 ms (-8.9%, 57.4 -> 52.3 ns per value), cast: false 49.82 -> 45.41 ms (-8.9%), prepared 45.47 -> 41.41 ms (-8.9%). Within every pair the branch range sits entirely below the base range. One drift note, disclosed: the prepared-path base dropped to ~41 ms in run 3 (both arms of that pair ran faster); the branch still beat it pairwise with no overlap (-4.8% for that pair).

Full suite: 509 examples, 0 failures, 10 pending (SSL-gated), RuboCop clean. Ruby 4.0.6, MySQL 9.6 (Homebrew, libmysqlclient), macOS arm64.
