### PR TITLE
Add :kill_on_timeout, escalating timeouts via KILL QUERY before teardown

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,13 +23,13 @@ Lint/MissingSuper:
 # Offense count: 2
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
 Metrics/AbcSize:
-  Max: 92
+  Max: 94
 
 # Offense count: 35
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
 # AllowedMethods: refine
 Metrics/BlockLength:
-  Max: 495
+  Max: 516
 
 # Offense count: 1
 # Configuration parameters: CountBlocks, CountModifierForms.
@@ -39,7 +39,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 195
+  Max: 236
 
 # Offense count: 3
 # Configuration parameters: AllowedMethods, AllowedPatterns.
@@ -49,7 +49,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 6
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
 Metrics/MethodLength:
-  Max: 54
+  Max: 55
 
 # Offense count: 2
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/README.md
+++ b/README.md
@@ -278,6 +278,8 @@ Mysql2::Client.new(
   :read_timeout = seconds,
   :write_timeout = seconds,
   :connect_timeout = seconds,
+  :kill_on_timeout = true/false,
+  :kill_grace = seconds,
   :connect_attrs = {:program_name => $PROGRAM_NAME, ...},
   :reconnect = true/false,
   :local_infile = true/false,
@@ -302,6 +304,57 @@ type of connection to make, with special interpretation you should be aware of:
 * A value of `"."` on Windows specifies a named-pipe connection.
 * An IPv4 or IPv6 address will result in a TCP connection.
 * Any other value will be looked up as a hostname for a TCP connection.
+
+### Cancelling a runaway query: kill_on_timeout
+
+By default, when a query outlives `:read_timeout` or its thread is interrupted
+(`Timeout.timeout`, `Thread#raise`), mysql2 abandons the connection -- and the
+server keeps executing the query anyway, holding locks and burning CPU until it
+finishes on its own. With `:kill_on_timeout` enabled, mysql2 instead escalates
+the way the mysql CLI's Ctrl-C handler does:
+
+1. Issue `KILL QUERY <thread_id>` from a short-lived helper connection opened
+   with the victim connection's own credentials.
+2. Resume waiting up to `:kill_grace` seconds (default 5) for the server to
+   answer the killed query -- normally `ER_QUERY_INTERRUPTED`, or the query's
+   own result if it finished before the KILL landed. Either way the protocol
+   stream stays in sync and **the connection survives** to run its next query.
+   The original `Mysql2::Error::TimeoutError` (or interrupting exception) is
+   still raised.
+3. Only if the helper can't connect, the KILL fails, or the grace period
+   expires is the connection torn down as before.
+
+``` ruby
+client = Mysql2::Client.new(read_timeout: 5, kill_on_timeout: true)
+```
+
+Both options may also be passed per query:
+
+``` ruby
+client.query("SELECT ...", kill_on_timeout: true, kill_grace: 2)
+```
+
+Notes:
+
+* `KILL QUERY` requires the same user, `SUPER`, or `CONNECTION_ADMIN`; the
+  helper connects with the victim's own credentials, so the same-user path is
+  the default.
+* The thread id used is the one the server assigned at handshake
+  (`Client#thread_id`). The handshake field is 32 bits wide, so on servers
+  whose connection ids exceed 32 bits, run `SELECT CONNECTION_ID()` yourself
+  and issue the KILL from your own connection instead.
+* Not supported on Windows, where the plain teardown behavior is unchanged.
+
+The same machinery is exposed directly, usable from another thread while the
+connection is stuck mid-query:
+
+``` ruby
+client.kill_query      # KILL QUERY <thread_id>: the blocked #query call
+                       # returns its error/result and the connection survives
+client.kill_connection # KILL CONNECTION <thread_id>: hard-kill for a
+                       # connection you are about to throw away, e.g. from a
+                       # connection pool reaper
+```
 
 ### Secure connections with SSL/TLS
 

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -18,7 +18,7 @@
 
 VALUE cMysql2Client;
 extern VALUE mMysql2, cMysql2Error, cMysql2ConnectionError, cMysql2TimeoutError;
-static VALUE sym_id, sym_version, sym_header_version, sym_async, sym_symbolize_keys, sym_as, sym_array, sym_stream;
+static VALUE sym_id, sym_version, sym_header_version, sym_async, sym_symbolize_keys, sym_as, sym_array, sym_stream, sym_kill_on_timeout;
 static ID intern_brackets, intern_merge, intern_merge_bang, intern_new_with_args,
   intern_current_query_options, intern_read_timeout, intern_values;
 
@@ -1634,6 +1634,30 @@ static VALUE do_query(VALUE args) {
   async_args->completion.completed = 1;
   return Qnil;
 }
+
+/* rb_rescue2 companion (do_query, kill_on_timeout queries only): the command
+ * was fully sent and none of its response has been read, so the protocol
+ * stream is intact -- the one window where an interrupted connection can
+ * survive. Leave the fd alone, mark the connection CANCEL_PENDING for
+ * Client#query (lib/mysql2/client.rb) to settle via the KILL QUERY
+ * escalation, and flag the wait handled so the enclosing rb_ensure skips
+ * its teardown. A non-exception unwind (Thread#exit) bypasses rb_rescue2
+ * entirely: completed stays unset and the rb_ensure companion tears down
+ * exactly as without kill_on_timeout, since no rescue upstream would ever
+ * run the escalation. */
+static VALUE defer_teardown_for_cancel(VALUE completionval, VALUE error) {
+  struct query_completion *completion = (void *)completionval;
+
+  completion->completed = 1;
+  completion->wrapper->state = MYSQL2_CLIENT_CANCEL_PENDING;
+  rb_exc_raise(error);
+}
+
+static VALUE do_query_deferring_teardown(VALUE args) {
+  struct async_query_args *async_args = (void *)args;
+
+  return rb_rescue2(do_query, args, defer_teardown_for_cancel, (VALUE)&async_args->completion, rb_eException, (VALUE)0);
+}
 #endif
 
 static VALUE disconnect_and_mark_inactive(VALUE self) {
@@ -1692,6 +1716,81 @@ static VALUE release_claim_or_disconnect(VALUE completionval) {
 
   return Qnil;
 }
+
+
+/* Whether a kill_on_timeout query's interrupted wait left the connection
+ * CANCEL_PENDING (see defer_teardown_for_cancel), awaiting the KILL QUERY
+ * escalation in Client#query. Only that caller, in the same fiber that ran
+ * the query, sees Qtrue: everyone else is fenced off by active_fiber. */
+static VALUE rb_mysql_client_cancel_pending(VALUE self) {
+  GET_CLIENT(self);
+  return wrapper->state == MYSQL2_CLIENT_CANCEL_PENDING ? Qtrue : Qfalse;
+}
+
+#ifndef _WIN32
+/* Rung 2 of the escalation: with KILL QUERY issued, wait up to grace
+ * seconds for the server's response to the interrupted query -- normally
+ * ER_QUERY_INTERRUPTED raised as an ordinary Mysql2::Error (the connection
+ * survives, in sync), or the query's own result if it finished before the
+ * KILL landed. Returns Qfalse if the grace period expires (or the poll
+ * fails): rung 3, the connection is invalidated just as an interrupted
+ * query without kill_on_timeout would be. */
+static VALUE rb_mysql_client_resume_cancelled_query(VALUE self, VALUE grace) {
+  struct timeval tv;
+  double sec;
+  int retval;
+  GET_CLIENT(self);
+
+  if (wrapper->state != MYSQL2_CLIENT_CANCEL_PENDING) {
+    rb_raise(cMysql2Error, "no cancelled query is pending on this connection");
+  }
+
+  sec = NUM2DBL(grace);
+  /* A negative timeval would make rb_wait_for_single_fd block forever;
+   * clamp to an immediate poll, making a negative grace behave like 0. */
+  if (sec < 0) {
+    sec = 0;
+  }
+  tv.tv_sec = (long)sec;
+  tv.tv_usec = (suseconds_t)((sec - (double)tv.tv_sec) * 1000000);
+
+  retval = rb_wait_for_single_fd(wrapper->client->net.fd, RB_WAITFD_IN, &tv);
+  if (retval <= 0) {
+    invalidate_after_interrupted_query(wrapper);
+    return Qfalse;
+  }
+
+  wrapper->state = MYSQL2_CLIENT_QUERYING;
+  return rb_ensure(rb_mysql_client_async_result, self, disconnect_and_mark_inactive, self);
+}
+
+/* Rung 3 as a callable: invalidate the connection if it is still
+ * CANCEL_PENDING, no-op otherwise. Client#query calls this from an ensure
+ * so that whatever cut the escalation short -- helper connection refused,
+ * KILL QUERY erroring, an interrupt during the resumed wait -- lands on
+ * the same teardown an interrupted query without kill_on_timeout gets. */
+static VALUE rb_mysql_client_abort_cancelled_query(VALUE self) {
+  GET_CLIENT(self);
+
+  if (wrapper->state == MYSQL2_CLIENT_CANCEL_PENDING) {
+    invalidate_after_interrupted_query(wrapper);
+  }
+
+  return Qnil;
+}
+#else
+/* The wait-phase deferral that produces CANCEL_PENDING is compiled out on
+ * Windows (no async wait phase exists there), so cancel_pending? is always
+ * false and these are never reached; they exist so Client#query's shared
+ * rescue path binds on every platform. */
+static VALUE rb_mysql_client_resume_cancelled_query(RB_MYSQL_UNUSED VALUE self, RB_MYSQL_UNUSED VALUE grace) {
+  return Qfalse;
+}
+
+static VALUE rb_mysql_client_abort_cancelled_query(RB_MYSQL_UNUSED VALUE self) {
+  return Qnil;
+}
+#endif
 
 /* call-seq:
  *    client.abandon_results!
@@ -1822,7 +1921,11 @@ static VALUE rb_mysql_query(VALUE self, VALUE sql, VALUE current) {
     async_args.completion.wrapper = wrapper;
     async_args.completion.completed = 0;
 
-    rb_ensure(do_query, (VALUE)&async_args, disconnect_query_if_incomplete, (VALUE)&async_args.completion);
+    if (RTEST(rb_hash_aref(current, sym_kill_on_timeout))) {
+      rb_ensure(do_query_deferring_teardown, (VALUE)&async_args, disconnect_query_if_incomplete, (VALUE)&async_args.completion);
+    } else {
+      rb_ensure(do_query, (VALUE)&async_args, disconnect_query_if_incomplete, (VALUE)&async_args.completion);
+    }
 
     return rb_ensure(rb_mysql_client_async_result, self, disconnect_and_mark_inactive, self);
   }
@@ -2864,6 +2967,9 @@ void init_mysql2_client(void) {
   rb_define_private_method(cMysql2Client, "initialize_ext", initialize_ext, 0);
   rb_define_private_method(cMysql2Client, "connect", rb_mysql_connect, 9);
   rb_define_private_method(cMysql2Client, "_query", rb_mysql_query, 2);
+  rb_define_private_method(cMysql2Client, "cancel_pending?", rb_mysql_client_cancel_pending, 0);
+  rb_define_private_method(cMysql2Client, "resume_cancelled_query", rb_mysql_client_resume_cancelled_query, 1);
+  rb_define_private_method(cMysql2Client, "abort_cancelled_query", rb_mysql_client_abort_cancelled_query, 0);
 
   sym_id              = ID2SYM(rb_intern("id"));
   sym_version         = ID2SYM(rb_intern("version"));
@@ -2873,6 +2979,7 @@ void init_mysql2_client(void) {
   sym_as              = ID2SYM(rb_intern("as"));
   sym_array           = ID2SYM(rb_intern("array"));
   sym_stream          = ID2SYM(rb_intern("stream"));
+  sym_kill_on_timeout = ID2SYM(rb_intern("kill_on_timeout"));
 
   intern_brackets = rb_intern("[]");
   intern_merge = rb_intern("merge");

--- a/ext/mysql2/client.h
+++ b/ext/mysql2/client.h
@@ -9,7 +9,15 @@
 typedef enum {
   MYSQL2_CLIENT_IDLE = 0,
   MYSQL2_CLIENT_QUERYING,
-  MYSQL2_CLIENT_STREAMING
+  MYSQL2_CLIENT_STREAMING,
+  /* A kill_on_timeout query's wait for the server's response was
+   * interrupted (read_timeout, Thread#raise) after the command was fully
+   * sent but before any of the response was read: the protocol stream is
+   * intact, so teardown is deferred while Client#query (lib/mysql2/
+   * client.rb) runs the KILL QUERY escalation. Still mid-exchange, like
+   * QUERYING. Settled by resume_cancelled_query/abort_cancelled_query
+   * (client.c). */
+  MYSQL2_CLIENT_CANCEL_PENDING
 } mysql2_client_state_t;
 
 /* A MYSQL_STMT handle whose Ruby wrapper was freed while the connection

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -16,6 +16,8 @@ module Mysql2
         cast: true,
         default_file: nil,
         default_group: nil,
+        kill_on_timeout: false,      # on read_timeout/interrupt mid-query, KILL QUERY from a helper connection and try to keep this connection alive
+        kill_grace: 5,               # seconds to wait for the server to acknowledge the KILL before falling back to closing the connection
       }
     end
 
@@ -115,7 +117,30 @@ module Mysql2
       tls_sni_name = tls_sni_name.to_s unless tls_sni_name.nil?
       conn_attrs = parse_connect_attrs(opts[:connect_attrs])
 
+      @kill_helper = build_kill_helper(opts)
+
       connect user, pass, host, port, database, socket, flags, conn_attrs, tls_sni_name
+    end
+
+    # Ask the server to abort the query this connection is currently
+    # running, via a short-lived helper connection issuing
+    # KILL QUERY <thread_id>. Safe to call from another thread while this
+    # connection is blocked in #query: the helper never touches this
+    # connection's own socket or protocol state. The victim connection
+    # then reads the server's answer to the killed query as usual --
+    # ER_QUERY_INTERRUPTED, or its completed result if the query won the
+    # race -- and stays usable.
+    def kill_query
+      kill 'QUERY'
+    end
+
+    # Hard-kill variant: KILL CONNECTION <thread_id> terminates this
+    # connection's server session outright. A thread blocked in #query on
+    # the victim connection wakes up with the connection error the server's
+    # hangup produces. Gives pools a sanctioned way to unstick a stuck
+    # connection they are about to discard.
+    def kill_connection
+      kill 'CONNECTION'
     end
 
     def parse_ssl_mode(mode)
@@ -234,8 +259,34 @@ module Mysql2
     private_constant :EMPTY_QUERY_OPTIONS
 
     def query(sql, options = EMPTY_QUERY_OPTIONS)
+      opts = @query_options.merge(options)
+      # Resolve the escalation budget before the query is in flight: a
+      # malformed :kill_grace raises here, at the call site, instead of
+      # surfacing mid-escalation with a timeout already in hand.
+      kill_grace = Float(opts[:kill_grace] || 5) if opts[:kill_on_timeout]
       Thread.handle_interrupt(::Mysql2::Util::TIMEOUT_ERROR_NEVER) do
-        _query(sql, @query_options.merge(options))
+        begin
+          _query(sql, opts)
+        rescue Exception => e # rubocop:disable Lint/RescueException -- interrupts arrive as non-StandardError classes (Timeout's, Thread#raise's)
+          begin
+            # Mask interrupts while settling the connection: a second one
+            # landing mid-escalation would abandon it half-resumed.
+            Thread.handle_interrupt(Object => :never) do
+              kill_and_resume_cancelled_query(kill_grace) if cancel_pending?
+            end
+          rescue StandardError
+            # The escalation is a safety net for the exception already in
+            # hand: a failure of its own -- a bug in the escalation path --
+            # must not replace that exception. The ensure below still tears
+            # down whatever the aborted escalation left behind.
+            nil
+          ensure
+            # Whatever cut the escalation short -- and, when kill_on_timeout
+            # isn't armed, this is a no-op on an already-settled connection.
+            abort_cancelled_query
+          end
+          raise e
+        end
       end
     end
 
@@ -288,6 +339,53 @@ module Mysql2
       # warning in ext/mysql2/result.c).
       warn ":cache_rows is ignored on a client with :stream enabled; pass cache_rows: false to acknowledge streaming semantics" \
         if @query_options[:stream] && @query_options[:cache_rows]
+    end
+
+    # Rungs 1 and 2 of the escalation for a kill_on_timeout query whose
+    # wait was interrupted (the C extension left the connection
+    # CANCEL_PENDING): ask the server to abort the in-flight query, then
+    # give the surviving connection `grace` seconds to read the
+    # server's acknowledgement -- normally ER_QUERY_INTERRUPTED, or the
+    # query's own result if it finished before the KILL landed. A
+    # Mysql2::Error along the way is the ladder resolving itself: either
+    # the helper/KILL failed, leaving the connection CANCEL_PENDING for
+    # the caller's ensure to tear down (rung 3), or the resumed read
+    # surfaced the server's error and the connection is settled. The
+    # caller re-raises the original timeout/interrupt regardless.
+    def kill_and_resume_cancelled_query(grace)
+      kill_query
+      resumed = resume_cancelled_query(grace)
+      # false means the grace period expired and the connection is
+      # already torn down. Anything else means the query finished before
+      # the KILL landed: drop any remaining result sets of a
+      # multi-statement batch so the connection is ready for its next
+      # command.
+      abandon_results! unless resumed == false
+    rescue Mysql2::Error
+      nil
+    end
+
+    # Factory for the KILL QUERY/CONNECTION helper connection used by
+    # #kill_query and #kill_connection: a second connection with this
+    # connection's own credentials (KILL requires the same user, SUPER, or
+    # CONNECTION_ADMIN), bounded so a wedged server can't hang the
+    # escalation -- small connect/read/write timeouts, one statement,
+    # closed immediately. A lambda over the connect options rather than the
+    # options in an ivar, so the password isn't somewhere #inspect prints.
+    def build_kill_helper(opts)
+      helper_opts = opts.merge(kill_on_timeout: false, connect_timeout: 5, read_timeout: 5, write_timeout: 5)
+      -> { self.class.new(helper_opts) }
+    end
+
+    def kill(target)
+      id = thread_id
+      helper = @kill_helper.call
+      begin
+        helper.query("KILL #{target} #{id}")
+      ensure
+        helper.close
+      end
+      nil
     end
 
     def check_and_clean_query_options

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -1340,6 +1340,187 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
         end.to raise_error(Mysql2::Error::TimeoutError)
       end
 
+      context "with :kill_on_timeout" do
+        def server_side_session(supervisor, client)
+          supervisor.query("SHOW PROCESSLIST").detect { |row| row['Id'] == client.thread_id }
+        end
+
+        it "stops the server-side query and keeps the connection on :read_timeout" do
+          client = new_client(read_timeout: 1, kill_on_timeout: true)
+          supervisor = new_client
+
+          expect { client.query("SELECT SLEEP(10)") }.to raise_error(Mysql2::Error::TimeoutError)
+
+          # Verify against the server, before using the victim connection for
+          # anything else: its session must still be registered but no longer
+          # executing the query.
+          victim = server_side_session(supervisor, client)
+          expect(victim).not_to be_nil
+          expect(victim['Info']).to be_nil
+
+          expect(client.query("SELECT 1 AS one").first).to eql('one' => 1)
+          expect(client.closed?).to be false
+        end
+
+        it "keeps the connection when the killed query dies with ER_QUERY_INTERRUPTED" do
+          supervisor = new_client
+          supervisor.query("SELECT GET_LOCK('mysql2_kill_on_timeout_spec', 10)")
+
+          # Unlike SLEEP above -- which reports being killed by completing
+          # early with a result -- a killed lock wait answers with
+          # ER_QUERY_INTERRUPTED (1317), so this exercises the resumed wait
+          # consuming an ordinary error packet. The caller still sees the
+          # timeout, not the interruption error. Also passes kill_on_timeout
+          # per-query rather than at connect, to cover that spelling.
+          client = new_client(read_timeout: 1)
+          expect do
+            client.query("SELECT GET_LOCK('mysql2_kill_on_timeout_spec', 30)", kill_on_timeout: true)
+          end.to raise_error(Mysql2::Error::TimeoutError)
+
+          expect(client.query("SELECT 1 AS one").first).to eql('one' => 1)
+        end
+
+        it "stops the server-side query and keeps the connection when the calling thread is interrupted" do
+          # ssl_mode pinned for the same reason as the non-standard exception
+          # class tests below: the interrupt must be able to fire mid-wait.
+          client = new_client(kill_on_timeout: true, ssl_mode: 'disabled')
+          supervisor = new_client
+
+          expect do
+            Timeout.timeout(0.2, ArgumentError) { client.query("SELECT SLEEP(10)") }
+          end.to raise_error(ArgumentError)
+
+          victim = server_side_session(supervisor, client)
+          expect(victim['Info']).to be_nil
+          expect(client.query("SELECT 1 AS one").first).to eql('one' => 1)
+        end
+
+        it "falls back to tearing down the connection when the KILL helper can't connect" do
+          client = new_client(read_timeout: 1, kill_on_timeout: true)
+          # Point the helper somewhere no server listens: rung 1 fails, so
+          # the escalation must skip straight to today's teardown.
+          client.instance_variable_set(:@kill_helper, -> { Mysql2::Client.new(host: '127.0.0.1', port: 2, connect_timeout: 1) })
+
+          expect { client.query("SELECT SLEEP(10)") }.to raise_error(Mysql2::Error::TimeoutError)
+          expect { client.query("SELECT 1") }.to raise_error(Mysql2::Error, 'MySQL client is not connected')
+        end
+
+        it "rejects a malformed :kill_grace at the call site, before the query runs" do
+          client = new_client(read_timeout: 1, kill_on_timeout: true)
+
+          expect { client.query("SELECT SLEEP(10)", kill_grace: "oops") }.to raise_error(ArgumentError)
+
+          # Nothing was sent: the connection is untouched and still usable.
+          expect(client.query("SELECT 1 AS one").first).to eql('one' => 1)
+        end
+
+        it "re-raises the original timeout when the escalation itself fails" do
+          client = new_client(read_timeout: 1, kill_on_timeout: true)
+          # A bug anywhere in the escalation path stays subordinate to the
+          # exception it is servicing: the caller sees the timeout, never
+          # the escalation's own error, and the connection is forfeited
+          # exactly as if kill_on_timeout were off.
+          allow(client).to receive(:kill_query).and_raise(ArgumentError, "bug in the escalation path")
+
+          expect { client.query("SELECT SLEEP(10)") }.to raise_error(Mysql2::Error::TimeoutError)
+          expect { client.query("SELECT 1") }.to raise_error(Mysql2::Error, 'MySQL client is not connected')
+        end
+
+        it "still tears down the connection when Thread#exit interrupts an armed query" do
+          # Thread#exit unwinds without an exception, so no rescue ever runs
+          # the escalation -- deferring teardown would leave the connection
+          # wedged on a dead fiber forever. The C extension only defers for
+          # exception unwinds; this must behave exactly like an unarmed
+          # interrupted query.
+          client = new_client(kill_on_timeout: true)
+          supervisor = new_client
+          thread = new_thread { client.query("SELECT SLEEP(10)") }
+          Timeout.timeout(5) do
+            sleep 0.05 until server_side_query(supervisor, client)
+          end
+
+          thread.exit
+          thread.join
+
+          expect { client.query("SELECT 1") }.to raise_error(Mysql2::Error, 'MySQL client is not connected')
+        end
+
+        it "tears down the connection when the grace period expires without a server response" do
+          client = new_client(read_timeout: 1, kill_on_timeout: true, kill_grace: 1)
+          # Neuter the KILL: the server keeps running the query, so the
+          # resumed wait must exhaust :kill_grace and forfeit the connection.
+          allow(client).to receive(:kill_query)
+
+          start = clock_time
+          expect { client.query("SELECT SLEEP(10)") }.to raise_error(Mysql2::Error::TimeoutError)
+          expect(clock_time - start).to be >= 2
+          expect { client.query("SELECT 1") }.to raise_error(Mysql2::Error, 'MySQL client is not connected')
+        end
+      end
+
+      describe "#kill_query" do
+        it "aborts an in-flight query from another thread, keeping the connection" do
+          client = new_client
+          supervisor = new_client
+          thr = new_thread do
+            begin
+              client.query("SELECT SLEEP(10) AS s")
+            rescue Mysql2::Error => e
+              e
+            end
+          end
+          Timeout.timeout(5) do
+            sleep 0.05 until server_side_query(supervisor, client)
+          end
+
+          start = clock_time
+          client.kill_query
+
+          # MySQL's SLEEP reports being killed mid-sleep by returning 1
+          # immediately; MariaDB aborts the statement with an error instead.
+          outcome = thr.value
+          if outcome.is_a?(Mysql2::Error)
+            expect(outcome.message).to match(/interrupted/i)
+          else
+            expect(outcome.first).to eql('s' => 1)
+          end
+          expect(clock_time - start).to be < 5
+          expect(client.query("SELECT 1 AS one").first).to eql('one' => 1)
+        end
+      end
+
+      describe "#kill_connection" do
+        it "hard-kills the server session so a blocked query errors out" do
+          client = new_client
+          supervisor = new_client
+          thr = new_thread do
+            begin
+              client.query("SELECT SLEEP(10)")
+              nil
+            rescue Mysql2::Error => e
+              e
+            end
+          end
+          Timeout.timeout(5) do
+            sleep 0.05 until server_side_query(supervisor, client)
+          end
+
+          client.kill_connection
+
+          error = thr.value
+          expect(error).to be_a(Mysql2::Error)
+          expect(error.message).to match(%r{Lost connection|TLS/SSL error})
+          expect { client.query("SELECT 1") }.to raise_error(Mysql2::Error)
+        end
+      end
+
+      # The session row for client on the server, but only while it is
+      # actually executing a query -- for waiting out the race between
+      # sending a query on another thread and the server starting to run it.
+      def server_side_query(supervisor, client)
+        supervisor.query("SHOW PROCESSLIST").detect { |row| row['Id'] == client.thread_id && row['Info'] }
+      end
+
       # XXX this test is not deterministic (because Unix signal handling is not)
       # and may fail on a loaded system
       it "should run signal handlers while waiting for a response" do


### PR DESCRIPTION
Proposed in #1511. Addresses the operational half of #1091, and supplies the hard-kill primitive that died with #1433.

When a query outlives :read_timeout or its thread is interrupted (Timeout.timeout, Thread#raise), mysql2 tears the connection down unconditionally -- and tells the server nothing. The server keeps executing the abandoned query until it finishes on its own, holding locks and burning CPU, and the connection is always sacrificed even though a timeout on an otherwise healthy connection is recoverable.

With kill_on_timeout: true (per connect or per query), Client#query instead runs the escalation ladder the mysql CLI's own Ctrl-C handler uses:

1. Issue KILL QUERY <thread_id> from a short-lived helper connection opened with the victim's own credentials (KILL requires same-user, SUPER, or CONNECTION_ADMIN, so same-user is the default path). The helper is bounded -- 5s connect/read/write timeouts, one statement, closed immediately (lib/mysql2/client.rb:252).
2. Resume waiting up to :kill_grace seconds (default 5) on the original connection. The expected outcome is the server abandoning the query and the client reading ER_QUERY_INTERRUPTED (1317) as an ordinary error packet -- the protocol stream stays in sync and the connection survives to run its next query. If the query finished before the KILL landed, its result is read and discarded (multi-statement leftovers via abandon_results!). Either way the caller still gets the original TimeoutError/interrupt, so Timeout.timeout semantics are preserved.
3. Only if the helper can't connect, the KILL fails, or the grace period expires does the connection get invalidated exactly as before.

### Mechanism

The C surface is deliberately thin; the policy lives in lib:

- The one recoverable window is the read-wait phase (do_query, client.c:1073): the command is fully sent and none of its response read, so the stream is intact. For kill_on_timeout queries that phase runs under rb_rescue2 (do_query_deferring_teardown, client.c:1100) whose companion defers teardown: it marks the connection MYSQL2_CLIENT_CANCEL_PENDING (client.h:20) instead of invalidating the fd, and re-raises (client.c:1092). Interrupted sends and mid-result reads keep today's unconditional teardown -- KILL can't resync a half-written or half-read stream.
- Thread#exit is a non-exception unwind: rb_rescue2 never sees it, so the existing rb_ensure companion tears down exactly as without the option -- no rescue upstream could ever run the escalation (spec: "Thread#exit interrupts an armed query").
- Client#query (lib/mysql2/client.rb:181) rescues, checks cancel_pending? (client.c:1140), and settles the connection under Thread.handle_interrupt(Object => :never): kill_and_resume_cancelled_query (lib/mysql2/client.rb:229) fires the KILL and calls resume_cancelled_query(grace) (client.c:1153), which re-waits on the fd and reuses the ordinary async_result/disconnect_and_mark_inactive read path. An ensure'd abort_cancelled_query (client.c:1187) is rung 3 as a callable: invalidate if still pending, no-op otherwise.
- The helper never touches the victim's MYSQL*, so there is no interaction with the active_fiber claim model; concurrent callers stay fenced off by active_fiber for the whole escalation.

The same machinery is public API:

- Client#kill_query -- cancel this connection's in-flight query from another thread; the blocked #query returns its error/result normally and the connection survives.
- Client#kill_connection -- KILL CONNECTION hard-kill, the sanctioned way for pools to unstick a connection they're about to discard (the capability lost when #1433 was closed unmerged).

Thread-id width: the KILL targets Client#thread_id, the id the server assigned at handshake. The handshake field is 32 bits, so on servers with wider connection ids the README documents SELECT CONNECTION_ID() as the alternative.

### Specs

All in the existing non-Windows guard, each verified to fail against deliberately broken builds:

| deliberate break | specs that catch it |
|-------------------------------------------------|---------------------|
| C deferral disabled (always plain teardown) | read_timeout-survive, ER_QUERY_INTERRUPTED, interrupt-survive, grace-expiry (4) |
| KILL statement never sent | all three keep-alive specs, #kill_query, #kill_connection (5) |
| ladder's rescue Mysql2::Error removed | ER_QUERY_INTERRUPTED, helper-unavailable fallback (2) |
| ensure-based deferral (defers Thread#exit too) | armed Thread#exit spec: fails with "in use by <dead fiber>" wedge (1) |

Server-side verification is direct: after the timeout raises, SHOW PROCESSLIST from a supervisor connection must show the victim session registered but idle (Info NULL) before the victim connection is touched again. Probed against MySQL 9.6: a killed SLEEP reports interruption by returning a result early (exercising the completed-result rung); a killed GET_LOCK wait raises 1317 (exercising the expected-error rung).

### Performance

Overhead on the unarmed hot path is one rb_hash_aref per synchronous query plus a Ruby rescue frame: tight SELECT 1 loop (7 samples x 20k queries, localhost, median qps) -- master 45,497 vs branch 45,286 (-0.5%, within run-to-run noise; sample ranges overlap fully).

### Behavior deltas

All opt-in unless noted:

- With kill_on_timeout enabled, the timeout/interrupt raise is delayed by the escalation: bounded by helper connect+kill (10s worst case) + :kill_grace. Defaults keep this ~15s worst case; typical is tens of milliseconds.
- A query that completes in the KILL race has its result discarded; the deadline contract wins over late delivery.
- Always-on (unarmed paths): Client#query gains a rescue-all that re-raises the same exception object after two cheap no-op C calls; initialize builds a helper-factory lambda per client (closes over the connect options, including the password -- held in the lambda rather than an ivar so #inspect doesn't print it).

### Coverage limits

- Client#query only. Statement#execute has no equivalent wait phase to resume (its interrupt handling is unchanged), and next_result's timeout path is likewise untouched. async: true callers own their own waits, so the ladder never arms there.
- Windows keeps plain teardown: the deferral lives in the non-Windows wait phase; cancel_pending? is always false there and the README documents the limitation.
- The ER_QUERY_INTERRUPTED spec asserts outcomes (timeout raised, connection survives), not the error number, so it stays valid on MariaDB even if a killed GET_LOCK reports differently there.
- Residual interrupt windows in the ladder itself are masked with handle_interrupt(Object => :never); an interrupt landing in the remaining one-call window before the mask (or on the ensure's own call site) degrades to rung-3 teardown -- parity with today -- except the ensure-call-site case, which can leave the connection fenced until its owning thread closes it. That window is the same class every Ruby ensure clause has.
