### PR TITLE
Result#query_time: time the server round trip in C on a monotonic clock

### DIFF
--- a/README.md
+++ b/README.md
@@ -715,6 +715,19 @@ NOTE: Because of the way MySQL's query API works, this method will block until t
 So if you really need things to stay async, it's best to just monitor the socket with something like EventMachine.
 If you need multiple query concurrency take a look at using a connection pool.
 
+### Query timing
+
+Every `Mysql2::Result` carries the server round trip that produced it, measured in C on a monotonic clock:
+
+``` ruby
+result = client.query("SELECT * FROM table")
+result.query_time # => 0.000542 (Float seconds)
+```
+
+The bracket opens when the command is written to the connection and closes when its first response has been fully read. Server execution and network time to the first response are in; buffering the remaining rows, casting values into Ruby objects, and GVL waits after the first response are out -- so it answers "how slow was the server?" without the noise a Ruby-level stopwatch around `#query` picks up. The reading is the round trip as observed by the calling thread: on a quiet process it matches the wire, while under heavy GVL contention it includes time the thread spent waiting to be rescheduled mid-round-trip, like any thread-observed timing in CRuby.
+
+For a query issued with `:async => true` the bracket closes inside `#async_result`, so time between the response becoming readable and that call is included. `#query_time` is `nil` when no reading applies: the second and later result sets of a multi-statement command, retrieved via `#store_result`.
+
 ### Row Caching
 
 By default, Mysql2 will cache rows that have been created in Ruby (since this happens lazily).

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -6,6 +6,7 @@
 #ifndef _WIN32
 #include <sys/types.h>
 #include <sys/socket.h>
+#include <sys/time.h>
 #endif
 #ifndef _MSC_VER
 #include <unistd.h>
@@ -598,6 +599,7 @@ static VALUE allocate(VALUE klass) {
   wrapper->closed = 1; /* will be set false after calling mysql_real_connect */
   wrapper->refcount = 1;
   wrapper->affected_rows = -1;
+  wrapper->query_start = 0;
   wrapper->client = (MYSQL*)xmalloc(sizeof(MYSQL));
   wrapper->state = MYSQL2_CLIENT_IDLE;
   wrapper->pending_stmt_closes = NULL;
@@ -841,6 +843,16 @@ static VALUE rb_mysql_client_closed(VALUE self) {
   return CONNECTED(wrapper) ? Qfalse : Qtrue;
 }
 
+double mysql2_monotonic_now(void) {
+#if defined(HAVE_CLOCK_GETTIME) && defined(CLOCK_MONOTONIC)
+  struct timespec ts;
+  return clock_gettime(CLOCK_MONOTONIC, &ts) == 0 ? (double)ts.tv_sec + (double)ts.tv_nsec / 1e9 : -1;
+#else
+  struct timeval tv;
+  return gettimeofday(&tv, NULL) == 0 ? (double)tv.tv_sec + (double)tv.tv_usec / 1e6 : -1;
+#endif
+}
+
 /*
  * mysql_send_query is unlikely to block since most queries are small
  * enough to fit in a socket buffer, but sometimes large UPDATE and
@@ -868,14 +880,24 @@ static VALUE do_send_query(VALUE args) {
   return Qnil;
 }
 
+struct nogvl_read_query_result_args {
+  MYSQL *mysql;
+  /* Round-trip close stamp, taken while the GVL is still released: under
+   * contention, reacquisition means queueing behind every runnable thread,
+   * and a stamp taken after it would charge that wait to the server. */
+  double query_end;
+};
+
 /*
  * even though we did rb_thread_select before calling this, a large
  * response can overflow the socket buffers and cause us to eventually
  * block while calling mysql_read_query_result
  */
 static void *nogvl_read_query_result(void *ptr) {
-  MYSQL * client = ptr;
-  my_bool res = mysql_read_query_result(client);
+  struct nogvl_read_query_result_args *args = ptr;
+  my_bool res = mysql_read_query_result(args->mysql);
+
+  args->query_end = mysql2_monotonic_now();
 
   return (void *)(res == 0 ? Qtrue : Qfalse);
 }
@@ -909,8 +931,9 @@ static void *nogvl_use_result(void *ptr) {
 /* Shared by async_result (a query's first result set) and store_result (a
  * later one, from a multi-statement batch): fetch the current result set as
  * either streamed or fully-buffered, per :stream, track it on wrapper, and
- * wrap it as a Result. */
-static VALUE mysql2_fetch_result_set(VALUE self, mysql_client_wrapper *wrapper) {
+ * wrap it as a Result carrying query_elapsed as its #query_time (negative
+ * for none). */
+static VALUE mysql2_fetch_result_set(VALUE self, mysql_client_wrapper *wrapper, double query_elapsed) {
   MYSQL_RES *result;
   VALUE resultObj, current, is_streaming;
 
@@ -948,7 +971,7 @@ static VALUE mysql2_fetch_result_set(VALUE self, mysql_client_wrapper *wrapper) 
   current = rb_hash_dup(rb_ivar_get(self, intern_current_query_options));
   (void)RB_GC_GUARD(current);
   Check_Type(current, T_HASH);
-  resultObj = rb_mysql_result_to_obj(self, wrapper->encoding, current, result, Qnil);
+  resultObj = rb_mysql_result_to_obj(self, wrapper->encoding, current, result, Qnil, query_elapsed);
 
   /* Track the open cursor so a later command can force-drain it if it's
    * abandoned instead of exhausted -- see mysql2_abandon_active_stream. */
@@ -965,6 +988,8 @@ static VALUE mysql2_fetch_result_set(VALUE self, mysql_client_wrapper *wrapper) 
  * Returns the result for the last async issued query.
  */
 static VALUE rb_mysql_client_async_result(VALUE self) {
+  struct nogvl_read_query_result_args read_args;
+  double query_elapsed;
   GET_CLIENT(self);
 
   /* if we're not waiting on a result, do nothing */
@@ -972,14 +997,24 @@ static VALUE rb_mysql_client_async_result(VALUE self) {
     return Qnil;
 
   REQUIRE_CONNECTED(wrapper);
-  if ((VALUE)rb_thread_call_without_gvl(nogvl_read_query_result, wrapper->client, RUBY_UBF_IO, 0) == Qfalse) {
+  read_args.mysql = wrapper->client;
+  if ((VALUE)rb_thread_call_without_gvl(nogvl_read_query_result, &read_args, RUBY_UBF_IO, 0) == Qfalse) {
     /* an error occurred, mark this connection inactive */
     wrapper->active_fiber = Qnil;
     wrapper->state = MYSQL2_CLIENT_IDLE;
     rb_raise_mysql2_error(wrapper);
   }
 
-  return mysql2_fetch_result_set(self, wrapper);
+  /* The first response is now fully read: the stamp nogvl_read_query_result
+   * took closes the round-trip bracket opened when the command was written
+   * (rb_mysql_query). The store phase in mysql2_fetch_result_set stays
+   * outside it -- Result#query_time measures the server, not local row
+   * buffering. A negative stamp at either end means the clock call itself
+   * failed; pass the sentinel through so the reading is nil, not garbage. */
+  query_elapsed = (wrapper->query_start < 0 || read_args.query_end < 0)
+    ? -1 : read_args.query_end - wrapper->query_start;
+
+  return mysql2_fetch_result_set(self, wrapper, query_elapsed);
 }
 
 #ifndef _WIN32
@@ -1191,6 +1226,11 @@ static VALUE rb_mysql_query(VALUE self, VALUE sql, VALUE current) {
   mysql2_reap_pending_stmt_closes(wrapper);
 
   wrapper->state = MYSQL2_CLIENT_QUERYING;
+
+  /* Open the round-trip bracket that async_result closes once the first
+   * response has been fully read -- including the socket wait in do_query,
+   * which is where most of a slow query's time goes. */
+  wrapper->query_start = mysql2_monotonic_now();
 
 #ifndef _WIN32
   rb_ensure(do_send_query, (VALUE)&args, disconnect_query_if_incomplete, (VALUE)&args.completion);
@@ -1759,8 +1799,13 @@ static VALUE rb_mysql_client_store_result(VALUE self)
    * result set after the first even when the original query asked to
    * stream them (see #600). Also refreshes affected_rows: it's a
    * per-statement value at the C level, so it needs re-reading here too,
-   * not just by async_result for the batch's first statement. */
-  return mysql2_fetch_result_set(self, wrapper);
+   * not just by async_result for the batch's first statement.
+   *
+   * No round-trip reading: this result set's response was read and consumed
+   * by Client#next_result, which no bracket surrounds -- the number the
+   * original bracket produced belongs to the batch's first result set, not
+   * this one. So #query_time is nil here. */
+  return mysql2_fetch_result_set(self, wrapper, -1);
 }
 
 /* call-seq:

--- a/ext/mysql2/client.h
+++ b/ext/mysql2/client.h
@@ -64,6 +64,11 @@ typedef struct {
   int refcount;
   int closed;
   uint64_t affected_rows;
+  /* Monotonic stamp taken when the current command is written to the wire
+   * (rb_mysql_query). Lives on the wrapper because the bracket closes in a
+   * separate Ruby call on the async path: Client#query with :async returns
+   * right after the send, and #async_result reads the response later. */
+  double query_start;
   MYSQL *client;
   mysql2_client_state_t state;
   mysql2_pending_stmt_close *pending_stmt_closes;
@@ -86,6 +91,12 @@ extern const rb_data_type_t rb_mysql_client_type;
 
 void init_mysql2_client(void);
 void decr_mysql2_client(mysql_client_wrapper *wrapper);
+
+/* Seconds on a clock suitable for measuring elapsed intervals: monotonic
+ * (immune to wall-clock adjustment) where available, gettimeofday otherwise.
+ * Negative if the clock call itself fails. Calls no Ruby APIs, so it is
+ * safe inside rb_thread_call_without_gvl functions. */
+double mysql2_monotonic_now(void);
 
 /* Raises a Mysql2::Error built from the client's current mysql_error()/
  * mysql_errno()/mysql_sqlstate() -- the only correct way to surface a

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -52,6 +52,9 @@ have_func('rb_hash_new_capa', 'ruby.h')
 # 2.3+ (guarded so the funcall path remains available on anything older)
 have_func('rb_time_timespec_new', 'ruby.h')
 
+# Monotonic clock for Result#query_time (gettimeofday fallback otherwise)
+have_func('clock_gettime', 'time.h')
+
 ### Find OpenSSL library
 
 # User-specified OpenSSL if explicitly specified

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -2165,8 +2165,30 @@ static VALUE rb_mysql_result_count(VALUE self) {
   }
 }
 
+/* call-seq:
+ *    result.query_time # => Float seconds, or nil
+ *
+ * The server round trip that produced this result, as observed by the
+ * calling thread: seconds from the moment the command was written to the
+ * connection until its first response had been fully read, measured in C
+ * on a monotonic clock. Server execution and network time to the first
+ * response are in; buffering the remaining rows (the store phase), casting
+ * values into Ruby objects, and GVL waits after the first response are
+ * out. On a quiet process the reading matches the wire; under GVL
+ * contention it includes time the thread spent waiting to be rescheduled
+ * mid-round-trip, like any thread-observed timing in CRuby. For a query
+ * issued with :async the bracket closes inside Client#async_result, so
+ * time between the response becoming readable and that call is included.
+ * nil when no reading applies -- the second and later result sets of a
+ * multi-statement command (Client#store_result).
+ */
+static VALUE rb_mysql_result_query_time(VALUE self) {
+  GET_RESULT(self);
+  return wrapper->query_time < 0 ? Qnil : DBL2NUM(wrapper->query_time);
+}
+
 /* Mysql2::Result */
-VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_RES *r, VALUE statement) {
+VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_RES *r, VALUE statement, double query_time) {
   VALUE obj;
   mysql2_result_wrapper * wrapper;
 
@@ -2202,6 +2224,7 @@ VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_
    * A plain uint copy: cannot raise, per the post-streaming-registration
    * lifecycle rules in client.c/statement.c. */
   wrapper->server_status = wrapper->client_wrapper->client->server_status;
+  wrapper->query_time = query_time;
   wrapper->result_buffers = NULL;
   wrapper->result_buffers_bound = 0;
   wrapper->is_null = NULL;
@@ -2258,6 +2281,7 @@ void init_mysql2_result(void) {
   rb_define_method(cMysql2Result, "free", rb_mysql_result_free_, 0);
   rb_define_method(cMysql2Result, "count", rb_mysql_result_count, 0);
   rb_define_method(cMysql2Result, "server_flags", rb_mysql_result_server_flags, 0);
+  rb_define_method(cMysql2Result, "query_time", rb_mysql_result_query_time, 0);
   rb_define_alias(cMysql2Result, "size", "count");
 
   intern_new          = rb_intern("new");

--- a/ext/mysql2/result.h
+++ b/ext/mysql2/result.h
@@ -2,7 +2,9 @@
 #define MYSQL2_RESULT_H
 
 void init_mysql2_result(void);
-VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_RES *r, VALUE statement);
+/* query_time is the round trip that produced this result in seconds
+ * (Result#query_time); pass a negative value when no reading applies. */
+VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_RES *r, VALUE statement, double query_time);
 
 /* Resolve a :force_encoding query option (an Encoding object or an encoding
  * name) to its Encoding object, in place in the given options hash, raising
@@ -71,6 +73,11 @@ typedef struct {
    * per-charset lookup, the binary branch, or the default_internal
    * conversion. */
   rb_encoding *forced_enc;
+  /* Seconds from the command being written to its first response being
+   * fully read, measured on a monotonic clock by the query/execute path;
+   * negative when no reading applies (e.g. Client#store_result results).
+   * Exposed as #query_time. */
+  double query_time;
   my_ulonglong numberOfFields;
   my_ulonglong numberOfRows;
   unsigned long lastRowProcessed;

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -252,14 +252,21 @@ static VALUE rb_mysql_stmt_field_count(VALUE self) {
   return UINT2NUM(mysql_stmt_field_count(stmt_wrapper->stmt));
 }
 
-static void *nogvl_stmt_execute(void *ptr) {
-  MYSQL_STMT *stmt = ptr;
+struct nogvl_stmt_execute_args {
+  MYSQL_STMT *stmt;
+  /* Round-trip close stamp, taken while the GVL is still released: under
+   * contention, reacquisition means queueing behind every runnable thread,
+   * and a stamp taken after it would charge that wait to the server. */
+  double query_end;
+};
 
-  if (mysql_stmt_execute(stmt)) {
-    return (void*)Qfalse;
-  } else {
-    return (void*)Qtrue;
-  }
+static void *nogvl_stmt_execute(void *ptr) {
+  struct nogvl_stmt_execute_args *args = ptr;
+  int rv = mysql_stmt_execute(args->stmt);
+
+  args->query_end = mysql2_monotonic_now();
+
+  return (void*)(rv == 0 ? Qtrue : Qfalse);
 }
 
 static void set_buffer_for_string(MYSQL_BIND* bind_buffer, unsigned long *length_buffer, VALUE string) {
@@ -349,6 +356,8 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
   VALUE resultObj;
   VALUE *params_enc = NULL;
   int is_streaming;
+  struct nogvl_stmt_execute_args execute_args;
+  double query_start, query_elapsed;
   rb_encoding *conn_enc;
 
   GET_STATEMENT(self);
@@ -588,11 +597,23 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
   // mysql2_enqueue_pending_stmt_close / mysql2_reap_pending_stmt_closes.
   wrapper->state = MYSQL2_CLIENT_QUERYING;
 
-  if ((VALUE)rb_thread_call_without_gvl(nogvl_stmt_execute, stmt, RUBY_UBF_IO, 0) == Qfalse) {
+  query_start = mysql2_monotonic_now();
+  execute_args.stmt = stmt;
+
+  if ((VALUE)rb_thread_call_without_gvl(nogvl_stmt_execute, &execute_args, RUBY_UBF_IO, 0) == Qfalse) {
     FREE_BINDS;
     wrapper->state = MYSQL2_CLIENT_IDLE;
     rb_raise_mysql2_stmt_error(stmt_wrapper);
   }
+
+  /* mysql_stmt_execute both writes the command and reads its first
+   * response, so the stamp nogvl_stmt_execute took closes the round-trip
+   * bracket. The metadata and store phases below stay outside it --
+   * Result#query_time measures the server, not local row buffering. A
+   * negative stamp at either end means the clock call itself failed; pass
+   * the sentinel through so the reading is nil, not garbage. */
+  query_elapsed = (query_start < 0 || execute_args.query_end < 0)
+    ? -1 : execute_args.query_end - query_start;
 
   FREE_BINDS;
 
@@ -629,7 +650,7 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
     wrapper->state = MYSQL2_CLIENT_STREAMING;
   }
 
-  resultObj = rb_mysql_result_to_obj(stmt_wrapper->client, wrapper->encoding, current, metadata, self);
+  resultObj = rb_mysql_result_to_obj(stmt_wrapper->client, wrapper->encoding, current, metadata, self, query_elapsed);
 
   /* Track the open cursor so a later command can force-drain it if it's
    * abandoned instead of exhausted -- see mysql2_abandon_active_stream. */

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -702,6 +702,46 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
     end
   end
 
+  context "#query_time" do
+    it "should report the server round trip in seconds as a Float" do
+      started = clock_time
+      result = @client.query "SELECT SLEEP(0.1)"
+      elapsed = clock_time - started
+
+      expect(result.query_time).to be_a(Float)
+      # SLEEP(0.1) can return a scheduler tick (~16ms on Windows) early, so the
+      # bound sits below the nominal sleep -- still orders of magnitude above a
+      # bracket that misses the socket wait, which measures ~0.2ms.
+      expect(result.query_time).to be >= 0.05
+      expect(result.query_time).to be <= elapsed
+    end
+
+    if RUBY_PLATFORM !~ /mingw|mswin/
+      it "should cover the wait for the response when the query is async" do
+        expect(@client.query("SELECT SLEEP(0.1)", async: true)).to be nil
+        result = @client.async_result
+
+        expect(result.query_time).to be >= 0.05
+      end
+    end
+
+    it "should be available before a streamed result's rows are read" do
+      result = @client.query "SELECT SLEEP(0.1)", stream: true, cache_rows: false
+
+      expect(result.query_time).to be >= 0.05
+      result.each.to_a
+    end
+
+    it "should be nil for later result sets of a multi-statement command" do
+      client = new_client(flags: Mysql2::Client::MULTI_STATEMENTS)
+      result = client.query "SELECT 1; SELECT 2"
+
+      expect(result.query_time).to be_a(Float)
+      expect(client.next_result).to be true
+      expect(client.store_result.query_time).to be nil
+    end
+  end
+
   context "streaming" do
     it "should maintain a count while streaming" do
       result = @client.query('SELECT 1', stream: true, cache_rows: false)

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -71,6 +71,28 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
     expect(rows).to eq([{ "1" => 1 }])
   end
 
+  it "should report the execute round trip as the result's query_time" do
+    statement = @client.prepare 'SELECT SLEEP(0.1)'
+    started = clock_time
+    result = statement.execute
+    elapsed = clock_time - started
+
+    expect(result.query_time).to be_a(Float)
+    # SLEEP(0.1) can return a scheduler tick (~16ms on Windows) early, so the
+    # bound sits below the nominal sleep -- still orders of magnitude above a
+    # bracket that misses the socket wait, which measures ~0.2ms.
+    expect(result.query_time).to be >= 0.05
+    expect(result.query_time).to be <= elapsed
+  end
+
+  it "should report query_time before a streamed execute's rows are read" do
+    statement = @client.prepare 'SELECT SLEEP(0.1)'
+    result = statement.execute(stream: true, cache_rows: false)
+
+    expect(result.query_time).to be >= 0.05
+    result.each.to_a
+  end
+
   it "should keep fields and field_types accessible for exhausted empty results" do
     statement = @client.prepare 'SELECT 1 AS only_col WHERE 1 = 0'
     result = statement.execute


### PR DESCRIPTION
Proposed in #1512.

There is no timing anywhere in ext/ or lib/. Every consumer that wants query latency wraps Client#query in Ruby-level Process.clock_gettime pairs (Active Record's log does exactly this), which blends three signals -- server round trip, Ruby row materialization, and GVL contention -- into one number, at the cost of two Ruby calls per query. There is no way to ask "how slow was the *server*" from the outside. trilogy has carried exactly this since 2.x: two monotonic stamps bracketing trilogy_query_recv, with its socket waits inside the bracket and column/row reading outside, surfaced as Trilogy::Result#query_time.

Two clock_gettime(CLOCK_MONOTONIC) stamps bracket the round trip:

* Open when the command is written to the wire. For the text protocol the stamp lives on the client wrapper (client.c, rb_mysql_query), because on the async path the bracket closes in a separate Ruby call: Client#query with :async returns right after the send, and #async_result reads the response later.
* Close when the first response has been fully read: right after nogvl_read_query_result in async_result (client.c) -- downstream of the rb_wait_for_single_fd loop in do_query, so the socket wait where a slow query spends its time is inside the bracket. For prepared statements both ends sit in rb_mysql_stmt_execute (statement.c) around nogvl_stmt_execute, since mysql_stmt_execute performs both the write and the first read within one call; the cursor-open handshake of a streaming execute falls inside the same bracket.

The reading rides into the Result as a new rb_mysql_result_to_obj parameter (result.c/result.h) -- a plain double assignment, so nothing new can raise inside to_obj (the streaming lifecycle depends on that) -- and comes out as Result#query_time, a Float in seconds. Server execution and network time are in; the store phase, casting into Ruby objects, and GVL waits after the first response are out. On the :async path the bracket closes inside #async_result, so time between the response becoming readable and that call is included. Closing at readability instead is not implementable: the gem runs no code between the send and the #async_result call (the caller monitors the socket themselves), and a stamp taken at #async_result entry would still sit after that dwell while excluding the read of the response itself. Client#store_result passes a negative sentinel: second and later result sets of a multi-statement command arrive after the bracket that measured the original command closed, so their #query_time is nil rather than a number that belongs to a different result set. #1512 floats an optional second reading for the store phase -- a split trilogy's design can't produce -- which stays a follow-up: this parcel carries the one bracket both drivers agree on.

clock_gettime(CLOCK_MONOTONIC) sits behind a have_func probe (extconf.rb) with a gettimeofday fallback for platforms without it (on Windows, gettimeofday comes from ruby/win32.h). Monotonic means immune to wall-clock steps; on the fallback path a backwards step could yield a negative reading, which the reader reports as nil rather than a negative Float.

Cost: two vDSO clock_gettime calls per query, no allocation. Purely additive -- no existing behavior moves.

Specs: text protocol (SELECT SLEEP(0.1): Float, >= the server sleep, <= a Ruby-level wall bracket around the whole call), async (>= the sleep; non-Windows only, where :async is real), streaming (reading available before any row is read), prepared statements (same three assertions as text), prepared streaming (reading available before the cursor's rows are fetched), and multi-statement (first result carries a Float, store_result nil). Verified they bite: re-stamping the open right before nogvl_read_query_result -- excluding the socket wait -- fails the text and streaming specs; passing the sentinel from statement.c fails the statement specs; passing it from only the streaming execute branch fails exactly the prepared-streaming spec; passing a number from store_result fails the nil spec; a reader hardwired to nil fails everything else, including async. The gettimeofday fallback is not exercised in CI -- every CI platform has CLOCK_MONOTONIC -- but was exercised locally: an #undef at the guard compiles the fallback branch and passes all six specs. (Disabling the extconf probe alone doesn't reach it: ruby/config.h defines HAVE_CLOCK_GETTIME on its own wherever Ruby's build found the function, which also means the probe can only ever widen coverage, not lose it.)

Full suite: 508 examples, 0 failures, 10 pending (SSL-gated), RuboCop clean.
