### PR TITLE
stream: {size: N} sets STMT_ATTR_PREFETCH_ROWS on server-side cursors

### DIFF
--- a/README.md
+++ b/README.md
@@ -776,6 +776,19 @@ There are a few things that need to be kept in mind while using streaming:
 
 Read more about the consequences of using `mysql_use_result` (what streaming is implemented with) here: [https://dev.mysql.com/doc/c-api/9.7/en/mysql-use-result.html](https://dev.mysql.com/doc/c-api/9.7/en/mysql-use-result.html).
 
+#### Prepared statement streaming and prefetch
+
+Prepared statements stream differently: `Statement#execute(stream: true)` opens a read-only server-side cursor and fetches one row per network round trip. Pass `stream: {size: N}` to fetch N rows per round trip instead:
+
+``` ruby
+statement = client.prepare("SELECT * FROM really_big_table")
+result = statement.execute(stream: { size: 1000 }, cache_rows: false)
+```
+
+`stream: true` is equivalent to `stream: {size: 1}`. `size` bounds how many rows land in client memory per batch, so it trades peak memory for fewer round trips — the win scales with network latency to the server and is barely visible against a local socket.
+
+The two streaming implementations don't share this knob: `Client#query(stream: true)` is `mysql_use_result`, where the server pushes rows and there is no prefetch to size, so `Client#query` raises `ArgumentError` if given `stream: {size: N}`.
+
 ### Lazy Everything
 
 Well... almost ;)

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1360,6 +1360,14 @@ static VALUE rb_mysql_query(VALUE self, VALUE sql, VALUE current) {
    * connection untouched and reusable. Nothing downstream of the send may
    * raise for this option -- rb_mysql_result_to_obj in particular. */
   mysql2_canonicalize_force_encoding(current);
+  /* Text-protocol streaming is mysql_use_result: the server pushes rows and
+   * the client pulls them off the socket, so there is no prefetch to size.
+   * The stream: {size: N} spelling is prepared-statement-only
+   * (Statement#execute drives a server-side cursor, which does prefetch);
+   * reject it here rather than silently stream one row at a time. */
+  if (RB_TYPE_P(rb_hash_aref(current, sym_stream), T_HASH)) {
+    rb_raise(rb_eArgError, "stream: {size: N} is only supported for prepared statements; Client#query streams with mysql_use_result, which has no prefetch");
+  }
   rb_ivar_set(self, intern_current_query_options, current);
 
   Check_Type(sql, T_STRING);

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -2249,7 +2249,15 @@ VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_
 
   /* Options that cannot be changed in results.each(...) { |row| }
    * should be processed here. */
-  wrapper->is_streaming = (rb_hash_aref(options, sym_stream) == Qtrue ? 1 : 0);
+  /* Both streaming spellings: stream: true, and stream: {size: N} (already
+   * validated at the execute entry point; only Statement#execute lets the
+   * hash form through). Any other value -- including other truthy ones --
+   * means the query ran buffered, so this test must match the execute-side
+   * predicate exactly or the fetch path desyncs from the protocol state. */
+  {
+    VALUE stream = rb_hash_aref(options, sym_stream);
+    wrapper->is_streaming = (stream == Qtrue || RB_TYPE_P(stream, T_HASH)) ? 1 : 0;
+  }
 
   /* :force_encoding was canonicalized to an Encoding object at the
    * query/execute entry point (mysql2_canonicalize_force_encoding), so

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -4,7 +4,7 @@
 
 extern VALUE mMysql2, cMysql2Error;
 static VALUE cMysql2Statement, cBigDecimal, cDateTime, cDate;
-static VALUE sym_stream, intern_new_with_args, intern_each, intern_to_s, intern_merge_bang;
+static VALUE sym_stream, sym_size, intern_new_with_args, intern_each, intern_to_s, intern_merge_bang;
 static VALUE intern_sec_fraction, intern_usec, intern_sec, intern_min, intern_hour, intern_day, intern_month, intern_year,
   intern_query_options, intern_mul, intern_truncate;
 
@@ -358,6 +358,7 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
   int is_streaming;
   struct nogvl_stmt_execute_args execute_args;
   double query_start, query_elapsed;
+  unsigned long prefetch_rows = 1;
   rb_encoding *conn_enc;
 
   GET_STATEMENT(self);
@@ -411,7 +412,35 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
 
   mysql2_canonicalize_force_encoding(current);
 
-  is_streaming = (Qtrue == rb_hash_aref(current, sym_stream));
+  // :stream comes in two shapes: true streams with the default prefetch of
+  // one row per COM_STMT_FETCH round trip, and {size: N} streams fetching N
+  // rows per round trip (STMT_ATTR_PREFETCH_ROWS below). The hash form is
+  // validated here, before any bind buffer is allocated and before anything
+  // is written to the wire, under the same no-raise-downstream rules as
+  // :force_encoding above. It admits exactly one key so that a future
+  // sizing key can be added without a silently-ignored spelling existing
+  // today.
+  {
+    VALUE stream = rb_hash_aref(current, sym_stream);
+    if (RB_TYPE_P(stream, T_HASH)) {
+      VALUE size = rb_hash_aref(stream, sym_size);
+      long size_l;
+      if (NIL_P(size) || RHASH_SIZE(stream) != 1) {
+        rb_raise(rb_eArgError, "stream: hash accepts only {size: Integer}");
+      }
+      if (!RB_TYPE_P(size, T_FIXNUM) && !RB_TYPE_P(size, T_BIGNUM)) {
+        rb_raise(rb_eTypeError, "stream: {size: } must be an Integer");
+      }
+      size_l = NUM2LONG(size);
+      if (size_l <= 0) {
+        rb_raise(rb_eArgError, "stream: {size: } must be positive (got %ld)", size_l);
+      }
+      prefetch_rows = (unsigned long)size_l;
+      is_streaming = 1;
+    } else {
+      is_streaming = (Qtrue == stream);
+    }
+  }
 
   // setup any bind variables in the query
   if (bind_count > 0) {
@@ -580,6 +609,13 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
     if (mysql_stmt_attr_set(stmt, STMT_ATTR_CURSOR_TYPE, &type)) {
       FREE_BINDS;
       rb_raise(cMysql2Error, "Unable to stream prepared statement, could not set CURSOR_TYPE_READ_ONLY");
+    }
+    // Set unconditionally: statement attributes persist on the handle
+    // across executes, so stream: true must restore the one-row default
+    // after an earlier stream: {size: N} execute on the same statement.
+    if (mysql_stmt_attr_set(stmt, STMT_ATTR_PREFETCH_ROWS, &prefetch_rows)) {
+      FREE_BINDS;
+      rb_raise(cMysql2Error, "Unable to stream prepared statement, could not set STMT_ATTR_PREFETCH_ROWS");
     }
   }
 
@@ -825,6 +861,7 @@ void init_mysql2_statement(void) {
   rb_define_method(cMysql2Statement, "closed?", rb_mysql_stmt_closed_p, 0);
 
   sym_stream = ID2SYM(rb_intern("stream"));
+  sym_size = ID2SYM(rb_intern("size"));
 
   intern_new_with_args = rb_intern("new_with_args");
   intern_each = rb_intern("each");

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -822,6 +822,14 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
   end
 
   context "#query" do
+    it "should reject stream: {size: N}, which only prepared statements support" do
+      # Text-protocol streaming is mysql_use_result -- no cursor, no
+      # prefetch to size. Raising beats silently streaming row-by-row.
+      expect do
+        @client.query("SELECT 1", stream: { size: 10 })
+      end.to raise_error(ArgumentError, /prepared statements/)
+    end
+
     it "should let you query again if iterating is finished when streaming" do
       @client.query("SELECT 1 UNION SELECT 2", stream: true, cache_rows: false).each.to_a
 

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -429,6 +429,104 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
         @client.query("DROP TABLE IF EXISTS stream_stmt_truncation_test")
       end
     end
+
+    context "with stream: {size: N}" do
+      # Com_stmt_fetch counts COM_STMT_FETCH commands the server received on
+      # this session -- a direct observation of how many round trips a
+      # cursor drain cost, from the same connection once it's idle again.
+      def com_stmt_fetch_count
+        @client.query("SHOW SESSION STATUS LIKE 'Com_stmt_fetch'").first['Value'].to_i
+      end
+
+      def fetches_during
+        before = com_stmt_fetch_count
+        yield
+        com_stmt_fetch_count - before
+      end
+
+      before(:example) do
+        @client.query("DROP TABLE IF EXISTS stream_prefetch_test")
+        @client.query("CREATE TABLE stream_prefetch_test (id INT PRIMARY KEY AUTO_INCREMENT, v VARCHAR(32))")
+        ins = @client.prepare("INSERT INTO stream_prefetch_test (v) VALUES (?)")
+        20.times { |i| ins.execute("row#{i}") }
+      end
+
+      after(:example) do
+        @client.query("DROP TABLE IF EXISTS stream_prefetch_test")
+      end
+
+      it "fetches N rows per round trip and returns the same rows as stream: true" do
+        stmt = @client.prepare("SELECT * FROM stream_prefetch_test ORDER BY id")
+
+        single_rows = nil
+        single = fetches_during do
+          single_rows = stmt.execute(stream: true, cache_rows: false).to_a
+        end
+
+        batched_rows = nil
+        batched = fetches_during do
+          batched_rows = stmt.execute(stream: { size: 10 }, cache_rows: false).to_a
+        end
+
+        expect(batched_rows).to eq(single_rows)
+        expect(single_rows.length).to eq(20)
+        expect(single).to be >= 20
+        expect(batched).to be <= 4
+      end
+
+      it "resets the prefetch size when the same statement streams with stream: true again" do
+        # STMT_ATTR_PREFETCH_ROWS persists on the statement handle, so a
+        # plain stream: true execute after a sized one must not inherit N.
+        stmt = @client.prepare("SELECT * FROM stream_prefetch_test ORDER BY id")
+        stmt.execute(stream: { size: 10 }, cache_rows: false).to_a
+
+        single = fetches_during do
+          stmt.execute(stream: true, cache_rows: false).to_a
+        end
+        expect(single).to be >= 20
+      end
+
+      it "grows a truncated column buffer inside a multi-row batch" do
+        # The regrow-on-MYSQL_DATA_TRUNCATED path (see the stream: true spec
+        # above), but with the large row arriving mid-batch rather than as
+        # the only row of its fetch.
+        @client.query("DROP TABLE IF EXISTS stream_prefetch_grow_test")
+        @client.query("CREATE TABLE stream_prefetch_grow_test (id INT PRIMARY KEY AUTO_INCREMENT, data MEDIUMBLOB)")
+        begin
+          small = "a" * 10
+          large = "b" * 300_000
+          values = [small, large, small, large, small]
+          ins = @client.prepare("INSERT INTO stream_prefetch_grow_test (data) VALUES (?)")
+          values.each { |v| ins.execute(v) }
+
+          stmt = @client.prepare("SELECT data FROM stream_prefetch_grow_test ORDER BY id")
+          rows = stmt.execute(stream: { size: 2 }, cache_rows: false).to_a
+          expect(rows.map { |r| r["data"] }).to eq(values)
+        ensure
+          @client.query("DROP TABLE IF EXISTS stream_prefetch_grow_test")
+        end
+      end
+
+      it "accepts stream: {size: 1} as equivalent to stream: true" do
+        stmt = @client.prepare("SELECT * FROM stream_prefetch_test ORDER BY id")
+        expect(stmt.execute(stream: { size: 1 }, cache_rows: false).to_a.length).to eq(20)
+      end
+
+      it "rejects invalid sizes before touching the network" do
+        stmt = @client.prepare("SELECT * FROM stream_prefetch_test")
+        expect { stmt.execute(stream: { size: 0 }) }.to raise_error(ArgumentError, /positive/)
+        expect { stmt.execute(stream: { size: -1 }) }.to raise_error(ArgumentError, /positive/)
+        expect { stmt.execute(stream: { size: 1.5 }) }.to raise_error(TypeError, /Integer/)
+        expect { stmt.execute(stream: { size: "10" }) }.to raise_error(TypeError, /Integer/)
+        expect { stmt.execute(stream: {}) }.to raise_error(ArgumentError, /size/)
+        expect { stmt.execute(stream: { sise: 10 }) }.to raise_error(ArgumentError, /size/)
+        expect { stmt.execute(stream: { size: 10, max_memory: 1 }) }.to raise_error(ArgumentError, /size/)
+
+        # The raises above happened at option parse: the statement and
+        # connection are untouched and still usable.
+        expect(stmt.execute(stream: { size: 5 }, cache_rows: false).to_a.length).to eq(20)
+      end
+    end
   end
 
   context "#each" do


### PR DESCRIPTION
Proposed in #1519.

Streaming prepared-statement execution already opens a server-side cursor: Statement#execute(stream: true) sets CURSOR_TYPE_READ_ONLY. But STMT_ATTR_PREFETCH_ROWS was never set anywhere in ext/, so every cursor ran at the client library's default prefetch of 1 -- one COM_STMT_FETCH round trip per row. A 10k-row streamed result cost 10k sequential round trips; the cursor machinery paid full protocol price for its memory bound.

Statement#execute now accepts a Hash for :stream:

    result = stmt.execute(stream: { size: 1000 }, cache_rows: false)

Mechanism:

- statement.c:402-430 parses the hash form at option parse time, before any bind buffer is allocated and before anything is written to the wire (the same no-raise-downstream discipline as :force_encoding). Invalid sizes (0, negative, non-Integer) raise there, and the hash admits exactly the key :size, so a future sizing key (e.g. a memory budget) can be added without a silently-ignored spelling existing today.
- statement.c:593-608 sets STMT_ATTR_PREFETCH_ROWS beside the existing CURSOR_TYPE_READ_ONLY call. It is set unconditionally in the streaming branch because statement attributes persist on the handle across executes: stream: true must restore the one-row default after an earlier stream: {size: N} execute on the same statement (covered by a spec that counts server-side Com_stmt_fetch).
- result.c:2229-2237 recognizes both streaming spellings when deciding wrapper->is_streaming, matching the execute-side predicate exactly.
- client.c:1165-1172: Client#query rejects the hash form with ArgumentError. Text-protocol streaming is mysql_use_result -- the server pushes rows, there is no prefetch to size -- so raising beats silently streaming one row at a time. The README documents the asymmetry.

stream: true is unchanged: it still streams at prefetch 1, and setting the attribute to 1 is wire-identical to never setting it (the fetch count rides in each COM_STMT_FETCH packet, default 1).

STMT_ATTR_PREFETCH_ROWS is a standard enum in both libmysqlclient and mariadb-connector-c (since MySQL 5.x) -- no have_const gate, no version probe. Verified against both: local macOS libmysqlclient 9.6 and Linux libmariadb 12.3.2.

Round trips are observable server-side as Com_stmt_fetch, which the new specs assert on directly: 20 rows drain in >= 20 fetches at stream: true and <= 4 at stream: {size: 10}. The regrow-on-MYSQL_DATA_TRUNCATED path (#1500) is exercised with 300KB blobs arriving mid-batch.

Benchmark: 10k-row table (VARCHAR(191) payload), prepared SELECT drained with cache_rows: false, as: :array; median of 15 interleaved drains per config, plus the server's Com_stmt_fetch delta. Apple M-series laptop against local MySQL 9.6 over loopback (libmysqlclient):

    config          min ms   median ms   stmt_fetches
    stream: true     96.77      103.80          10001
    size: 100        10.89       11.68            101
    size: 1000        9.90       10.39             11

Ryzen 7950X against MySQL 9.6 in Docker on 127.0.0.1 (libmariadb 12.3.2, load < 0.3):

    config          min ms   median ms   stmt_fetches
    stream: true    246.27      251.66          10001
    size: 100         7.21        7.44            101
    size: 1000        4.63        4.72             11

That is 9x / 34x-53x on loopback, where a round trip is only a syscall pair; the reduction is multiplicative in real network latency (10k round trips at 0.5ms RTT is 5 seconds of pure waiting).

Behavior deltas, disclosed:

- Statement#execute(stream: {...}): previously any non-true :stream value silently meant "not streaming", so a hash executed buffered. Now the hash form streams (valid sizes) or raises (anything else).
- Client#query(stream: {...}): previously silently not streaming; now ArgumentError.
- A sized streaming execute leaves CURSOR_TYPE_READ_ONLY and the prefetch size set on the statement handle for a later buffered execute, exactly as stream: true already left the cursor type (pre-existing, unchanged); mysql_stmt_store_result drains the cursor identically either way, which a spec-level parity check confirms.

Coverage limits: the Com_stmt_fetch assertions use inequalities (>= rows, <= 4) rather than exact counts to stay robust across MySQL/MariaDB fetch-termination differences; prefetch sizing is asserted at the protocol level, not as wall-clock time. stream: true and stream: {size: 1} are asserted equivalent behaviorally, not byte-compared on the wire.
