### PR TITLE
Extend the fiber-claim guard to every command-issuing method

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -136,6 +136,7 @@ struct nogvl_send_query_args {
 struct nogvl_select_db_args {
   MYSQL *mysql;
   char *db;
+  struct query_completion completion;
 };
 
 static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
@@ -906,6 +907,14 @@ static void *nogvl_use_result(void *ptr) {
   return nogvl_do_result(ptr, 1);
 }
 
+/* Unlike nogvl_store_result above, leaves active_fiber alone: the drain loop
+ * in do_abandon_results holds its claim across every result set in the
+ * batch, not just up to the first stored one. */
+static void *nogvl_store_result_raw(void *ptr) {
+  mysql_client_wrapper *wrapper = ptr;
+  return mysql_store_result(wrapper->client);
+}
+
 /* Shared by async_result (a query's first result set) and store_result (a
  * later one, from a multi-statement batch): fetch the current result set as
  * either streamed or fully-buffered, per :stream, track it on wrapper, and
@@ -1109,6 +1118,37 @@ static VALUE disconnect_and_mark_inactive(VALUE self) {
   return Qnil;
 }
 
+/* rb_ensure companion for the fiber-claimed command methods that release the
+ * GVL mid-command (select_db, next_result, abandon_results!): releases the
+ * claim on every kind of unwind, so no raise -- or Thread#exit -- between
+ * claim and release can leave the connection permanently reporting "This
+ * connection is in use by". When the body never reached its completion mark,
+ * an interrupt landed mid-exchange and the connection may be stuck
+ * mid-protocol, so it also gets invalidated, same as an interrupted query.
+ * Bodies mark completion before raising a server-reported error: that reply
+ * finished the round trip, so the connection itself is still usable. */
+static VALUE release_claim_or_disconnect(VALUE completionval) {
+  struct query_completion *completion = (void *)completionval;
+  mysql_client_wrapper *wrapper = completion->wrapper;
+
+  if (completion->completed) {
+    wrapper->active_fiber = Qnil;
+  } else {
+#ifndef _WIN32
+    invalidate_after_interrupted_query(wrapper);
+#else
+    wrapper->active_fiber = Qnil;
+    wrapper->state = MYSQL2_CLIENT_IDLE;
+    if (CONNECTED(wrapper)) {
+      close(wrapper->client->net.fd);
+      wrapper->client->net.fd = -1;
+    }
+#endif
+  }
+
+  return Qnil;
+}
+
 /* call-seq:
  *    client.abandon_results!
  *
@@ -1117,26 +1157,42 @@ static VALUE disconnect_and_mark_inactive(VALUE self) {
  * put the connection back into a state where queries can be issued
  * again.
  */
-static VALUE rb_mysql_client_abandon_results(VALUE self) {
+static VALUE do_abandon_results(VALUE completionval) {
+  struct query_completion *completion = (void *)completionval;
+  mysql_client_wrapper *wrapper = completion->wrapper;
   MYSQL_RES *result;
   int ret;
-
-  GET_CLIENT(self);
 
   while (mysql_more_results(wrapper->client) == 1) {
     ret = mysql_next_result(wrapper->client);
     if (ret > 0) {
+      /* A complete server reply reporting a failed statement in the batch;
+       * the connection is fine, so the rb_ensure companion only releases
+       * the claim. */
+      completion->completed = 1;
       rb_raise_mysql2_error(wrapper);
     }
 
-    result = (MYSQL_RES *)rb_thread_call_without_gvl(nogvl_store_result, wrapper, RUBY_UBF_IO, 0);
+    result = (MYSQL_RES *)rb_thread_call_without_gvl(nogvl_store_result_raw, wrapper, RUBY_UBF_IO, 0);
 
     if (result != NULL) {
       mysql_free_result(result);
     }
   }
 
+  completion->completed = 1;
   return Qnil;
+}
+
+static VALUE rb_mysql_client_abandon_results(VALUE self) {
+  struct query_completion completion;
+  GET_CLIENT(self);
+
+  completion.wrapper = wrapper;
+  completion.completed = 0;
+
+  rb_mysql_client_set_active_fiber(self, false);
+  return rb_ensure(do_abandon_results, (VALUE)&completion, release_claim_or_disconnect, (VALUE)&completion);
 }
 
 /* call-seq:
@@ -1514,6 +1570,20 @@ static void *nogvl_select_db(void *ptr) {
     return (void *)Qfalse;
 }
 
+static VALUE do_select_db(VALUE argsval) {
+  struct nogvl_select_db_args *args = (void *)argsval;
+
+  if (rb_thread_call_without_gvl(nogvl_select_db, args, RUBY_UBF_IO, 0) == Qfalse) {
+    /* A complete round trip -- the server replied with an error -- so the
+     * rb_ensure companion only releases the claim. */
+    args->completion.completed = 1;
+    rb_raise_mysql2_error(args->completion.wrapper);
+  }
+
+  args->completion.completed = 1;
+  return Qnil;
+}
+
 /* call-seq:
  *    client.select_db(name)
  *
@@ -1529,9 +1599,11 @@ static VALUE rb_mysql_client_select_db(VALUE self, VALUE db)
 
   args.mysql = wrapper->client;
   args.db = StringValueCStr(db);
+  args.completion.wrapper = wrapper;
+  args.completion.completed = 0;
 
-  if (rb_thread_call_without_gvl(nogvl_select_db, &args, RUBY_UBF_IO, 0) == Qfalse)
-    rb_raise_mysql2_error(wrapper);
+  rb_mysql_client_set_active_fiber(self, false);
+  rb_ensure(do_select_db, (VALUE)&args, release_claim_or_disconnect, (VALUE)&args.completion);
 
   /* This originates as a Ruby VALUE, but we're using its C pointer
    * directly -- keep the VALUE live on the stack so GC can't collect it
@@ -1614,13 +1686,20 @@ static VALUE rb_mysql_client_ping(VALUE self) {
  * for more information.
  */
 static VALUE rb_mysql_client_set_server_option(VALUE self, VALUE value) {
+  int option;
+  int rv;
   GET_CLIENT(self);
 
-  if (mysql_set_server_option(wrapper->client, NUM2INT(value)) == 0) {
-    return Qtrue;
-  } else {
-    return Qfalse;
-  }
+  option = NUM2INT(value);
+
+  /* mysql_set_server_option runs its whole COM_SET_OPTION round trip with
+   * the GVL held, so nothing can raise -- and no interrupt can land --
+   * between this claim and its release below. */
+  rb_mysql_client_set_active_fiber(self, false);
+  rv = mysql_set_server_option(wrapper->client, option);
+  wrapper->active_fiber = Qnil;
+
+  return rv == 0 ? Qtrue : Qfalse;
 }
 
 /* call-seq:
@@ -1673,8 +1752,9 @@ static void *nogvl_next_result(void *ptr) {
 }
 #endif
 
-static VALUE mysql2_next_result_reset_state(VALUE self) {
-  GET_CLIENT(self);
+static VALUE mysql2_next_result_reset_state(VALUE completionval) {
+  struct query_completion *completion = (void *)completionval;
+  mysql_client_wrapper *wrapper = completion->wrapper;
 
   if (wrapper->state != MYSQL2_CLIENT_IDLE) {
     wrapper->state = MYSQL2_CLIENT_IDLE;
@@ -1682,10 +1762,17 @@ static VALUE mysql2_next_result_reset_state(VALUE self) {
     mysql2_reap_pending_stmt_closes(wrapper);
   }
 
-  return Qnil;
+  return release_claim_or_disconnect(completionval);
 }
 
-static VALUE mysql2_next_result_body(VALUE self) {
+struct next_result_args {
+  VALUE self;
+  struct query_completion completion;
+};
+
+static VALUE mysql2_next_result_body(VALUE argsval) {
+  struct next_result_args *args = (void *)argsval;
+  VALUE self = args->self;
   GET_CLIENT(self);
 
   /* Mark the connection busy for the duration of the wait: on the fast
@@ -1699,6 +1786,10 @@ static VALUE mysql2_next_result_body(VALUE self) {
 #if defined(HAVE_MYSQL_NEXT_RESULT_NONBLOCKING) && !defined(_WIN32)
   {
     enum net_async_status status = next_result_nonblocking(self, wrapper);
+    /* The exchange finished: even NET_ASYNC_ERROR is a complete reply (a
+     * failed statement in the batch), not a mid-protocol interruption, so
+     * the rb_ensure companion only releases the claim. */
+    args->completion.completed = 1;
     wrapper->affected_rows = mysql_affected_rows(wrapper->client);
 
     switch (status) {
@@ -1715,6 +1806,9 @@ static VALUE mysql2_next_result_body(VALUE self) {
 #else
   {
     int ret = (int)(intptr_t)rb_thread_call_without_gvl(nogvl_next_result, wrapper, RUBY_UBF_IO, 0);
+    /* Same as the nonblocking path: a nonzero ret is a complete
+     * server-reported error, not a mid-protocol interruption. */
+    args->completion.completed = 1;
     wrapper->affected_rows = mysql_affected_rows(wrapper->client);
 
     if (ret > 0) {
@@ -1737,10 +1831,17 @@ static VALUE mysql2_next_result_body(VALUE self) {
  */
 static VALUE rb_mysql_client_next_result(VALUE self)
 {
+  struct next_result_args args;
+
   GET_CLIENT(self);
   REQUIRE_CONNECTED(wrapper);
 
-  return rb_ensure(mysql2_next_result_body, self, mysql2_next_result_reset_state, self);
+  args.self = self;
+  args.completion.wrapper = wrapper;
+  args.completion.completed = 0;
+
+  rb_mysql_client_set_active_fiber(self, false);
+  return rb_ensure(mysql2_next_result_body, (VALUE)&args, mysql2_next_result_reset_state, (VALUE)&args.completion);
 }
 
 /* call-seq:
@@ -1752,6 +1853,11 @@ static VALUE rb_mysql_client_next_result(VALUE self)
 static VALUE rb_mysql_client_store_result(VALUE self)
 {
   GET_CLIENT(self);
+
+  /* The claim is released inside nogvl_do_result once the result is stored
+   * (or, on a fetch error, by mysql2_fetch_result_set before it raises) --
+   * the same lifecycle a query's own result fetch follows. */
+  rb_mysql_client_set_active_fiber(self, false);
 
   /* Honor :stream on later result sets of a multi-statement query the same
    * way async_result already does for the first one -- previously this

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -1096,6 +1096,34 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
         end.to raise_error(Timeout::Error)
       end
 
+      it "does not leave the connection claimed after an interrupted #next_result" do
+        @multi_client.query("SELECT 1 AS a; SELECT SLEEP(2) AS b")
+
+        expect do
+          Timeout.timeout(0.3) { @multi_client.next_result }
+        end.to raise_error(Timeout::Error)
+
+        # The interrupted exchange invalidates the connection, same as an
+        # interrupted query's read -- a normal, actionable connection error
+        # is fine, but a permanently leaked claim is not, whether reported
+        # to another fiber ("in use by") or to this one ("still waiting").
+        begin
+          @multi_client.query("SELECT 1")
+        rescue Mysql2::Error => e
+          expect(e.message).not_to match(/This connection is in use by|still waiting for a result/)
+        end
+      end
+
+      it "releases its claim and keeps the connection usable when #abandon_results! hits a failed statement" do
+        @multi_client.query("SELECT 1; SELECT * FROM abandon_no_such_table; SELECT 3")
+
+        expect do
+          @multi_client.abandon_results!
+        end.to raise_error(Mysql2::Error, /abandon_no_such_table/)
+
+        expect(@multi_client.query("SELECT 4 AS a").first).to eq('a' => 4)
+      end
+
       it "#more_results? should work" do
         @multi_client.query("SELECT 1 AS 'set_1'; SELECT 2 AS 'set_2'")
         expect(@multi_client.more_results?).to be true
@@ -1670,6 +1698,56 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     end
     expect(thread.value.to_a).to eq([{ "SLEEP(1)" => 0 }])
     expect(@client.close).to be_nil
+  end
+
+  it "should not allow concurrent use of #select_db" do
+    thread = new_thread { @client.query("SELECT SLEEP(1)") }
+    thread.join(0.1)
+    expect do
+      @client.select_db(DatabaseCredentials['root']['database'])
+    end.to raise_error(Mysql2::Error, /This connection is in use by/)
+    expect(thread.value.to_a).to eq([{ "SLEEP(1)" => 0 }])
+    expect(@client.select_db(DatabaseCredentials['root']['database'])).to eq(DatabaseCredentials['root']['database'])
+  end
+
+  it "should not allow concurrent use of #next_result" do
+    thread = new_thread { @client.query("SELECT SLEEP(1)") }
+    thread.join(0.1)
+    expect do
+      @client.next_result
+    end.to raise_error(Mysql2::Error, /This connection is in use by/)
+    expect(thread.value.to_a).to eq([{ "SLEEP(1)" => 0 }])
+    expect(@client.next_result).to be false
+  end
+
+  it "should not allow concurrent use of #store_result" do
+    thread = new_thread { @client.query("SELECT SLEEP(1)") }
+    thread.join(0.1)
+    expect do
+      @client.store_result
+    end.to raise_error(Mysql2::Error, /This connection is in use by/)
+    expect(thread.value.to_a).to eq([{ "SLEEP(1)" => 0 }])
+    expect(@client.query("SELECT 1 AS a").first).to eq('a' => 1)
+  end
+
+  it "should not allow concurrent use of #abandon_results!" do
+    thread = new_thread { @client.query("SELECT SLEEP(1)") }
+    thread.join(0.1)
+    expect do
+      @client.abandon_results!
+    end.to raise_error(Mysql2::Error, /This connection is in use by/)
+    expect(thread.value.to_a).to eq([{ "SLEEP(1)" => 0 }])
+    expect(@client.abandon_results!).to be_nil
+  end
+
+  it "should not allow concurrent use of #set_server_option" do
+    thread = new_thread { @client.query("SELECT SLEEP(1)") }
+    thread.join(0.1)
+    expect do
+      @client.set_server_option(Mysql2::Client::OPTION_MULTI_STATEMENTS_ON)
+    end.to raise_error(Mysql2::Error, /This connection is in use by/)
+    expect(thread.value.to_a).to eq([{ "SLEEP(1)" => 0 }])
+    expect(@client.set_server_option(Mysql2::Client::OPTION_MULTI_STATEMENTS_OFF)).to be true
   end
 
   context "#ping interrupted mid-flight" do


### PR DESCRIPTION
Proposed in #1522.

The active_fiber claim -- the GVL-atomic check-and-set that raises "This connection is in use by ..." instead of letting two fibers interleave commands on one MYSQL* -- was taken by exactly three methods: query, ping, and close. Every other method that issues a command on the shared connection ran unguarded: select_db, abandon_results!, store_result, next_result, and set_server_option. A fiber calling any of them while another fiber's query was in flight interleaved two commands on one protocol stream, and the failure was not an error: desynced packets and corrupted results inside the client library, with nothing raised at the point of misuse.

Each of the five now takes the same claim query takes (rb_mysql_client_set_active_fiber -- client.c:1194, 1605, 1698, 1843, 1860), placed after all raise-capable setup so a failed argument conversion can't leak it. Every guard honors the no-raise-between-claim-and-clear rule: any unwind between taking the claim and releasing it -- an ordinary raise, a Timeout interrupt, or a Thread#exit -- releases the claim, reusing the completion-flag + rb_ensure shape #1508 established for query's own send/read phases.

Mechanism per method:

- set_server_option (client.c:1688): claim, run the COM_SET_OPTION round trip (GVL-held, so no interrupt can land mid-guard), release. The raise-capable NUM2INT happens before the claim.
- select_db (client.c:1595): the wire call runs under rb_ensure with a shared companion, release_claim_or_disconnect (client.c:1130): a body that reached its completion mark just releases the claim; one that didn't was interrupted mid-exchange, so the companion also invalidates the socket, same as an interrupted query. A server error reply ("Unknown database") marks completion before raising -- the round trip finished, so the connection stays usable, which the existing select_db specs (a successful select_db right after a failed one) pin.
- next_result (client.c:1833): claim before the existing rb_ensure; the reset-state companion (client.c:1755) now chains to release_claim_or_disconnect. A failed statement in the batch (NET_ASYNC_ERROR / ret > 0) is a complete server reply: completion is marked before the raise, so the connection survives -- pinned by the existing "raise an exception when one of multiple statements fails" spec, which calls next_result again after the raise.
- store_result (client.c:1854): claim on entry; release follows the exact lifecycle a query's own result fetch already has -- nogvl_do_result clears the claim once the result is stored, and the fetch-error path in mysql2_fetch_result_set clears it before raising.
- abandon_results! (client.c:1185): claims once and holds across the whole drain loop -- a new nogvl_store_result_raw (client.c:913) stores without the claim-clearing side effect of nogvl_store_result, so the guard isn't porous between result sets. A failed statement mid-batch marks completion before raising, leaving the connection usable (new spec).

Behavior changes, both changelog-visible:

- Concurrent misuse that previously corrupted silently now raises Mysql2::Error from all five methods, matching what query/ping/close already did. Code relying on (already unsafe) concurrent select_db/next_result/etc. will see new exceptions; same-fiber misuse (e.g. abandon_results! while an async query is outstanding) raises "This connection is still waiting for a result".
- An interrupted next_result / select_db / abandon_results! (Timeout, Thread#raise, or Thread#exit landing mid-exchange) now invalidates the connection, exactly as an interrupted query read always has -- previously the connection was left open mid-protocol, where the next command silently desynced. The new "does not leave the connection claimed after an interrupted #next_result" spec pins the no-lockout half: after the interrupt, the next caller gets a normal connection error, never a permanent "in use by"/"still waiting" claim.

Verification: each new spec fails against a deliberately broken build -- one break per guard (claim removed: the matching "should not allow concurrent use of #X" spec fails), one with abandon_results!'s completion mark dropped before its raise (the failed-statement spec fails because the companion then invalidates a healthy connection), and one with the companion's not-completed branch disabled (the interrupted-next_result spec fails with a leaked same-fiber claim -- which is why that spec matches both claim messages, not just "in use by"). Full suite green: 545 examples, 0 failures (11 pre-existing pendings); rubocop clean. The blocking-mysql_next_result fallback path (MariaDB / MySQL < 8.0.16) was force-compiled locally with HAVE_MYSQL_NEXT_RESULT_NONBLOCKING off and passes the same specs.

Bench (Apple Silicon, localhost server, 3 trials each): 3000 drains of a 3-statement batch via next_result/store_result -- master 0.115-0.136s, guarded 0.108-0.164s; 1000 select_db round trips -- 0.012-0.017s on both builds. Flat within noise, as expected: each guard adds one rb_fiber_current + compare per method call, nothing per-row.

Coverage limits: the closing-only dead-fiber takeover rule in rb_mysql_client_set_active_fiber is untouched -- #1508's ensure-based cleanup already covers the Thread#exit lockout that this issue's takeover generalization originally targeted. Statement#execute's send/read path remains unguarded, as noted in #1508, and is out of scope here. The Windows branch of release_claim_or_disconnect mirrors disconnect_and_mark_inactive's existing socket-close idiom and is compile-verified by CI only. Pre-existing and untouched: calling store_result on a client that has never issued a query crashes (a hash lookup on the unset query-options ivar) on master exactly as before, and deserves a separate fix.
