### PR TITLE
Drop the STMT_ATTR_UPDATE_MAX_LENGTH prepass: grow result buffers on demand

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -944,6 +944,11 @@ static VALUE mysql2_cast_integer(const char *str, unsigned long len) {
   }
 }
 
+/* Initial size for variable-length (char[]) result buffers. Wide enough that
+ * typical short strings, decimals, enums, and sets never truncate; anything
+ * wider grows to fit on first encounter and stays grown. */
+#define MYSQL2_INITIAL_BUFFER_LENGTH 128
+
 static void rb_mysql_result_alloc_result_buffers(VALUE self, MYSQL_FIELD *fields) {
   unsigned int i;
   GET_RESULT(self);
@@ -1007,8 +1012,14 @@ static void rb_mysql_result_alloc_result_buffers(VALUE self, MYSQL_FIELD *fields
       case MYSQL_TYPE_ENUM:         // char[]
       case MYSQL_TYPE_GEOMETRY:     // char[]
       default:
-        wrapper->result_buffers[i].buffer = xmalloc(fields[i].max_length);
-        wrapper->result_buffers[i].buffer_length = fields[i].max_length;
+        /* Variable-length columns start small and grow on demand: a value
+         * that doesn't fit comes back as MYSQL_DATA_TRUNCATED, and the
+         * fetch loop grows the buffer to the reported length and re-fetches
+         * the missing tail (see rb_mysql_result_fetch_row_stmt). Buffers
+         * never shrink, so each one levels off at its column's widest value
+         * actually read rather than the column's declared maximum. */
+        wrapper->result_buffers[i].buffer = xmalloc(MYSQL2_INITIAL_BUFFER_LENGTH);
+        wrapper->result_buffers[i].buffer_length = MYSQL2_INITIAL_BUFFER_LENGTH;
         break;
     }
 
@@ -1057,13 +1068,14 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
 
   /* Bind once per result set rather than once per row. The buffers are
    * allocated exactly once (rb_mysql_result_alloc_result_buffers returns early
-   * when they exist), but a variable-length column's buffer may grow later --
-   * see the MYSQL_DATA_TRUNCATED case below -- always in place, at the same
-   * address registered here, so the bind itself never needs to be redone.
-   * Buffers are only released by rb_mysql_result_free_result, which nulls the
-   * pointer and clears this flag. So the addresses registered here stay valid
-   * for every subsequent mysql_stmt_fetch on this result. Re-binding per row
-   * copied the whole MYSQL_BIND array into the statement each time for no gain.
+   * when they exist), and the addresses registered here stay valid for every
+   * subsequent mysql_stmt_fetch until a variable-length column's buffer is
+   * grown -- see the MYSQL_DATA_TRUNCATED case below. Both client libraries
+   * copy the MYSQL_BIND array into the statement handle at bind time, so a
+   * grow (xrealloc may move the buffer) leaves the registered copy pointing
+   * at freed memory; the grow path clears this flag so the next fetch
+   * re-registers the current addresses first. Re-binding per row copied the
+   * whole MYSQL_BIND array into the statement each time for no gain.
    *
    * Binding is tracked separately from allocation so that a failed bind is
    * still retried on a later fetch, exactly as it was when the bind ran on
@@ -1101,21 +1113,49 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
         return Qnil;
 
       case MYSQL_DATA_TRUNCATED: {
-        /* A streaming (cursor-mode) fetch never calls mysql_stmt_store_result(),
-         * so fields[i].max_length was never populated and buffers started too
-         * small -- see the alloc comment above. Grow just the truncated
-         * column(s) to their actual length (wrapper->length[i]) and re-fetch
-         * with mysql_stmt_fetch_column(), MySQL's documented recovery for this
-         * case. That call copies data already buffered in the client library,
-         * so no GVL release is needed here. */
+        /* One or more variable-length columns arrived wider than their
+         * current buffer (wrapper->error[j], populated by the fetch). Grow
+         * each one to the length the server reported for this row
+         * (wrapper->length[j], also populated by the fetch) and complete it
+         * with mysql_stmt_fetch_column(), MySQL's documented recovery for
+         * this case. The truncating fetch already copied the first
+         * buffer_length bytes and xrealloc preserves them, so the re-fetch
+         * starts at that offset and copies only the missing tail -- from the
+         * client library's own row buffer, so no network I/O and no GVL
+         * release. The tail fetch reports into scratch variables: the row's
+         * authoritative length/error/is_null were already set by the
+         * truncating fetch, and what a partial fetch writes back to them
+         * differs between client libraries. */
         unsigned int j;
+
+        /* Growing can move a buffer, leaving the binds registered in the
+         * statement handle pointing at freed memory, so re-register them
+         * before the next fetch. Cleared before the loop rather than after
+         * it so a mid-loop allocation failure or fetch_column error cannot
+         * leave a stale registration behind for a rescued fetch to write
+         * through. */
+        wrapper->result_buffers_bound = 0;
+
         for (j = 0; j < wrapper->numberOfFields; j++) {
+          MYSQL_BIND tail;
+          unsigned long filled, tail_length = 0;
+          my_bool tail_error = 0;
+          my_bool tail_is_null = 0;
+
           if (!wrapper->error[j]) continue;
 
+          filled = wrapper->result_buffers[j].buffer_length;
           wrapper->result_buffers[j].buffer = xrealloc(wrapper->result_buffers[j].buffer, wrapper->length[j]);
           wrapper->result_buffers[j].buffer_length = wrapper->length[j];
 
-          if (mysql_stmt_fetch_column(wrapper->stmt_wrapper->stmt, &wrapper->result_buffers[j], j, 0)) {
+          tail = wrapper->result_buffers[j];
+          tail.buffer = (char *)tail.buffer + filled;
+          tail.buffer_length = wrapper->length[j] - filled;
+          tail.length = &tail_length;
+          tail.error = &tail_error;
+          tail.is_null = &tail_is_null;
+
+          if (mysql_stmt_fetch_column(wrapper->stmt_wrapper->stmt, &tail, j, filled)) {
             rb_raise_mysql2_stmt_error(wrapper->stmt_wrapper);
           }
         }

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -195,14 +195,6 @@ VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql) {
     rb_raise(cMysql2Error, "Unable to initialize prepared statement: out of memory");
   }
 
-  // set STMT_ATTR_UPDATE_MAX_LENGTH attr
-  {
-    my_bool truth = 1;
-    if (mysql_stmt_attr_set(stmt_wrapper->stmt, STMT_ATTR_UPDATE_MAX_LENGTH, &truth)) {
-      rb_raise(cMysql2Error, "Unable to initialize prepared statement: set STMT_ATTR_UPDATE_MAX_LENGTH");
-    }
-  }
-
   // call mysql_stmt_prepare w/o gvl
   {
     struct nogvl_prepare_statement_args args;

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -429,12 +429,60 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
     end
 
     it "should return wide variable-width columns correctly on every row" do
-      # Variable-width buffers are sized once, from fields[i].max_length. A row
+      # Variable-width buffers start at a small fixed size and grow on
+      # MYSQL_DATA_TRUNCATED (see rb_mysql_result_fetch_row_stmt). A row
       # fetched into a stale or too-short buffer would be truncated or wrong
-      # here, where the value is far larger than any inline buffer.
+      # here, where the value is far larger than the initial buffer.
       expected = ['a' * 60_000, 'b' * 60_000]
       result = @client.prepare("SELECT REPEAT('a', 60000) AS v UNION ALL SELECT REPEAT('b', 60000)").execute
       expect(result.to_a.map { |row| row['v'] }).to eq(expected)
+    end
+
+    it "should grow the result buffer past a wide value and keep every later row intact" do
+      # A wide value truncates, grows its buffer to fit, and completes via a
+      # tail-only mysql_stmt_fetch_column at the truncation offset; growing
+      # can move the buffer, so the statement's registered binds are
+      # re-registered before the next fetch. The varied byte patterns make a
+      # misplaced tail (wrong offset, or a skipped tail fetch) show up as a
+      # content mismatch, and the rows after each wide one catch a bind left
+      # pointing at the buffer's pre-grow address.
+      @client.query("DROP TABLE IF EXISTS stmt_buffer_grow_test")
+      @client.query("CREATE TABLE stmt_buffer_grow_test (id INT PRIMARY KEY AUTO_INCREMENT, data MEDIUMBLOB)")
+
+      begin
+        pattern = ->(n) { (0...n).map { |i| ((i * 7 + 13) % 256).chr }.join.b }
+        rows = [pattern.call(10), pattern.call(1_000_000), pattern.call(200), pattern.call(2_000_000), nil, pattern.call(10)]
+        ins = @client.prepare("INSERT INTO stmt_buffer_grow_test (data) VALUES (?)")
+        rows.each { |v| ins.execute(v) }
+
+        stmt = @client.prepare("SELECT data FROM stmt_buffer_grow_test ORDER BY id")
+        expect(stmt.execute.to_a.map { |r| r["data"] }).to eq(rows)
+      ensure
+        @client.query("DROP TABLE IF EXISTS stmt_buffer_grow_test")
+      end
+    end
+
+    it "should grow multiple truncated columns in the same row" do
+      # Each truncated column in a row is grown and tail-fetched
+      # independently before the binds are re-registered once.
+      @client.query("DROP TABLE IF EXISTS stmt_multi_grow_test")
+      @client.query("CREATE TABLE stmt_multi_grow_test (id INT PRIMARY KEY AUTO_INCREMENT, a MEDIUMBLOB, b MEDIUMBLOB)")
+
+      begin
+        pattern = ->(n, salt) { (0...n).map { |i| ((i * 11 + salt) % 256).chr }.join.b }
+        rows = [
+          [pattern.call(5, 3), pattern.call(7, 5)],
+          [pattern.call(70_000, 17), pattern.call(90_000, 29)],
+          [pattern.call(9, 7), pattern.call(4, 11)],
+        ]
+        ins = @client.prepare("INSERT INTO stmt_multi_grow_test (a, b) VALUES (?, ?)")
+        rows.each { |a, b| ins.execute(a, b) }
+
+        stmt = @client.prepare("SELECT a, b FROM stmt_multi_grow_test ORDER BY id")
+        expect(stmt.execute.to_a.map { |r| [r["a"], r["b"]] }).to eq(rows)
+      ensure
+        @client.query("DROP TABLE IF EXISTS stmt_multi_grow_test")
+      end
     end
 
     it "should yield rows as hash's with symbol keys if :symbolize_keys was set to true" do
@@ -497,11 +545,6 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
       # Result#fields behaves exactly as it did with the per-cell
       # materialization over the binary protocol, including after an abandoned
       # stream is force-freed by the next query.
-      #
-      # Integer-only columns: streaming prepared statements size their result
-      # buffers from fields[i].max_length, which is 0 for var-length columns
-      # without mysql_stmt_store_result -- a pre-existing limitation unrelated
-      # to field names.
       let(:sql) { "SELECT 1 AS a, 10 AS b UNION SELECT 2, 20 UNION SELECT 3, 30" }
 
       it "should return field names after iteration" do
@@ -931,15 +974,10 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
       expect(row['int_val']).to eql(1)
     end
 
-    it "passes through streaming execution" do
-      # Streaming prepared statements cannot return string values at all,
-      # with or without this option: statement streaming skips
-      # mysql_stmt_store_result, leaving max_length 0, and string fetches
-      # die with MYSQL_DATA_TRUNCATED ("IMPLBUG..."). So there is nothing to
-      # retag here; pin that the option at least threads through the
-      # streaming execute path unharmed.
-      rows = @client.prepare("SELECT 1 UNION SELECT 2").execute(stream: true, cache_rows: false, as: :array, force_encoding: 'binary').to_a
-      expect(rows).to eql([[1], [2]])
+    it "retags string values through streaming execution" do
+      rows = @client.prepare("SELECT 'ab' UNION SELECT 'cd'").execute(stream: true, cache_rows: false, as: :array, force_encoding: 'binary').to_a
+      expect(rows).to eql([['ab'], ['cd']])
+      expect(rows.flatten.map(&:encoding).uniq).to eql([Encoding::BINARY])
     end
 
     it "raises for an unknown encoding name before the statement executes" do


### PR DESCRIPTION
Proposed in #1520.

Every prepared statement enabled `STMT_ATTR_UPDATE_MAX_LENGTH` at prepare time, making `mysql_stmt_store_result` take an extra pass over each buffered result to populate `fields[i].max_length`, which the fetch path then used to size every variable-length column buffer before the first row was read. That is a whole-result scan per store, and worst-case allocation: one 10MB blob among 10k narrow rows means a 10MB buffer per string-ish column even when the caller stops after one narrow row. It also forked the statement fetch code: a streaming (cursor) result never stores, so its max_length was always 0 and streaming needed the truncation-regrow path from the #1058 fix to return strings at all.

Both paths now start variable-length buffers at a small fixed size (`MYSQL2_INITIAL_BUFFER_LENGTH`, 128 bytes, result.c:950) and share one grow path: a value that doesn't fit comes back `MYSQL_DATA_TRUNCATED` with the too-small columns flagged in the per-column `error[]` array and their true lengths in `length[]`, and the fetch loop grows exactly those buffers (result.c:1115). Buffers never shrink, so each levels off at the widest value its column actually produced rather than the column's declared maximum.

Two mechanics changed alongside, both forced by the nonzero initial size:

- The re-fetch is tail-only. The truncating fetch already copied the first `buffer_length` bytes into the bound buffer -- both client libraries fill it before flagging truncation -- and xrealloc preserves them, so `mysql_stmt_fetch_column` now starts at that offset and copies only the missing remainder (result.c:1158). The regrow path introduced for streaming re-fetched from offset 0, equivalent only while the pre-grow buffer held zero bytes. The tail fetch reports through scratch variables because what a partial fetch writes back to length/error/is_null differs between client libraries, and the values from the truncating fetch are the authoritative ones.
- Growing re-registers the binds. Both libmysqlclient and mariadb-connector-c memcpy the `MYSQL_BIND` array into the statement handle at bind time, so once xrealloc moves a buffer the registered copy points at freed memory. The grow path clears `result_buffers_bound` (result.c:1137) and the existing bind-on-next-fetch block re-registers the current addresses; the flag is cleared before the grow loop so a mid-loop allocation failure or fetch_column error cannot leave a stale registration behind for a rescued fetch to write through. The streaming-only regrow never needed this because its buffers started at zero bytes: the registered `buffer_length` stayed 0, the stale pointer was never written, and every nonempty value was re-fetched through `mysql_stmt_fetch_column` with a realloc on every row. Those per-row costs are gone; streaming now levels off exactly like buffered.

Truncation parity was verified on both client libraries against a MySQL 9.6 server: libmysqlclient 9.6.0 (macOS arm64) and MariaDB Connector/C 3.4.9 (Linux x86_64). `MYSQL_DATA_TRUNCATED`, the per-column `error[]` flags, tail-offset `mysql_stmt_fetch_column`, and a mid-result `mysql_stmt_bind_result` behave identically on both -- shown by content-exact specs rather than reasoning: the new specs use varied byte patterns, so a misplaced or skipped tail surfaces as a mismatch, not a lucky pass.

Each new spec was verified to fail against a deliberately broken build:

- "should grow the result buffer past a wide value and keep every later row intact": with the re-bind removed, the process aborts on the row after the 1MB grow (stale registered buffer); with the fetch_column offset forced to 0, it fails with a visibly duplicated 128-byte prefix; with the tail fetch skipped, it fails on content.
- "should grow multiple truncated columns in the same row": fails on the same offset-0 and skipped-tail breaks.
- The force_encoding streaming spec, written when streaming statements could not return strings at all, now asserts the retag on streamed strings instead of pinning that limitation.

Bench: prepared statements over 10k narrow rows (VARCHAR(32) + 100-byte blob) plus one 10MB blob row; medians over 9 samples of min-of-5 each, base -> branch. Linux numbers from a 32-core x86_64 host holding an exclusive lock on the bench rig, load < 1.5; server MySQL 9.6.0 for both columns.

| arm | Linux x86_64, libmariadb 3.4.9 | macOS arm64, libmysqlclient 9.6.0 |
|---|---|---|
| store + first row (blob table) | 9.03 -> 8.78 ms | 13.79 -> 13.36 ms |
| full iteration (blob table) | 9.04 -> 8.94 ms | 14.38 -> 13.62 ms |
| full iteration (no blob) | 4.06 -> 4.03 ms | 5.58 -> 5.68 ms |
| stream 10k x 500-byte strings | 270.0 -> 262.1 ms | 402.7 -> 379.1 ms |
| ratchet: every row wider than the last | 148.3 -> 146.4 ms | 134.5 -> 136.0 ms |
| store + first row, fresh-process RSS | 60.5 -> 60.9 MB | 79.5 -> 79.4 MB |

The honest reading: the removed store-time scan is nearly free at this scale, so the buffered arms move only a few percent; streaming gains 3-6% from shedding its per-row realloc + re-fetch; and the adversarial ratchet shape -- every row a new high-water mark, so one grow + tail fetch + re-bind per row -- costs nothing measurable on either allocator. Resident memory is flat because the 10MB buffer the base build allocated up front was never touched before the blob row arrived, and the blob bytes live in the client library's stored result either way: the allocation win is address space and allocator traffic, not RSS, and becomes concrete only where a huge max_length made the upfront allocation itself fail or many wide columns multiplied it.

Behavior deltas: `fields[i].max_length` is no longer populated on prepared-statement results -- mysql2 never exposed it to Ruby, so nothing observable changes. A buffered result's first value wider than 128 bytes per column now costs one xrealloc + tail fetch + re-bind where it previously cost a whole-result scan and a max_length-sized allocation before the first row.

Coverage limits: both client libraries were exercised against a MySQL 9.6 server locally; MariaDB servers are covered by the existing CI matrix, and Windows' vendored libmariadb only by CI.

Heads-up for #1525 and #1526, written in parallel against the same buffer-sizing code: this deletes the attr set in statement.c and rewrites the char[] sizing default and `MYSQL_DATA_TRUNCATED` case in result.c, so branches based on the old shape will need to rebase across it.
