### PR TITLE
README: document ASCII-8BIT encodings for non-text columns [skip ci]

### DIFF
--- a/README.md
+++ b/README.md
@@ -638,6 +638,16 @@ emoji; `utf8mb4` can. See the
 docs for the full list of supported character sets and how they interact
 with column- and server-level collations.
 
+Under `:cast => false` and `:cast => :fast`, values from numeric and
+date/time columns come back as `ASCII-8BIT`-encoded Strings. The
+connection's encoding only applies to text columns. Numeric and
+date/time values are always plain ASCII, so this is safe for
+concatenation, comparison, and interpolation with other
+ASCII-compatible character sets, including ISO-8859 and UTF-8. Ruby's
+`Encoding::ASCII-8BIT` and `Encoding::Binary` are aliases of one
+another; it's the same encoding used for `BLOB`, `BINARY`, and
+`VARBINARY` columns too.
+
 ### Forcing a string encoding
 
 Pass `:force_encoding` to `Client#query` or `Statement#execute` to retag string results with an encoding of your choosing:


### PR DESCRIPTION
## Summary

Documents a long-standing, non-obvious behavior: under `:cast => false` and `:cast => :fast`, values from numeric and date/time columns come back `ASCII-8BIT`-encoded rather than tagged with the connection's encoding.

## Why

MySQL's protocol reports no character set at all for non-character columns -- the same `charsetnr` signal it uses for genuine `BLOB`/`BINARY` data (traced to `ext/mysql2/result.c`'s `mysql2_set_field_string_encoding`, which keys off `field.charsetnr == 63`). mysql2 has no way to distinguish "this is a number" from "this is binary data" using that signal alone, so it tags both `ASCII-8BIT`.

This isn't a functional bug: numeric and date/time values are always plain ASCII, so `ASCII-8BIT` tagging is safe for ordinary string operations (concatenation, comparison, interpolation) against any ASCII-compatible encoding -- Ruby's own encoding-compatibility rules already cover this. It only surprises code that inspects `.encoding` directly.

## Changes

- `README.md`: new paragraph in the "Character encoding" section (added by #1557) explaining this.

## Test plan

- [x] Docs only, no code changes

Fixes #1066.

🤖 Generated with [Claude Code](https://claude.com/claude-code)