### PR TITLE
Stop permanently pinning column-name symbols under symbolize_keys

### DIFF
--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -34,6 +34,9 @@ end
 have_func('rb_absint_size')
 have_func('rb_absint_singlebit_p')
 
+# 2.2+
+have_func('rb_check_symbol_cstr', 'ruby.h')
+
 # 2.7+
 have_func('rb_gc_mark_movable')
 

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -345,8 +345,15 @@ static VALUE rb_mysql_result_fetch_field(VALUE self, unsigned int idx, int symbo
 
     field = mysql_fetch_field_direct(wrapper->result, idx);
     if (symbolize_keys) {
+#ifdef HAVE_RB_CHECK_SYMBOL_CSTR
+      rb_field = rb_check_symbol_cstr(field->name, field->name_length, rb_utf8_encoding());
+      if (rb_field == Qnil) {
+        rb_field = rb_str_intern(rb_enc_str_new(field->name, field->name_length, rb_utf8_encoding()));
+      }
+#else
       rb_field = rb_intern3(field->name, field->name_length, rb_utf8_encoding());
       rb_field = ID2SYM(rb_field);
+#endif
     } else {
 #ifdef HAVE_RB_ENC_INTERNED_STR
       rb_field = rb_enc_interned_str(field->name, field->name_length, conn_enc);

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -180,6 +180,33 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
       end
     end
 
+    it "should return the same symbol key across results and against literals" do
+      first = @client.query("SELECT 1 AS sym_parity_col", symbolize_keys: true).first.keys.first
+      second = @client.query("SELECT 2 AS sym_parity_col", symbolize_keys: true).first.keys.first
+      expect(first).to eql(second)
+      expect(first).to eql(:sym_parity_col)
+    end
+
+    it "should not permanently pin symbols for dynamically-named columns" do
+      skip "dynamic symbols are only GC-able on Ruby 2.2+" if RUBY_VERSION < "2.2"
+
+      name = "sym_gc_col_#{rand(2**32)}"
+
+      # Run the query on its own thread so its stack -- and any stale
+      # references conservative scanning would find there -- is gone before
+      # the collection check below.
+      Thread.new do
+        @client.query("SELECT 1 AS #{name}", symbolize_keys: true).each { |_| }
+        nil
+      end.join
+
+      collected = 10.times.any? do
+        GC.start
+        Symbol.all_symbols.none? { |sym| sym.to_s == name }
+      end
+      expect(collected).to be true
+    end
+
     it "should be able to return results as an array" do
       @result.each(as: :array) do |row|
         expect(row).to be_an_instance_of(Array)


### PR DESCRIPTION
Proposed in #1515.

Fixes #1515.

Under `symbolize_keys: true`, every distinct column name is interned with `rb_intern3` (result.c:348), which creates a pinned symbol -- immortal, never collected. Aliased or generated column names (`SELECT x AS col_#{i}`, report builders, pivot queries) grow the symbol table without bound for the life of the process. This is the extension's sole dynamic intern site -- every other intern is an init-time static -- and both the text and binary protocols funnel through `rb_mysql_result_fetch_field`, so one fix covers everything. The string half was already fixed: non-symbolized names go through GC-able `rb_enc_interned_str` (result.c:352); the symbol path never got the same treatment.

Adopt pg's recipe (pg_result.c, `pg_cstr_to_sym`) at the one site:

* `rb_check_symbol_cstr(name, len, utf8)` returns the existing symbol if one is live -- static or dynamic -- without creating or pinning anything.
* On Qnil, build the name String and `rb_str_intern` it, creating a dynamic, GC-able symbol (GC-able since CRuby 2.2).

Guarded behind `#ifdef HAVE_RB_CHECK_SYMBOL_CSTR` (probed in extconf.rb; the function is 2.2+, the gem supports 2.0+) with the `rb_intern3` path kept as the fallback, matching the file's existing feature-guard style (`HAVE_RB_ENC_INTERNED_STR` sits directly below).

Semantics are unchanged where it matters: symbols are still cached per-Result in `wrapper->fields`, so the lookup runs once per column per result, and dynamic symbols are unique per content -- `:id` from one Result is identical to `:id` from another and to an `:id` literal in user code. Encoding normalization also matches `rb_intern3`: ASCII-only names produce US-ASCII symbols, multibyte names produce UTF-8 symbols (probed both against literals on the new build). A symbol used as a hash key stays alive as long as any row hash referencing it does; once the last reference drops, the GC may now reclaim it instead of never.

Evidence -- 10,000 uniquely-aliased `symbolize_keys` queries, then GC, `Symbol.all_symbols.size` delta (Ruby 4.0.6, MySQL 9.6, macOS arm64):

| build      | delta   |
|------------|---------|
| master     | +10,000 |
| this patch | 0       |

Specs:

* Cross-Result parity: the same aliased name yields `eql` symbol keys across two Results and against a literal -- exercising the `rb_check_symbol_cstr` hit path, since the literal already exists. This spec passes on master too, by design: it pins the semantics the swap must preserve rather than the fix itself.
* Collection: a randomly-named column fetched under `symbolize_keys` on a discarded thread (isolating its stack from conservative scanning) is absent from `Symbol.all_symbols` after GC -- exercising the miss path. Verified to fail against `rb_intern3`: reverting the result.c hunk fails this spec (symbol still present after 10 GC passes) and only this spec. Stable across 25 consecutive isolated runs under varied `RUBY_GC_*` tunings and repeated whole-file runs: the discarded thread plus the ten-pass GC loop absorb conservative-scanning luck.

Coverage limit disclosed: the `#else` fallback branch is the exact code it replaces and is what the verify-to-fail run compiled. On a real pre-2.2 Ruby every symbol is pinned, so the collection spec skips there via a `RUBY_VERSION` gate -- an exact proxy, since `rb_check_symbol_cstr` entered the public headers in 2.2.0 -- rather than fail against behavior the fallback cannot provide. No CI leg runs anything near that old; the oldest is 2.6.

Full suite: 504 examples, 0 failures, 10 pending (SSL-gated), RuboCop clean.
