### PR TITLE
Cache statement metadata artifacts across executes

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -176,7 +176,17 @@ static void rb_mysql_result_free_result(mysql2_result_wrapper * wrapper, int fro
                  && wrapper->client_wrapper;
 
     if (wrapper->stmt_wrapper) {
-      if (!wrapper->stmt_wrapper->closed) {
+      mysql_stmt_wrapper *stmt_wrapper = wrapper->stmt_wrapper;
+      /* Whether the statement's metadata snapshot still describes the shape
+       * these artifacts were built for: an intervening execute can have
+       * rebuilt it (ALTER TABLE) while this Result sat unfreed after a
+       * mid-iteration raise, and handing back buffers bound for the old
+       * shape would make a later execute silently convert values into the
+       * wrong C types. */
+      int cache_compatible = !stmt_wrapper->closed &&
+                             stmt_wrapper->metadata_epoch == wrapper->stmt_metadata_epoch;
+
+      if (!stmt_wrapper->closed) {
         if (defer_free) {
           mysql2_enqueue_pending_result_free(wrapper->client_wrapper, NULL, wrapper->stmt_wrapper->stmt);
         } else {
@@ -194,11 +204,50 @@ static void rb_mysql_result_free_result(mysql2_result_wrapper * wrapper, int fro
         wrapper->stmt_wrapper->stmt->bind_result_done = 0;
       }
 
-      if (wrapper->statement != Qnil) {
-        decr_mysql2_stmt(wrapper->stmt_wrapper);
+      /* Hand the result buffers back to the statement for the next execute
+       * to adopt, instead of freeing them, whenever the cache slot is open
+       * and the shape still matches. Pointer moves only, so this is safe
+       * from the GC dfree path too. Everything cache-related happens before
+       * the decr below, which can free stmt_wrapper outright when this
+       * Result held the last reference. The bind-type election travels with
+       * the buffers (cached_result_buffers_string_binds): an adopting
+       * execute under the other cast mode sees the mismatch at fetch time
+       * and re-elects, exactly as a mid-result #each mode switch does. */
+      if (wrapper->result_buffers &&
+          cache_compatible && stmt_wrapper->cached_result_buffers == NULL) {
+        stmt_wrapper->cached_result_buffers = wrapper->result_buffers;
+        stmt_wrapper->cached_is_null = wrapper->is_null;
+        stmt_wrapper->cached_error = wrapper->error;
+        stmt_wrapper->cached_length = wrapper->length;
+        stmt_wrapper->cached_result_buffers_string_binds = wrapper->result_buffers_string_binds;
+        /* Clue that the next statement execute will need to allocate or
+         * adopt a result buffer. */
+        wrapper->result_buffers = NULL;
+        wrapper->result_buffers_bound = 0;
+      } else {
+        rb_mysql_result_free_result_buffers(wrapper);
       }
 
-      rb_mysql_result_free_result_buffers(wrapper);
+      /* Hand back the field-name array as a private dup, so caller
+       * mutations of this Result's #fields can never reach the cache. Only
+       * from the ordinary free path -- rb_ary_dup allocates, which a GC
+       * dfree callback must not -- and only for a non-streaming Result:
+       * those are materialized and freed entirely inside Statement#execute,
+       * so the array provably carries the execute-time :symbolize_keys and
+       * no user code has run against it. A streaming Result's names are
+       * built under its first #each's options instead, which may differ. */
+      if (!from_dfree_callback && !wrapper->is_streaming && cache_compatible &&
+          wrapper->fields != Qnil &&
+          (my_ulonglong)RARRAY_LEN(wrapper->fields) == wrapper->numberOfFields &&
+          (stmt_wrapper->cached_fields == Qnil ||
+           stmt_wrapper->cached_fields_symbolized != wrapper->fields_symbolized)) {
+        stmt_wrapper->cached_fields = rb_ary_dup(wrapper->fields);
+        stmt_wrapper->cached_fields_symbolized = wrapper->fields_symbolized;
+      }
+
+      if (wrapper->statement != Qnil) {
+        decr_mysql2_stmt(stmt_wrapper);
+      }
     }
 
     /* For prepared statements, wrapper->result is the result metadata
@@ -411,6 +460,7 @@ static VALUE rb_mysql_result_fetch_field(VALUE self, unsigned int idx, int symbo
 #endif
     }
     rb_ary_store(wrapper->fields, idx, rb_field);
+    wrapper->fields_symbolized = symbolize_keys ? 1 : 0;
   }
 
   return rb_field;
@@ -2455,9 +2505,52 @@ VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_
 
   /* Keep a handle to the Statement to ensure it doesn't get garbage collected first */
   wrapper->statement = statement;
+  wrapper->stmt_metadata_epoch = 0;
+  wrapper->fields_symbolized = 0;
   if (statement != Qnil) {
-    wrapper->stmt_wrapper = DATA_PTR(statement);
-    wrapper->stmt_wrapper->refcount++;
+    mysql_stmt_wrapper *stmt_wrapper = DATA_PTR(statement);
+    wrapper->stmt_wrapper = stmt_wrapper;
+    stmt_wrapper->refcount++;
+    wrapper->stmt_metadata_epoch = stmt_wrapper->metadata_epoch;
+
+    /* Adopt the artifacts cached from this statement's previous execute;
+     * mysql2_stmt_validate_metadata_cache already verified them against
+     * this execute's freshly read metadata (dropping them on mismatch), so
+     * whatever survives here is shape-compatible. Buffer sizes are
+     * data-dependent, not part of that validation: an adopted char[] buffer
+     * can be smaller than this result's widest value, and the
+     * MYSQL_DATA_TRUNCATED grow-and-refetch path in
+     * rb_mysql_result_fetch_row_stmt grows it to fit, exactly as it grows a
+     * freshly allocated initial-size buffer. The bind-type election is
+     * adopted along with the buffers: when this execute's cast mode wants
+     * the other election, the fetch path sees the mismatch and re-elects
+     * (frees and reallocates) before binding, exactly as it does for a
+     * mid-result #each mode switch. */
+    if (stmt_wrapper->cached_result_buffers) {
+      wrapper->result_buffers = stmt_wrapper->cached_result_buffers;
+      wrapper->is_null = stmt_wrapper->cached_is_null;
+      wrapper->error = stmt_wrapper->cached_error;
+      wrapper->length = stmt_wrapper->cached_length;
+      wrapper->result_buffers_string_binds = stmt_wrapper->cached_result_buffers_string_binds;
+      wrapper->numberOfFields = stmt_wrapper->cached_field_count;
+      stmt_wrapper->cached_result_buffers = NULL;
+      stmt_wrapper->cached_is_null = NULL;
+      stmt_wrapper->cached_error = NULL;
+      stmt_wrapper->cached_length = NULL;
+    }
+
+    /* Field names are adopted only for a non-streaming Result (a streaming
+     * one materializes names under its first #each's options, which may
+     * differ from these) and only when they were built under the same
+     * :symbolize_keys. The cache keeps its private master copy; this Result
+     * gets a dup, so mutations of #fields stay its own. */
+    if (stmt_wrapper->cached_fields != Qnil &&
+        rb_hash_aref(options, sym_stream) != Qtrue &&
+        stmt_wrapper->cached_fields_symbolized == (RTEST(rb_hash_aref(options, sym_symbolize_keys)) ? 1 : 0)) {
+      wrapper->fields = rb_ary_dup(stmt_wrapper->cached_fields);
+      wrapper->fields_symbolized = stmt_wrapper->cached_fields_symbolized;
+      wrapper->numberOfFields = stmt_wrapper->cached_field_count;
+    }
   } else {
     wrapper->stmt_wrapper = NULL;
   }

--- a/ext/mysql2/result.h
+++ b/ext/mysql2/result.h
@@ -102,6 +102,17 @@ typedef struct {
   my_bool *is_null;
   my_bool *error;
   unsigned long *length;
+  /* The statement's metadata_epoch when this Result was created. Cached
+   * artifacts are only handed back to the statement while its epoch still
+   * matches: an intervening execute may have rebuilt the snapshot around a
+   * different shape (ALTER TABLE), and buffers bound for the old shape would
+   * silently convert or truncate the new one. 0 and unused without a
+   * statement. */
+  unsigned long stmt_metadata_epoch;
+  /* Whether wrapper->fields holds symbolized names, recorded as they are
+   * built so the statement cache can refuse to reuse the array for an
+   * execute with a different :symbolize_keys. */
+  int fields_symbolized;
   mysql2_each_opts_cache each_opts;
 } mysql2_result_wrapper;
 

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -26,6 +26,7 @@ static void rb_mysql_stmt_mark(void * ptr) {
   if (!stmt_wrapper) return;
 
   rb_gc_mark_movable(stmt_wrapper->client);
+  rb_gc_mark_movable(stmt_wrapper->cached_fields);
 }
 
 static void rb_mysql_stmt_free(void *ptr) {
@@ -44,6 +45,7 @@ static void rb_mysql_stmt_compact(void * ptr) {
   if (!stmt_wrapper) return;
 
   rb_mysql2_gc_location(stmt_wrapper->client);
+  rb_mysql2_gc_location(stmt_wrapper->cached_fields);
 }
 #endif
 
@@ -73,6 +75,93 @@ static void *nogvl_stmt_close(void *ptr) {
   return NULL;
 }
 
+/* Free every cached metadata artifact: the validation snapshot, the private
+ * field-name array (dropped for the GC to reclaim), and the result bind
+ * buffers. Plain xfree and C-struct writes only, so this is safe from a GC
+ * dfree callback (decr_mysql2_stmt) as well as from ordinary Ruby code. */
+static void mysql2_stmt_metadata_cache_clear(mysql_stmt_wrapper *stmt_wrapper) {
+  unsigned int i;
+
+  if (stmt_wrapper->cached_field_meta) {
+    for (i = 0; i < stmt_wrapper->cached_field_count; i++) {
+      xfree(stmt_wrapper->cached_field_meta[i].name);
+    }
+    xfree(stmt_wrapper->cached_field_meta);
+    stmt_wrapper->cached_field_meta = NULL;
+  }
+
+  if (stmt_wrapper->cached_result_buffers) {
+    for (i = 0; i < stmt_wrapper->cached_field_count; i++) {
+      if (stmt_wrapper->cached_result_buffers[i].buffer) {
+        xfree(stmt_wrapper->cached_result_buffers[i].buffer);
+      }
+    }
+    xfree(stmt_wrapper->cached_result_buffers);
+    xfree(stmt_wrapper->cached_is_null);
+    xfree(stmt_wrapper->cached_error);
+    xfree(stmt_wrapper->cached_length);
+    stmt_wrapper->cached_result_buffers = NULL;
+    stmt_wrapper->cached_is_null = NULL;
+    stmt_wrapper->cached_error = NULL;
+    stmt_wrapper->cached_length = NULL;
+  }
+
+  stmt_wrapper->cached_fields = Qnil;
+  stmt_wrapper->cached_field_count = 0;
+}
+
+/* Compare freshly read result metadata against the statement's snapshot.
+ * On a match, every cached artifact was derived from an identical shape and
+ * remains valid, so it is kept for rb_mysql_result_to_obj to adopt. On any
+ * mismatch -- or when no snapshot exists yet -- drop the artifacts, bump the
+ * epoch, and snapshot the fresh fields.
+ *
+ * Names are compared NUL-trimmed, the same rule rb_mysql_result_fetch_field
+ * uses to derive them: the library can report a name_length that counts
+ * bytes past the terminator (#1288), and the byte beyond it is arbitrary,
+ * so a raw comparison could spuriously invalidate an unchanged name. */
+static void mysql2_stmt_validate_metadata_cache(mysql_stmt_wrapper *stmt_wrapper, MYSQL_RES *metadata) {
+  MYSQL_FIELD *fields = mysql_fetch_fields(metadata);
+  unsigned int field_count = mysql_num_fields(metadata);
+  unsigned int i;
+
+  if (stmt_wrapper->cached_field_meta && stmt_wrapper->cached_field_count == field_count) {
+    for (i = 0; i < field_count; i++) {
+      const mysql2_stmt_field_meta *meta = &stmt_wrapper->cached_field_meta[i];
+      const char *name_end = memchr(fields[i].name, '\0', fields[i].name_length);
+      unsigned long name_length = name_end ? (unsigned long)(name_end - fields[i].name) : fields[i].name_length;
+
+      if (meta->type != fields[i].type ||
+          meta->flags != fields[i].flags ||
+          meta->charsetnr != fields[i].charsetnr ||
+          meta->name_length != name_length ||
+          memcmp(meta->name, fields[i].name, name_length) != 0) {
+        break;
+      }
+    }
+    if (i == field_count) return;
+  }
+
+  mysql2_stmt_metadata_cache_clear(stmt_wrapper);
+  stmt_wrapper->metadata_epoch++;
+  stmt_wrapper->cached_field_count = field_count;
+  /* xcalloc so the name pointers start NULL: an allocation failure part way
+   * through the copy loop leaves a snapshot mysql2_stmt_metadata_cache_clear
+   * can free safely. */
+  stmt_wrapper->cached_field_meta = xcalloc(field_count, sizeof(mysql2_stmt_field_meta));
+  for (i = 0; i < field_count; i++) {
+    mysql2_stmt_field_meta *meta = &stmt_wrapper->cached_field_meta[i];
+    const char *name_end = memchr(fields[i].name, '\0', fields[i].name_length);
+
+    meta->name_length = name_end ? (unsigned long)(name_end - fields[i].name) : fields[i].name_length;
+    meta->name = xmalloc(meta->name_length);
+    memcpy(meta->name, fields[i].name, meta->name_length);
+    meta->type = fields[i].type;
+    meta->flags = fields[i].flags;
+    meta->charsetnr = fields[i].charsetnr;
+  }
+}
+
 void decr_mysql2_stmt(mysql_stmt_wrapper *stmt_wrapper) {
   stmt_wrapper->refcount--;
 
@@ -97,6 +186,7 @@ void decr_mysql2_stmt(mysql_stmt_wrapper *stmt_wrapper) {
                                          (uintptr_t)stmt_wrapper);
     }
 
+    mysql2_stmt_metadata_cache_clear(stmt_wrapper);
     decr_mysql2_client(stmt_wrapper->client_wrapper);
     xfree(stmt_wrapper);
   }
@@ -165,6 +255,16 @@ VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql) {
     stmt_wrapper->refcount = 1;
     stmt_wrapper->closed = 0;
     stmt_wrapper->stmt = NULL;
+    stmt_wrapper->cached_field_count = 0;
+    stmt_wrapper->cached_field_meta = NULL;
+    stmt_wrapper->metadata_epoch = 0;
+    stmt_wrapper->cached_fields = Qnil;
+    stmt_wrapper->cached_fields_symbolized = 0;
+    stmt_wrapper->cached_result_buffers = NULL;
+    stmt_wrapper->cached_is_null = NULL;
+    stmt_wrapper->cached_error = NULL;
+    stmt_wrapper->cached_length = NULL;
+    stmt_wrapper->cached_result_buffers_string_binds = 0;
 
     /* Keep a handle to the Client to ensure it doesn't get garbage collected first */
     stmt_wrapper->client = rb_client;
@@ -646,6 +746,13 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
     wrapper->state = MYSQL2_CLIENT_STREAMING;
   }
 
+  /* The metadata was read fresh above -- reading it is cheap and it goes
+   * stale under ALTER TABLE -- and only the artifacts derived from it are
+   * cached. On a match the field-name array and result buffers from the
+   * previous execute remain compatible and rb_mysql_result_to_obj below
+   * adopts them; on a miss they are dropped and rebuilt from scratch. */
+  mysql2_stmt_validate_metadata_cache(stmt_wrapper, metadata);
+
   resultObj = rb_mysql_result_to_obj(stmt_wrapper->client, wrapper->encoding, current, metadata, self, query_elapsed);
 
   /* Track the open cursor so a later command can force-drain it if it's
@@ -777,6 +884,7 @@ static VALUE rb_mysql_stmt_close(VALUE self) {
       stmt_wrapper->closed = 1;
       rb_hash_delete(wrapper->prepared_statements, ULL2NUM((unsigned long long)stmt_wrapper));
       rb_thread_call_without_gvl(nogvl_stmt_close, stmt_wrapper, RUBY_UBF_IO, 0);
+      mysql2_stmt_metadata_cache_clear(stmt_wrapper);
   }
 
   return Qnil;

--- a/ext/mysql2/statement.h
+++ b/ext/mysql2/statement.h
@@ -1,12 +1,55 @@
 #ifndef MYSQL2_STATEMENT_H
 #define MYSQL2_STATEMENT_H
 
+/* Per-field snapshot of the result metadata that a statement's cached
+ * artifacts were derived from. Metadata itself is re-read from the server's
+ * response on every execute (it goes stale under ALTER TABLE); this snapshot
+ * exists only to tell whether the artifacts built from the previous execute's
+ * metadata are still compatible. max_length is deliberately absent: it is
+ * data-dependent per execute, and buffer sizing differences are handled by
+ * the grow-to-fit fetch path in result.c instead. */
+typedef struct {
+  char *name;                 /* xmalloc'd copy of the field name bytes */
+  unsigned long name_length;
+  enum enum_field_types type;
+  unsigned int flags;
+  unsigned int charsetnr;
+} mysql2_stmt_field_meta;
+
 typedef struct {
   VALUE client;
   MYSQL_STMT *stmt;
   mysql_client_wrapper *client_wrapper;
   int refcount;
   int closed;
+  /* Cross-execute cache of metadata-derived artifacts, validated against
+   * freshly read metadata by mysql2_stmt_validate_metadata_cache on every
+   * execute and adopted by the new Result in rb_mysql_result_to_obj. A
+   * Result hands its artifacts back when it is freed (result.c,
+   * rb_mysql_result_free_result). metadata_epoch increments whenever the
+   * snapshot is rebuilt, so a Result created under an older snapshot can
+   * tell its artifacts no longer match the current shape and must not be
+   * handed back. cached_fields is a private master copy that is never
+   * returned to Ruby callers: each adopting Result receives a dup, so
+   * mutations of Result#fields cannot reach the cache. It is marked (and
+   * compacted) via rb_mysql_stmt_mark/rb_mysql_stmt_compact. */
+  unsigned int cached_field_count;
+  mysql2_stmt_field_meta *cached_field_meta;
+  unsigned long metadata_epoch;
+  VALUE cached_fields;
+  int cached_fields_symbolized;
+  MYSQL_BIND *cached_result_buffers;
+  my_bool *cached_is_null;
+  my_bool *cached_error;
+  unsigned long *cached_length;
+  /* The bind-type election the cached buffers were built under (see
+   * result_buffers_string_binds in result.h), recorded when they are handed
+   * back and restored when they are adopted. Meaningful only while
+   * cached_result_buffers is non-NULL. An execute whose cast mode wants the
+   * other election adopts and then re-elects at fetch time, so the election
+   * is deliberately not part of cache validation: it can never decode
+   * values through the wrong types, only miss the cache. */
+  char cached_result_buffers_string_binds;
 } mysql_stmt_wrapper;
 
 void init_mysql2_statement(void);

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -620,6 +620,117 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
     end
   end
 
+  context "metadata cached across executes" do
+    # A statement caches its metadata-derived artifacts (field-name array,
+    # result bind buffers) between executes, re-reading and validating the
+    # metadata each time. These specs pin the seams: buffers sized by a
+    # previous execute's data, metadata invalidated by ALTER TABLE, per-execute
+    # option changes, mutation isolation of #fields, and GC/compaction safety
+    # of the VALUEs rooted on the statement wrapper.
+    before(:example) do
+      @client.query "CREATE TEMPORARY TABLE cross_execute_test (id INT, val VARCHAR(255))"
+      @client.query "INSERT INTO cross_execute_test (id, val) VALUES (1, 'short')"
+    end
+
+    it "should return fresh rows on every execute, growing value buffers as the data widens" do
+      stmt = @client.prepare "SELECT id, val FROM cross_execute_test ORDER BY id"
+      expect(stmt.execute.to_a).to eql([{ "id" => 1, "val" => "short" }])
+
+      @client.query "INSERT INTO cross_execute_test (id, val) VALUES (2, REPEAT('x', 255))"
+      expect(stmt.execute.to_a).to eql([{ "id" => 1, "val" => "short" }, { "id" => 2, "val" => "x" * 255 }])
+    end
+
+    it "should reread metadata when ALTER TABLE changes a column type between executes" do
+      @client.query "CREATE TEMPORARY TABLE alter_type_test (id INT, num INT)"
+      @client.query "INSERT INTO alter_type_test VALUES (1, 42)"
+      stmt = @client.prepare "SELECT * FROM alter_type_test"
+      expect(stmt.execute.first["num"]).to eql(42)
+
+      @client.query "ALTER TABLE alter_type_test MODIFY num VARCHAR(16)"
+      expect(stmt.execute.first["num"]).to eql("42")
+    end
+
+    it "should reread metadata when ALTER TABLE flips a column to unsigned between executes" do
+      @client.query "CREATE TEMPORARY TABLE alter_unsigned_test (num INT)"
+      @client.query "INSERT INTO alter_unsigned_test VALUES (1)"
+      stmt = @client.prepare "SELECT * FROM alter_unsigned_test"
+      expect(stmt.execute.first["num"]).to eql(1)
+
+      @client.query "ALTER TABLE alter_unsigned_test MODIFY num INT UNSIGNED"
+      @client.query "UPDATE alter_unsigned_test SET num = 4294967295"
+      expect(stmt.execute.first["num"]).to eql(4294967295)
+    end
+
+    it "should keep row keys in step with the statement's own fresh metadata after ALTER TABLE renames a column" do
+      # MySQL pins a prepared handle's result-set column names for the life of
+      # the handle (even Statement#fields, which re-reads metadata, reports the
+      # original name after a rename), so this cannot demand the new name.
+      # What it pins instead is that cached names always track whatever the
+      # freshly read metadata reports: on a server that does propagate the
+      # rename, stale cached names would break this equality.
+      @client.query "CREATE TEMPORARY TABLE alter_name_test (id INT, before_name INT)"
+      @client.query "INSERT INTO alter_name_test VALUES (1, 42)"
+      stmt = @client.prepare "SELECT * FROM alter_name_test"
+      expect(stmt.execute.first.keys).to eql(stmt.fields)
+
+      @client.query "ALTER TABLE alter_name_test CHANGE before_name after_name INT"
+      expect(stmt.execute.first.keys).to eql(stmt.fields)
+    end
+
+    it "should re-elect bind types when the cast mode changes between executes" do
+      # Bind types are elected from the cast mode (cast: true binds server
+      # types; cast: false / :fast bind strings), so cached buffers carry
+      # their election across executes and an execute under the other mode
+      # must re-elect rather than decode through the adopted types.
+      stmt = @client.prepare "SELECT id, val FROM cross_execute_test"
+      expect(stmt.execute(cast: false).first).to eql("id" => "1", "val" => "short")
+      expect(stmt.execute.first).to eql("id" => 1, "val" => "short")
+      expect(stmt.execute(cast: :fast).first).to eql("id" => 1, "val" => "short")
+    end
+
+    it "should not reuse field names for an execute with different :symbolize_keys" do
+      stmt = @client.prepare "SELECT id FROM cross_execute_test"
+      expect(stmt.execute(symbolize_keys: true).first.keys).to eql([:id])
+      expect(stmt.execute.first.keys).to eql(["id"])
+      expect(stmt.execute(symbolize_keys: true).first.keys).to eql([:id])
+    end
+
+    it "should give each execute's result its own #fields array" do
+      stmt = @client.prepare "SELECT id, val FROM cross_execute_test"
+      # The first result's array is the one the statement harvests; the
+      # second's is handed out from the cache. Mutating both proves neither
+      # end of the exchange shares an array with the statement.
+      first = stmt.execute
+      first.fields << "mutated on harvest side"
+      second = stmt.execute
+      expect(second.fields).to eql(%w[id val])
+      second.fields << "mutated on adoption side"
+      expect(stmt.execute.fields).to eql(%w[id val])
+    end
+
+    it "should keep results correct across GC and compaction with a held statement" do
+      stmt = @client.prepare "SELECT id, val FROM cross_execute_test ORDER BY id"
+      expected = stmt.execute.to_a
+      stmt.execute
+      GC.start
+      GC.verify_compaction_references(expand_heap: true, toward: :empty) if GC.respond_to?(:verify_compaction_references) && RUBY_VERSION >= "3.2"
+      result = stmt.execute
+      expect(result.to_a).to eql(expected)
+      expect(result.fields).to eql(%w[id val])
+    end
+
+    it "should keep results correct when GC.stress runs between executes" do
+      stmt = @client.prepare "SELECT id, val FROM cross_execute_test"
+      expected = stmt.execute.to_a
+      begin
+        GC.stress = true
+        3.times { expect(stmt.execute.to_a).to eql(expected) }
+      ensure
+        GC.stress = false
+      end
+    end
+  end
+
   context "row data type mapping" do
     let(:test_result) { @client.prepare("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").execute.first }
 


### PR DESCRIPTION
Proposed in #1525.

Every Statement#execute rebuilt everything derived from result metadata from scratch, even for the workload prepared statements exist for -- the same statement executed thousands of times against an unchanged result shape. The field-name VALUE array was rebuilt per Result, and the MYSQL_BIND array, the is_null/error/length arrays, and one buffer per column were xcalloc'd per Result and freed with it (rb_mysql_result_alloc_result_buffers, result.c:989).

Now the statement wrapper carries a cross-execute cache of those artifacts (statement.h:36-44). Metadata is still read on every execute -- mysql_stmt_result_metadata is a cheap local call, and fields go stale under ALTER TABLE -- and compared against a snapshot of the shape the artifacts were built from: field count plus per-field name, type, flags, and charsetnr (mysql2_stmt_validate_metadata_cache, statement.c:123, called at statement.c:736). Names are compared NUL-trimmed, the same rule the name derivation uses (#1288). On a match the new Result adopts the cached buffers and a dup of the cached field-name array (rb_mysql_result_to_obj, result.c:2266-2299); on a miss the cache is dropped and rebuilt. When a Result is freed it hands its buffers back to the statement and stores a dup of its field-name array (rb_mysql_result_free_result, result.c:186-231). Statement#close and the statement's final free clear the cache (statement.c:869, :189).

Load-bearing details:

- Buffer sizes are data-dependent -- char[] buffers are sized from fields[i].max_length, computed from whatever rows the previous execute returned -- so size is deliberately not part of validation. An adopted buffer smaller than this execute's widest value takes the existing MYSQL_DATA_TRUNCATED grow-and-refetch path (result.c:1145), exactly as a streaming fetch that never had max_length does. Verified by breaking that path: the widening-data spec then returns truncated bytes.

- The cached field-name array is a private master copy: adoption hands each Result rb_ary_dup(cache) (result.c:2296), harvest stores rb_ary_dup(fields) (result.c:229), so mutating one Result#fields can never reach another execute's keys. Both dups are individually load-bearing -- the mutation-isolation spec fails with either one removed. Steady state is one array dup per execute in exchange for skipping the N per-field interned-string lookups and the array build.

- Field names are only harvested from and adopted by non-streaming Results, and only when built under the same :symbolize_keys as the adopting execute. A non-streaming prepared Result is materialized and freed entirely inside Statement#execute, so its array provably carries the execute-time options and no user code has touched it; a streaming Result's names are built under its first #each's options, which may differ. Buffers, which are never user-visible, are reused in both modes.

- The new VALUE rooted on the statement wrapper (cached_fields) is marked and compacted in rb_mysql_stmt_mark/rb_mysql_stmt_compact (statement.c:29, :48) -- the #1068 bug class. Verified by removing the hooks: the compaction spec segfaults.

- metadata_epoch (statement.h:38, result.h:99): a Result stranded holding buffers by a mid-iteration raise can be GC'd after a later execute has rebuilt the snapshot around an ALTERed shape; its dfree would hand back buffers whose bind types no longer match, and the next execute would adopt them and silently convert values (an INT-shaped bind against a column now VARCHAR converts "1" to 1). The Result records the epoch it was created under and buffers are handed back only on a match (result.c:165). The window only opens when GC collects the strand between a later execute's validation and that execute's own free, so it has no deterministic spec: under GC.stress the strand is always collected before validation, whose mismatch path already clears the stale handback -- verified by removing the epoch check and failing to provoke the bug under stress, which is exactly why the guard stays.

Numbers (thelio: Linux x86_64, MySQL 9.6 over local TCP, ruby 4.0.6; wall = median of 9 samples x 400 ops; allocation counts over 4000 ops; C-heap traffic via an LD_PRELOAD malloc counter; two interleaved base/branch repetitions, deltas identical in both):

```
arm                C mallocs/op          C KB/op        Ruby objs/op   wall
point_read_10col    27.0 -> 13.0  (-52%) 20.3 -> 18.9   28.0 (flat)    flat
point_read_100col  123.0 -> 18.0  (-85%) 56.7 -> 43.9   211.0 (flat)   flat
rows100_10col      128.0 -> 114.0 (-11%) 73.9 -> 72.5   919.0 (flat)   flat
```

This is an allocation-pressure change and wall time is flat, matching go-sql-driver's merged version of the same mechanism (go PR 1711: allocs/op -98.4%, wall flat at p=1.000). One refinement to the issue's sizing: Ruby-object allocations are flat too, because field names were already interned process-wide -- mysql2 was already ahead of go on the axis that produced go's -98%. What this removes is C-heap churn: the per-execute MYSQL_BIND array, the three flag/length arrays, one xmalloc per column, and the field-name array build. That is the -52%/-85% malloc-call reduction above; GC.count deltas were unchanged.

Behavior deltas and coverage limits:

- ALTER TABLE changing a column's type or flags between executes is validated and rebuilt. Specs cover the type change and a signed->unsigned flip, which would otherwise silently mis-decode values >= 2^31. A rename alone never reaches validation on the server tested: MySQL 9.6 pins a prepared handle's result-set names for the life of the handle -- even Statement#fields, which re-reads metadata per call, reports the old name, and master behaves identically. The rename spec therefore pins cached names to whatever fresh metadata reports (row keys == stmt.fields) rather than demanding the new name; on a server that does propagate renames, stale cached names would break that equality.

- ALTER TABLE changing the column count between executes fails inside libmysqlclient ("The number of columns in the result set differs from the number of bound buffers") before metadata can be read. Unchanged from master, verified side by side.

Note for parallel review: #1520 and #1526 touch the same sizing/binding code; this is built against master, and any overlap will surface as a textual conflict in the alloc/free paths at merge time.
