### PR TITLE
Raise TypeError for bind parameters no branch knows how to convert

### DIFF
--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -519,6 +519,22 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
             params_enc[i] = rb_val_as_string;
             params_enc[i] = rb_str_export_to_enc(params_enc[i], conn_enc);
             set_buffer_for_string(&bind_buffers[i], &length_buffers[i], params_enc[i]);
+          } else {
+            int state = 0;
+            VALUE inspect = rb_protect(rb_inspect, argv[i], &state);
+            if (!state && rb_str_strlen(inspect) > 40) {
+              inspect = rb_str_substr(inspect, 0, 40);
+              rb_str_cat2(inspect, "...");
+            }
+            /* An inspect that raised, or inspect output holding a NUL byte
+             * (which rb_raise's PRIsVALUE formatting rejects), still gets the
+             * TypeError -- just without the value. */
+            if (state || memchr(RSTRING_PTR(inspect), '\0', RSTRING_LEN(inspect))) {
+              rb_raise(rb_eTypeError, "can't bind parameter %lu: no conversion for %s",
+                       i + 1, rb_obj_classname(argv[i]));
+            }
+            rb_raise(rb_eTypeError, "can't bind parameter %lu: no conversion for %s (%" PRIsVALUE ")",
+                     i + 1, rb_obj_classname(argv[i]), inspect);
           }
           break;
       }

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -119,6 +119,67 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
     expect(stmt.execute(1, as: :array).first).to eq([1])
   end
 
+  it "should raise TypeError naming the parameter index, class, and value for an unsupported bind type" do
+    stmt = @client.prepare 'SELECT ?, ?'
+
+    expect { stmt.execute(1, :pending) }.to \
+      raise_error(TypeError, "can't bind parameter 2: no conversion for Symbol (:pending)")
+    expect { stmt.execute({ key: "value" }, 2) }.to \
+      raise_error(TypeError, "can't bind parameter 1: no conversion for Hash (#{{ key: 'value' }.inspect})")
+    expect { stmt.execute(Object.new, 2) }.to \
+      raise_error(TypeError, /\Acan't bind parameter 1: no conversion for Object \(#<Object:0x\h+>\)\z/)
+  end
+
+  it "should truncate long values in the unsupported bind type message" do
+    stmt = @client.prepare 'SELECT ?'
+
+    expect { stmt.execute(("a" * 60).to_sym) }.to \
+      raise_error(TypeError, "can't bind parameter 1: no conversion for Symbol (:#{'a' * 39}...)")
+  end
+
+  it "should keep the parameter index when the value's inspect itself raises, chaining the inspect error as the cause" do
+    stmt = @client.prepare 'SELECT ?, ?'
+    broken = Object.new
+    def broken.inspect
+      raise ArgumentError, "broken inspect"
+    end
+
+    expect { stmt.execute(1, broken) }.to raise_error(TypeError, "can't bind parameter 2: no conversion for Object") { |error|
+      expect(error.cause).to be_an(ArgumentError)
+      expect(error.cause.message).to eq("broken inspect")
+    }
+  end
+
+  it "should omit the value when its inspect contains a NUL byte" do
+    stmt = @client.prepare 'SELECT ?'
+    nul = Object.new
+    def nul.inspect
+      "nul\0byte"
+    end
+
+    expect { stmt.execute(nul) }.to \
+      raise_error(TypeError, "can't bind parameter 1: no conversion for Object")
+  end
+
+  it "should remain usable after an unsupported bind type raises" do
+    stmt = @client.prepare 'SELECT ? AS a'
+
+    expect { stmt.execute(:pending) }.to raise_error(TypeError)
+    expect(stmt.execute(1).first).to eq("a" => 1)
+  end
+
+  it "should raise for an unsupported bind type instead of writing zero to the table" do
+    @client.query 'USE test'
+    @client.query 'DROP TABLE IF EXISTS mysql2_stmt_bind_type_test'
+    @client.query 'CREATE TABLE mysql2_stmt_bind_type_test (int_test INT)'
+
+    stmt = @client.prepare("INSERT INTO mysql2_stmt_bind_type_test VALUES (?)")
+    expect { stmt.execute(:pending) }.to raise_error(TypeError)
+    expect(@client.query("SELECT * FROM mysql2_stmt_bind_type_test").to_a).to be_empty
+
+    @client.query 'DROP TABLE IF EXISTS mysql2_stmt_bind_type_test'
+  end
+
   it "should keep its result after other query" do
     @client.query 'USE test'
     @client.query 'CREATE TABLE IF NOT EXISTS mysql2_stmt_q(a int)'


### PR DESCRIPTION
Proposed in #1524.

Fixes the residual from #775, closes #1524.

The prepared-statement bind loop's `default:` arm (statement.c:464) is an if/else-if chain over Time/DateTime/Date/BigDecimal with no final else. `bind_buffers` is xcalloc'd (statement.c:405), so a parameter of any other class -- a Symbol, a Hash, a custom object -- sailed through as a zeroed MYSQL_BIND: buffer_type 0 (MYSQL_TYPE_DECIMAL), NULL buffer, zero length. The server received a zero-length DECIMAL and stored 0. No error, no warning: `stmt.execute(:pending)` wrote 0 to the column. This is the corruption reported in #775, where the consensus was that unhandled types should raise; the agreement never became a patch.

Now the chain ends in an else that raises TypeError naming the parameter index (1-based), the class, and the value's inspect truncated to 40 characters (statement.c:522-538):

```
TypeError: can't bind parameter 2: no conversion for Symbol (:pending)
```

TypeError rather than a Mysql2::Error subclass, deliberately. The failure is diagnosed client-side at bind time -- a programming error, not a database condition; nothing reaches the wire, so error_number/sql_state would be meaningless. It follows the convention in this gem and its neighbors: mysql2 already raises TypeError for a non-String query string (Check_Type), trilogy does the same for its argument-type failures, pg raises core TypeError/ArgumentError for client-side value-encoding failures (pg_coder.c) rather than PG::Error, and sqlite3-ruby raises RuntimeError ("can't prepare Symbol") rather than SQLite3::Exception. A core class also keeps this out of `rescue Mysql2::Error` reconnect-and-retry handlers, which should not retry a permanent bug. The one in-gem counterexample -- this same function's bind-count mismatch raises Mysql2::Error -- is longstanding API, left untouched.

Zero cost on the success path: the new branch occupies the position where the loop previously fell through to the zeroed bind, and no other branch changes. The message is defensive about hostile inspects. Truncation counts characters, not bytes, so multibyte output cannot be split mid-character. The one rb_inspect call is wrapped in rb_protect (signature-compatible, no helper needed), so an object whose #inspect itself raises still gets the TypeError with index and class -- the value is omitted and the inspect's own error is chained as the cause (Ruby 2.1+ semantics; on 2.0 the TypeError simply has no cause). Inspect output containing a NUL byte is likewise omitted rather than interpolated: rb_raise's PRIsVALUE path goes through StringValueCStr (ruby__sfvextra in sprintf.c) and raises "string contains null byte" on embedded NULs, which would replace the TypeError and lose the index. Non-ASCII encodings are safe without guarding -- rb_inspect escapes ASCII-incompatible strings, and the message formatter transcodes with replacement rather than raising. asyncpg, the precedent for this annotation, leaves repr unprotected and loses the argument index when it raises; here the corner costs four lines to close, so it is closed.

The behavior change is the point, and it is broader than the obvious Symbol/Hash cases: the Time/DateTime/Date/BigDecimal branches match with CLASS_OF (exact class), so subclasses of those -- and duck types like ActiveSupport::TimeWithZone -- were also silently zeroed and now raise. Any caller who depended on an unhandled type binding as 0 gets a new exception; per the #775 consensus, that dependence is the bug this fixes.

One disclosed limit: a raise inside the bind loop leaks the buffers allocated for earlier parameters -- FREE_BINDS only covers post-loop paths. The raise-capable calls already in the loop (rb_str_export_to_enc, the Time/Date rb_funcall chains) have the same leak, so this raise makes nothing worse; #1529 fixes the class by construction and is deliberately not folded in here.

Every C API the new arm uses exists at the gemspec's Ruby 2.0.0 floor: rb_protect, rb_inspect, rb_str_strlen, rb_str_substr, rb_str_cat2, and rb_obj_classname are all declared in v2.0.0's include/ruby/intern.h; PRIsVALUE is defined in v2.0.0's ruby.h and handled by rb_raise's formatter in v2.0.0's sprintf.c. The %lu specifier matches the loop index's unsigned long, including on LLP64 Windows.

Specs: message content for Symbol (exact), Hash (exact, via interpolated inspect so the assertion tracks the running Ruby's hash-inspect format), and Object (pattern); 40-character truncation with the "..." marker; the raising-inspect corner (index and class preserved, cause chained); the NUL-in-inspect corner (value omitted); statement reusability after the raise; and a regression spec asserting the INSERT path raises and the table stays empty where it previously gained a zero row. The four behavior specs fail against master (the INSERT writes 0, SELECTs return the zeroed bind) -- verified by stashing the C change, recompiling, and running them.

Full suite: 508 examples, 0 failures, 10 pending (SSL-gated). RuboCop clean. Ruby 4.0.6, MySQL 9.6, macOS arm64.
