### PR TITLE
Do not read a field name past its NUL terminator

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1,6 +1,7 @@
 #include <mysql2_ext.h>
 
 #include <limits.h>
+#include <string.h>
 
 #include "mysql_enc_to_ruby.h"
 #define MYSQL2_CHARSETNR_SIZE (sizeof(mysql2_mysql_enc_to_rb)/sizeof(mysql2_mysql_enc_to_rb[0]))
@@ -352,6 +353,8 @@ static VALUE rb_mysql_result_fetch_field(VALUE self, unsigned int idx, int symbo
     MYSQL_FIELD *field = NULL;
     rb_encoding *default_internal_enc = rb_default_internal_encoding();
     rb_encoding *conn_enc = wrapper->conn_enc;
+    size_t name_length;
+    const char *name_end;
 
     /* A name that was never cached has to be read from the result, which the
      * force-free of an abandoned stream has already released. Hash-mode rows
@@ -366,24 +369,34 @@ static VALUE rb_mysql_result_fetch_field(VALUE self, unsigned int idx, int symbo
     }
 
     field = mysql_fetch_field_direct(wrapper->result, idx);
+
+    /* The C API defines MYSQL_FIELD.name as a NUL-terminated string, so
+     * nothing past the first NUL is part of the name -- but the library can
+     * deliver a name_length that counts bytes beyond it. A long expression
+     * name truncated under GROUP BY arrives here with name_length 257 for a
+     * 255-byte name: the terminator plus one arbitrary byte (#1288). Stop
+     * at the terminator, capped by name_length. */
+    name_end = memchr(field->name, '\0', field->name_length);
+    name_length = name_end ? (size_t)(name_end - field->name) : field->name_length;
+
     if (symbolize_keys) {
 #ifdef HAVE_RB_CHECK_SYMBOL_CSTR
-      rb_field = rb_check_symbol_cstr(field->name, field->name_length, rb_utf8_encoding());
+      rb_field = rb_check_symbol_cstr(field->name, name_length, rb_utf8_encoding());
       if (rb_field == Qnil) {
-        rb_field = rb_str_intern(rb_enc_str_new(field->name, field->name_length, rb_utf8_encoding()));
+        rb_field = rb_str_intern(rb_enc_str_new(field->name, name_length, rb_utf8_encoding()));
       }
 #else
-      rb_field = rb_intern3(field->name, field->name_length, rb_utf8_encoding());
+      rb_field = rb_intern3(field->name, name_length, rb_utf8_encoding());
       rb_field = ID2SYM(rb_field);
 #endif
     } else {
 #ifdef HAVE_RB_ENC_INTERNED_STR
-      rb_field = rb_enc_interned_str(field->name, field->name_length, conn_enc);
+      rb_field = rb_enc_interned_str(field->name, name_length, conn_enc);
       if (default_internal_enc && default_internal_enc != conn_enc) {
         rb_field = rb_str_to_interned_str(rb_str_export_to_enc(rb_field, default_internal_enc));
       }
 #else
-      rb_field = rb_enc_str_new(field->name, field->name_length, conn_enc);
+      rb_field = rb_enc_str_new(field->name, name_length, conn_enc);
       if (default_internal_enc && default_internal_enc != conn_enc) {
         rb_field = rb_str_export_to_enc(rb_field, default_internal_enc);
       }

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -1,5 +1,7 @@
 #include <mysql2_ext.h>
 
+#include <string.h>
+
 extern VALUE mMysql2, cMysql2Error;
 static VALUE cMysql2Statement, cBigDecimal, cDateTime, cDate;
 static VALUE sym_stream, intern_new_with_args, intern_each, intern_to_s, intern_merge_bang;
@@ -682,8 +684,15 @@ static VALUE rb_mysql_stmt_fields(VALUE self) {
 
   for (i = 0; i < field_count; i++) {
     VALUE rb_field;
+    const char *name_end;
+    size_t name_length;
 
-    rb_field = rb_str_new(fields[i].name, fields[i].name_length);
+    /* See the note on name_length in rb_mysql_result_fetch_field
+     * (result.c): the count can cross the name's NUL terminator. */
+    name_end = memchr(fields[i].name, '\0', fields[i].name_length);
+    name_length = name_end ? (size_t)(name_end - fields[i].name) : fields[i].name_length;
+
+    rb_field = rb_str_new(fields[i].name, name_length);
     rb_enc_associate(rb_field, conn_enc);
     if (default_internal_enc) {
      rb_field = rb_str_export_to_enc(rb_field, default_internal_enc);

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -396,6 +396,57 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
       expect(result.field_types.length).to eql(1)
     end
 
+    context "when the server truncates a long expression name" do
+      # A long un-aliased expression grouped over a real column gets its name
+      # truncated, and the client library can hand back a name_length that
+      # counts bytes past the truncated name's NUL terminator, leaving
+      # arbitrary trailing bytes on every name surface (#1288). These pin
+      # that a name stops at its terminator.
+      #
+      # The expected name is taken from Statement#fields for the same query
+      # rather than from the SQL text: it is the server's own rendering at
+      # the server's own truncation length, read through a metadata path
+      # whose byte count is not affected by this bug. On a stack whose
+      # client library counts the text-protocol length correctly these pass
+      # without exercising the fix.
+      before do
+        @client.query("CREATE TEMPORARY TABLE mysql2_long_names (created_at DATETIME)")
+        @client.query("INSERT INTO mysql2_long_names VALUES (NOW()), (NOW() - INTERVAL 1 DAY)")
+      end
+
+      let(:expression) do
+        "IF(#{(['1=1'] * 76).join(' AND ')}, mysql2_long_names.created_at, mysql2_long_names.created_at)"
+      end
+      let(:sql) { "SELECT #{expression} FROM mysql2_long_names GROUP BY #{expression}" }
+
+      let(:expected_name) do
+        name = @client.prepare(sql).fields.first
+        expect(name).not_to be_empty
+        # A NUL is valid UTF-8, so the encoding check alone would accept a
+        # NUL-padded oracle -- and with it, identically corrupt names on
+        # every surface compared against it.
+        expect(name).not_to include("\0")
+        expect(name.valid_encoding?).to be true
+        name
+      end
+
+      it "should return the truncated name without trailing bytes" do
+        expect(@client.query(sql).fields.first).to eql(expected_name)
+      end
+
+      it "should use the same clean name for hash keys and symbols" do
+        expect(@client.query(sql).first.keys.first).to eql(expected_name)
+        sym = @client.query(sql, symbolize_keys: true).first.keys.first
+        expect(sym).to eql(expected_name.to_sym)
+      end
+
+      it "should use the same clean name for an executed prepared statement" do
+        result = @client.prepare(sql).execute
+        expect(result.fields.first).to eql(expected_name)
+        expect(result.first.keys.first).to eql(expected_name)
+      end
+    end
+
     context "when a hash row raises part way through" do
       # Hash rows materialize field names one cell at a time, so a raise between
       # cells leaves only part of the set cached. Filling the rest reads field


### PR DESCRIPTION
Fixes #1288.

The truncated-name corruption is live on every stack I could assemble, current ones included — it is not confined to the 8.0-era stack the report used. The trigger is narrower than "long name": in every combination tested, the corruption appeared only when the expression referenced a real column, was grouped by, and carried no alias.

### Repro

```ruby
cond = (["1=1"] * 76).join(" AND ")
expr = "IF(#{cond}, posts.created_at, posts.created_at)"
name = client.query("SELECT #{expr} FROM posts GROUP BY #{expr}").fields.first
name.bytesize        # => 257 -- the 255-byte truncated name + NUL + one arbitrary byte
name.valid_encoding? # => false (the trailing byte was 0xFF here; the report saw a second NUL)
```

Every `Mysql2::Result` name surface is affected — `#fields`, hash keys, and `:symbolize_keys` symbols. The trailing garbage varies by build, which also means the corrupt name is not even stable across environments.

Measured combinations, all with this same query shape:

| client library | server | result |
|---|---|---|
| libmysqlclient 8.0.31 (Ubuntu 20.04 distro package — the same version string the report names for its server; the report does not identify its client library) | MySQL 8.0.31 | corrupt |
| libmysqlclient 8.0.46 (Homebrew, macOS arm64) | MySQL 8.0.31 | corrupt |
| libmysqlclient 9.6.0 (Homebrew, macOS arm64) | MySQL 8.0.31 | corrupt |
| libmysqlclient 9.6.0 | MySQL 9.6.0 | corrupt |

Variants that do NOT trigger it, which is what kept this hidden: the same expression without `GROUP BY` or built from constants only (a clean 255 bytes each), and with an alias (the alias is the name).

### Where the bad count comes from

A packet capture of the failing query shows the server behaving: the column-definition packet declares the name as length-encoded 255 (`FC FF 00`) followed by exactly 255 clean bytes. The 257 with trailing garbage is manufactured on the client-library side of the wire.

<details>
<summary>Capture excerpt (TLS disabled; server → client, column-definition packet)</summary>

```
# name: length prefix fc ff 00 (= 255), then the name text begins
fc ff 00 49 46 28 31 3d 31 20 41 4e 44 20 31 3d 31 20 41 4e 44 20 31 3d | ...IF(1=1 AND 1=1 AND 1=

# exactly 255 bytes later: the last name bytes, then org_name's own fc ff 00 prefix
41 4e 44 20 31 3d 31 20 fc ff 00 49 46 28 31 3d | AND 1=1 ...IF(1=
```

No NUL and no extra bytes between the declared end of `name` and the next field's
length prefix.
</details> I have not chased the miscount into the library source; whatever its internals, `MYSQL_FIELD.name` is NUL-terminated in the library's own buffer, and identifiers cannot contain NUL, so the terminator is authoritative.

### The fix

Stop at the name's NUL terminator, capped by `name_length`, at the one place result field names are materialized:

```c
name_end = memchr(field->name, '\0', field->name_length);
name_length = name_end ? (size_t)(name_end - field->name) : field->name_length;
```

(`memchr` rather than `strnlen`, which is POSIX rather than ISO C.) The C API documents `MYSQL_FIELD.name` as a NUL-terminated string, so nothing past the first NUL is part of the name by contract — that, more than any identifier rule, is what makes the terminator authoritative.

For a correctly-counted name this is exactly `name_length`, so healthy stacks are unchanged. The one way a NUL could legitimately enter a name — a string literal whose value becomes the column name, since identifiers themselves cannot contain NUL — turns out to be cut at the NUL by the server already (`SELECT 'a\0b'` names its column `a`, measured on both stacks), so the clamp cannot shorten a name that would otherwise have arrived intact. `Statement#fields` reads the same struct through its own metadata path. That path counted correctly on every client library above — both `Statement#fields` and executed statement results came back clean — but it trusts `name_length` the same way, so it gets the same stop-at-the-terminator treatment for the same contract. Said plainly: no stack I tested miscounts there, so that hunk is consistency rather than an observed fix, and it drops cleanly if you'd rather keep the diff to the observed path. (Executed statement results materialize names through the patched Result function either way.)

### Tests

Three specs on the faithful trigger shape: `#fields`, hash keys + symbols, and an executed prepared statement's result. The expected name is taken from `Statement#fields` for the same query rather than from the SQL text: it is the server's own rendering at the server's own truncation length, read through a metadata path whose byte count is not affected by this bug — so the comparison is byte-exact without assuming anything about how a given server renders or truncates expression names. (Verified equal to the text-protocol name on healthy paths against both servers, and 255 vs 257 on the afflicted ones.) The oracle itself is guarded with a no-NUL assertion — a NUL is valid UTF-8, so without it, metadata corrupted identically on both paths could satisfy every equality. On a stack whose client library counts the text-protocol length correctly the specs pass without exercising the fix (said out loud rather than implied: there they cannot bite).

Regression check: with both C changes reverted and the specs kept, the `#fields` and key/symbol specs fail against MySQL 9.6 — the text-protocol 257-byte name differing from the statement-metadata 255. The executed-statement spec passes either way on the stacks here, consistent with the statement path measuring clean; it pins that surface rather than biting on it.

### Tested on

macOS 26.5.2 (arm64), Ruby 3.3.10, MySQL 9.6.0 + libmysqlclient 9.6.0 (Unix socket), MySQL 8.0.31 in Docker (TCP), libmysqlclient 8.0.31/8.0.46 cross-builds as tabled above, Apple clang 21.0.0. Full suite 538 examples / 0 failures / 11 pending (pre-existing environment skips: 7 SSL client-cert, 3 LOCAL INFILE, 1 TLS-SNI capability). RuboCop clean, no new compiler warnings. Rebased onto current master (a2f3dc8) after #1554 reworked the symbolize path — the clamped length feeds `rb_check_symbol_cstr` and its fallback the same way it feeds the other constructors. *(An earlier revision of this description reported a symbol-GC spec failure on this machine; that traced to a stale local build configuration — an extconf run predating #1554's feature check — not to the suite. With a fresh configure the suite is fully green.)* Not exercised here: MariaDB servers, MariaDB Connector/C, Windows.
