### PR TITLE
Warn at connect time on incoherent or silently-ignored option pairs

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,7 +39,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 147
+  Max: 153
 
 # Offense count: 3
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -174,7 +174,28 @@ module Mysql2
 
     private
 
+    # Warns once per client, before connecting, about option combinations
+    # that are incoherent or silently ignored. Warnings only: the connection
+    # proceeds exactly as it would have without them.
+    def warn_incoherent_options
+      # The client key and certificate only take effect together. Given one
+      # without the other, libmysqlclient silently sends no client certificate
+      # and MariaDB Connector/C aborts the connection with a bare TLS error
+      # that never names the real problem.
+      # https://dev.mysql.com/doc/refman/en/using-encrypted-connections.html
+      warn ":sslkey and :sslcert only take effect together; alone, libmysqlclient sends no client certificate and MariaDB Connector/C fails to connect" \
+        if @query_options[:sslkey].nil? != @query_options[:sslcert].nil?
+
+      # Streaming results are never cached, so a client-wide :stream default
+      # overrides the :cache_rows default on every query (see the per-query
+      # warning in ext/mysql2/result.c).
+      warn ":cache_rows is ignored on a client with :stream enabled; pass cache_rows: false to acknowledge streaming semantics" \
+        if @query_options[:stream] && @query_options[:cache_rows]
+    end
+
     def check_and_clean_query_options
+      warn_incoherent_options
+
       if %i[user pass hostname dbname db sock].any? { |k| @query_options.key?(k) }
         warn "============= WARNING FROM mysql2 ============="
         warn "The options :user, :pass, :hostname, :dbname, :db, and :sock are deprecated and will be removed at some point in the future."

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -247,6 +247,46 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     end
   end
 
+  context "option coherence warnings" do
+    it "warns when :sslkey is given without :sslcert" do
+      expect do
+        begin
+          new_client(sslkey: '/path/to/client-key.pem')
+        rescue Mysql2::Error
+          # MariaDB Connector/C rejects a lone key at connect; the warning precedes it.
+        end
+      end.to output(/:sslkey and :sslcert only take effect together/).to_stderr
+    end
+
+    it "warns when :sslcert is given without :sslkey" do
+      expect do
+        begin
+          new_client(sslcert: '/path/to/client-cert.pem')
+        rescue Mysql2::Error
+          # MariaDB Connector/C rejects a lone certificate at connect; the warning precedes it.
+        end
+      end.to output(/:sslkey and :sslcert only take effect together/).to_stderr
+    end
+
+    it "warns when :stream is enabled with :cache_rows left on" do
+      expect do
+        new_client(stream: true)
+      end.to output(/:cache_rows is ignored on a client with :stream enabled/).to_stderr
+    end
+
+    it "does not warn when :stream is enabled with :cache_rows disabled" do
+      expect do
+        new_client(stream: true, cache_rows: false)
+      end.not_to output(/:cache_rows is ignored/).to_stderr
+    end
+
+    it "does not warn on a plain connection" do
+      expect do
+        new_client
+      end.not_to output(/:sslkey and :sslcert only take effect together|:cache_rows is ignored/).to_stderr
+    end
+  end
+
   def run_gc
     if defined?(Rubinius)
       GC.run(true)


### PR DESCRIPTION
Proposed in #1530.

Client#initialize massages its options silently, and the file's own TODO (lib/mysql2/client.rb:35) has said "stricter validation rather than silent massaging" for years. This ships the connect-time warning layer proposed there: two checks, each with its evidence cited in a comment beside it, warn-and-proceed only -- no connection behavior changes. They live in a private warn_incoherent_options called from check_and_clean_query_options, the file's existing warn-at-connect spot (deprecated key names already warn there), so each fires at most once per client, before connect:

* :sslkey and :sslcert given singly. The pair only takes effect together; alone, libmysqlclient sends no client certificate (MySQL Reference Manual, "Configuring MySQL to Use Encrypted Connections") while MariaDB Connector/C refuses the connection outright with a TLS error that never names the missing half (verified against Connector/C 3.4.9: "TLS/SSL error: No such file or directory" for a bogus lone key, "TLS/SSL error: no start line" for a real one). The warning precedes connect on both flavors, naming the silence on one and decoding the error on the other. nil-presence is the test (not key?), so an explicit sslkey: nil beside a real sslcert warns too, matching what ssl_set receives.

* Client-wide stream: true with :cache_rows left at its true default. Every query on such a client warns and coerces at materialization time (ext/mysql2/result.c:1828); the connect-time warning names the fix (cache_rows: false) once at the source instead. Per-query query(sql, stream: true) is untouched -- the check reads the connection-level defaults only.

Deliberately not included, per #1530's own sizing: no unknown-option-key notice (unbounded noise surface across adapters and forks), no Client.capabilities roster, no reconnect-vs-callable-password check (no callable passwords exist yet). A write_timeout/streaming pairing was considered and dropped: no issue or PR substantiates an incoherence there.

Also dropped, on review (see below): the :ssl_mode-on-MariaDB warning this PR originally led with, citing the #879/#936 enforcement gaps. #1506 closed those gaps in the extension itself -- verify_ca and verify_identity both map to MYSQL_OPT_SSL_VERIFY_SERVER_CERT on the MariaDB code path, enforced, no :sslverify required -- so the warning would have misfired on every correctly configured verification-mode MariaDB connection and prescribed a redundant option. The CLIENT_LIB_FLAVOR export went with it: its only consumer was that warning.

Behavior delta, disclosed: two new stderr warnings for configurations that were previously silent. Test suites that promote warnings to errors will surface them -- a one-line fix (cache_rows: false, or dropping the lone key/cert) in each case. Also disclosed: Metrics/ClassLength in .rubocop_todo.yml bumps 147 -> 153 for the new method, by hand as in #1482 (a full --regenerate-todo rewrites unrelated entries from RuboCop version drift); the cap stays sized to the class's current line count exactly, as before.

On coverage: the sslkey/sslcert specs tolerate a connect abort (rescue inside the expectation) because the warning fires before connect and the flavors then diverge as described above. Verified the specs bite: with the lib change reverted to master's, the three positive warning specs fail; restored, all 5 in the new context pass.

Full suite on Ruby 4.0.6, rebased on current master (includes #1506): libmysqlclient 8.0.46 (Homebrew) / MySQL 9.6 over a local socket, macOS arm64: 540 examples, 0 failures, 11 pending (SSL-gated), RuboCop clean.
