### PR TITLE
stmt results: elect bind types by cast mode, honoring cast: false and :fast

### DIFF
--- a/README.md
+++ b/README.md
@@ -690,7 +690,9 @@ result = client.query("SELECT * FROM table", :cast => :fast)
 
 This is for callers that consume mysql2 results directly -- raw-mysql2 pipelines, ETL jobs, and applications that do their own value parsing -- where DECIMAL and temporal columns are often passed through or parsed lazily, and paying BigDecimal/Time construction for every cell up front is waste. Your code must be prepared to receive Strings for those columns. Note that Active Record does not use this option.
 
-Any `:cast` value other than the exact symbol `:fast` (or `false`/`nil`) keeps meaning full casting. Prepared statement results are always fully cast, as with `:cast => false`.
+Any `:cast` value other than the exact symbol `:fast` (or `false`/`nil`) keeps meaning full casting.
+
+Prepared statements honor `:cast => false` and `:cast => :fast` too: result columns are bound as strings, so the client library delivers each value's string form from the binary protocol. Those strings are value-equivalent to the text protocol's, and byte-identical for every column type in the spec suite's parity matrix, under both libmysqlclient and libmariadb. Pass `:cast` to `Statement#execute` (or set it client-wide): non-streaming `#execute` materializes rows internally with `#each`, so a `:cast` passed to a later `Result#each` call only applies to rows not already materialized.
 
 ### Async
 

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -121,6 +121,27 @@ static void rb_mysql_result_mark(void * wrapper) {
   }
 }
 
+/* Free the statement result bind buffers so the next fetch (or the next
+ * statement execute) allocates and binds fresh ones. Called from
+ * rb_mysql_result_free_result and when a fetch needs buffers of the other
+ * bind-type election (see result_buffers_string_binds in result.h). */
+static void rb_mysql_result_free_result_buffers(mysql2_result_wrapper *wrapper) {
+  if (wrapper->result_buffers) {
+    unsigned int i;
+    for (i = 0; i < wrapper->numberOfFields; i++) {
+      if (wrapper->result_buffers[i].buffer) {
+        xfree(wrapper->result_buffers[i].buffer);
+      }
+    }
+    xfree(wrapper->result_buffers);
+    xfree(wrapper->is_null);
+    xfree(wrapper->error);
+    xfree(wrapper->length);
+  }
+  wrapper->result_buffers = NULL;
+  wrapper->result_buffers_bound = 0;
+}
+
 /* this may be called manually or during GC.
  *
  * from_dfree_callback must be true when called from rb_mysql_result_free
@@ -177,21 +198,7 @@ static void rb_mysql_result_free_result(mysql2_result_wrapper * wrapper, int fro
         decr_mysql2_stmt(wrapper->stmt_wrapper);
       }
 
-      if (wrapper->result_buffers) {
-        unsigned int i;
-        for (i = 0; i < wrapper->numberOfFields; i++) {
-          if (wrapper->result_buffers[i].buffer) {
-            xfree(wrapper->result_buffers[i].buffer);
-          }
-        }
-        xfree(wrapper->result_buffers);
-        xfree(wrapper->is_null);
-        xfree(wrapper->error);
-        xfree(wrapper->length);
-      }
-      /* Clue that the next statement execute will need to allocate a new result buffer. */
-      wrapper->result_buffers = NULL;
-      wrapper->result_buffers_bound = 0;
+      rb_mysql_result_free_result_buffers(wrapper);
     }
 
     /* For prepared statements, wrapper->result is the result metadata
@@ -944,7 +951,7 @@ static VALUE mysql2_cast_integer(const char *str, unsigned long len) {
   }
 }
 
-static void rb_mysql_result_alloc_result_buffers(VALUE self, MYSQL_FIELD *fields) {
+static void rb_mysql_result_alloc_result_buffers(VALUE self, MYSQL_FIELD *fields, int stringBinds) {
   unsigned int i;
   GET_RESULT(self);
 
@@ -954,8 +961,86 @@ static void rb_mysql_result_alloc_result_buffers(VALUE self, MYSQL_FIELD *fields
   wrapper->is_null = xcalloc(wrapper->numberOfFields, sizeof(my_bool));
   wrapper->error = xcalloc(wrapper->numberOfFields, sizeof(my_bool));
   wrapper->length = xcalloc(wrapper->numberOfFields, sizeof(unsigned long));
+  wrapper->result_buffers_string_binds = stringBinds;
 
   for (i = 0; i < wrapper->numberOfFields; i++) {
+    if (stringBinds) {
+      /* cast: false / :fast -- bind MYSQL_TYPE_STRING so the client library
+       * converts every value to its string form (the documented
+       * mysql_stmt_bind_result conversion table) and no per-cell cast layer
+       * is needed on fetch. Fixed-width server types need type-derived
+       * sizes: for a stored result fields[i].max_length is the BINARY wire
+       * length (4 bytes for an INT), not the converted string length, and
+       * for a streaming result it is 0. Each constant is the widest value
+       * the type can print ("-2147483648" for LONG, "-838:59:59.000000" for
+       * TIME, ...), further widened to fields[i].length because the client
+       * library pads ZEROFILL columns to their display width and my_fcvt
+       * output for a DOUBLE(M,D) scales with M and D. FLOAT/DOUBLE get
+       * enough headroom that the conversion never has to round: libmysql
+       * limits my_gcvt precision to the bind's buffer_length, so an
+       * undersized buffer would silently lose digits rather than report
+       * truncation. Variable-length types keep max_length sizing and the
+       * MYSQL_DATA_TRUNCATED grow-and-refetch backstop, exactly as under
+       * server-type binds. */
+      unsigned long len;
+      int fixed_width = 1;
+
+      switch(fields[i].type) {
+        case MYSQL_TYPE_NULL:
+          len = 0;
+          break;
+        case MYSQL_TYPE_TINY:
+          len = 4;   // "-128"
+          break;
+        case MYSQL_TYPE_SHORT:
+        case MYSQL_TYPE_YEAR:
+          len = 6;   // "-32768"
+          break;
+        case MYSQL_TYPE_INT24:
+        case MYSQL_TYPE_LONG:
+          len = 11;  // "-2147483648"
+          break;
+        case MYSQL_TYPE_LONGLONG:
+          len = 20;  // "-9223372036854775808"
+          break;
+        case MYSQL_TYPE_FLOAT:
+        case MYSQL_TYPE_DOUBLE:
+          len = 512; // my_fcvt worst case (DOUBLE(255,30) fixed notation) plus headroom
+          break;
+        case MYSQL_TYPE_TIME:
+          len = 17;  // "-838:59:59.000000"
+          break;
+        case MYSQL_TYPE_DATE:
+        case MYSQL_TYPE_NEWDATE:
+          len = 10;  // "2010-04-04"
+          break;
+        case MYSQL_TYPE_DATETIME:
+        case MYSQL_TYPE_TIMESTAMP:
+          len = 26;  // "2010-04-04 11:44:00.123456"
+          break;
+        default:
+          /* Variable-length: fields[i].length is the declared maximum (4GB
+           * for LONGBLOB), so only the fixed-width widening below wants it. */
+          len = fields[i].max_length;
+          fixed_width = 0;
+          break;
+      }
+      if (fields[i].type != MYSQL_TYPE_NULL) {
+        if (fixed_width && len < fields[i].length) len = fields[i].length;
+        wrapper->result_buffers[i].buffer_type = MYSQL_TYPE_STRING;
+        wrapper->result_buffers[i].buffer = xmalloc(len);
+      } else {
+        wrapper->result_buffers[i].buffer_type = MYSQL_TYPE_NULL;
+      }
+      wrapper->result_buffers[i].buffer_length = len;
+
+      wrapper->result_buffers[i].is_null = &wrapper->is_null[i];
+      wrapper->result_buffers[i].length  = &wrapper->length[i];
+      wrapper->result_buffers[i].error   = &wrapper->error[i];
+      wrapper->result_buffers[i].is_unsigned = ((fields[i].flags & UNSIGNED_FLAG) != 0);
+      continue;
+    }
+
     wrapper->result_buffers[i].buffer_type = fields[i].type;
 
     //      mysql type    |            C type
@@ -1051,8 +1136,20 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
 #endif
   }
 
+  /* Bind types are elected from the cast mode (see the string-binds arm of
+   * rb_mysql_result_alloc_result_buffers), so buffers left by an earlier
+   * #each with the other cast mode cannot be decoded through -- free them
+   * and let the re-allocation below elect afresh. The client library
+   * applies result binds at fetch time, so rows not yet fetched (this only
+   * arises when an earlier iteration stopped short) convert under the new
+   * types; already-yielded rows are unaffected. */
+  if (wrapper->result_buffers != NULL &&
+      wrapper->result_buffers_string_binds != (args->cast != MYSQL2_CAST_ALL)) {
+    rb_mysql_result_free_result_buffers(wrapper);
+  }
+
   if (wrapper->result_buffers == NULL) {
-    rb_mysql_result_alloc_result_buffers(self, fields);
+    rb_mysql_result_alloc_result_buffers(self, fields, args->cast != MYSQL2_CAST_ALL);
   }
 
   /* Bind once per result set rather than once per row. The buffers are
@@ -1131,6 +1228,39 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
     rb_mysql_result_materialize_field_names(self, args->symbolizeKeys);
   }
 
+  /* cast: false -- every column is string-bound (see
+   * rb_mysql_result_alloc_result_buffers), so every non-NULL cell is the
+   * client library's string conversion of the value: a raw String with the
+   * right encoding, no type dispatch at all. This loop is the stmt twin of
+   * the MYSQL2_CAST_NONE loop in rb_mysql_result_fetch_row: the same
+   * length-based rb_str_new (embedded NULs intact), the same
+   * mysql2_set_field_string_encoding, the same MYSQL_TYPE_NULL and NULL-cell
+   * handling, and the same key-before-value evaluation order. */
+  if (args->cast == MYSQL2_CAST_NONE) {
+    for (i = 0; i < wrapper->numberOfFields; i++) {
+      /* Hash keys only; array-mode names were batch-materialized above. */
+      VALUE field = args->asArray ? Qnil : rb_mysql_result_fetch_field(self, i, args->symbolizeKeys);
+      VALUE val;
+
+      if (!wrapper->is_null[i] && fields[i].type != MYSQL_TYPE_NULL) {
+        val = rb_str_new(wrapper->result_buffers[i].buffer, wrapper->length[i]);
+        val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc, wrapper->forced_enc);
+      } else {
+        val = Qnil;
+      }
+
+      if (args->asArray) {
+        args->rowScratch[i] = val;
+      } else {
+        rb_hash_aset(rowVal, field, val);
+      }
+    }
+    if (args->asArray) {
+      rowVal = rb_ary_new4(wrapper->numberOfFields, args->rowScratch);
+    }
+    return rowVal;
+  }
+
   for (i = 0; i < wrapper->numberOfFields; i++) {
     /* Hash keys only; array-mode names were batch-materialized above. */
     VALUE field = args->asArray ? Qnil : rb_mysql_result_fetch_field(self, i, args->symbolizeKeys);
@@ -1139,6 +1269,61 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
 
     if (wrapper->is_null[i]) {
       val = Qnil;
+    } else if (args->cast == MYSQL2_CAST_FAST) {
+      /* cast: :fast over string-bound columns: dispatch on the server type
+       * (every buffer_type is MYSQL_TYPE_STRING here) and mirror the text
+       * path's :fast contract cell for cell -- cast the cheap types from
+       * their string bytes with the same mechanisms (mysql2_cast_integer,
+       * Kernel#Float, the :cast_booleans checks), defer everything
+       * expensive (DECIMAL, temporals) as tagged Strings. */
+      const MYSQL_BIND* const result_buffer = &wrapper->result_buffers[i];
+      const char *str = result_buffer->buffer;
+      const unsigned long len = *(result_buffer->length);
+
+      switch(fields[i].type) {
+        case MYSQL_TYPE_NULL:
+          val = Qnil;
+          break;
+        case MYSQL_TYPE_TINY:
+          if (args->castBool && fields[i].length == 1) {
+            val = *str != '0' ? Qtrue : Qfalse;
+            break;
+          }
+          /* Deliberate fallthrough into the integer cases, exactly as in
+           * rb_mysql_result_fetch_row. */
+        case MYSQL_TYPE_SHORT:
+        case MYSQL_TYPE_LONG:
+        case MYSQL_TYPE_INT24:
+        case MYSQL_TYPE_LONGLONG:
+        case MYSQL_TYPE_YEAR:
+          val = mysql2_cast_integer(str, len);
+          break;
+        case MYSQL_TYPE_BIT:
+          /* String-bound BIT is a byte copy, so the boolean check reads the
+           * raw byte, as the text path reads the wire byte. */
+          if (args->castBool && fields[i].length == 1) {
+            val = *str == 1 ? Qtrue : Qfalse;
+          } else {
+            val = rb_str_new(str, len);
+          }
+          break;
+        case MYSQL_TYPE_FLOAT:
+        case MYSQL_TYPE_DOUBLE: {
+          /* Kernel#Float() parses this locale-independently; strtod()
+           * would read '.' according to the current LC_NUMERIC. */
+          VALUE column_as_float = rb_funcall(rb_mKernel, intern_Float, 1, rb_str_new(str, len));
+          if (RFLOAT_VALUE(column_as_float) == 0.000000){
+            val = opt_float_zero;
+          }else{
+            val = column_as_float;
+          }
+          break;
+        }
+        default:
+          val = rb_str_new(str, len);
+          val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc, wrapper->forced_enc);
+          break;
+      }
     } else {
       const MYSQL_BIND* const result_buffer = &wrapper->result_buffers[i];
 
@@ -2015,13 +2200,6 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
   if (wrapper->stmt_wrapper && !cacheRows && !wrapper->is_streaming) {
     rb_warn(":cache_rows is forced for prepared statements (if not streaming)");
     cacheRows = 1;
-  }
-
-  /* The binary-protocol row fetch (rb_mysql_result_fetch_row_stmt) always
-   * fully casts; the existing warning already reads as "any non-true :cast
-   * is overridden here", so cast: :fast reuses it verbatim. */
-  if (wrapper->stmt_wrapper && cast != MYSQL2_CAST_ALL) {
-    rb_warn(":cast is forced for prepared statements");
   }
 
   /* A freed result can only be re-iterated from the fully cached rows array

--- a/ext/mysql2/result.h
+++ b/ext/mysql2/result.h
@@ -30,9 +30,9 @@ void mysql2_result_force_free(VALUE self);
  * nothing here is a heap VALUE, so no GC marking is needed. A call that
  * passes per-each options neither reads nor writes this cache.
  *
- * cacheRows and cast are stored as parsed, before the prepared-statement
- * forcing in #each, so the warnings and forcing replay identically on every
- * call whether the parse was cached or not. warnDbTimezone records that the
+ * cacheRows is stored as parsed, before the prepared-statement forcing in
+ * #each, so the warning and forcing replay identically on every call
+ * whether the parse was cached or not. warnDbTimezone records that the
  * invalid-:database_timezone warning must be re-issued (each warns every
  * call, and the warning point is after the freed-result guard). */
 typedef struct {
@@ -86,6 +86,11 @@ typedef struct {
   unsigned int server_status;
   /* statement result bind buffers */
   char result_buffers_bound;
+  /* Whether result_buffers were elected as MYSQL_TYPE_STRING binds (cast:
+   * false / :fast) rather than server-type binds (cast: true). Consulted on
+   * every fetch so a later #each with the other cast mode frees and
+   * re-elects the buffers instead of decoding through the wrong types. */
+  char result_buffers_string_binds;
   MYSQL_BIND *result_buffers;
   my_bool *is_null;
   my_bool *error;

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -1644,6 +1644,7 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
           bigint_umax_col BIGINT UNSIGNED,
           decimal_col DECIMAL(10,3),
           float_col FLOAT(10,3),
+          double_col DOUBLE,
           date_col DATE,
           datetime_col DATETIME(6),
           time_col TIME,
@@ -1658,12 +1659,13 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
       ]
       @client.query %[
         INSERT INTO mysql2_cast_false_test VALUES
-          (1, -2147483648, 18446744073709551615, 10.3, 10.3, '2010-04-04',
+          (1, -2147483648, 18446744073709551615, 10.3, 10.3,
+           1.7976931348623157e308, '2010-04-04',
            '2010-04-04 11:44:00.123456', '-838:59:59', 2009, b'101', 1,
            'héllo ☃', 'héllo', _binary X'00DEADBEEF00FF', _binary X'760062'),
-          (2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+          (2, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
            NULL, NULL, NULL, NULL),
-          (3, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+          (3, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
            '', '', '', '')
       ]
     end
@@ -1672,8 +1674,8 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
 
     let(:column_names) do
       %w[
-        row_id int_min_col bigint_umax_col decimal_col float_col date_col datetime_col time_col
-        year_col bit_col tiny1_col varchar_utf8_col varchar_latin1_col blob_col varbinary_col
+        row_id int_min_col bigint_umax_col decimal_col float_col double_col date_col datetime_col
+        time_col year_col bit_col tiny1_col varchar_utf8_col varchar_latin1_col blob_col varbinary_col
       ]
     end
 
@@ -1690,6 +1692,10 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
           'bigint_umax_col'    => ["18446744073709551615", Encoding::BINARY],
           'decimal_col'        => ["10.300", Encoding::BINARY],
           'float_col'          => ["10.300", Encoding::BINARY],
+          # Shortest round-trip formatting of DBL_MAX: the widest spot in the
+          # parity matrix for the client library's double-to-string
+          # conversion on the prepared-statement path.
+          'double_col'         => ["1.7976931348623157e308", Encoding::BINARY],
           'date_col'           => ["2010-04-04", Encoding::BINARY],
           'datetime_col'       => ["2010-04-04 11:44:00.123456", Encoding::BINARY],
           'time_col'           => ["-838:59:59", Encoding::BINARY],
@@ -1704,7 +1710,7 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
         {
           'row_id' => ["2", Encoding::BINARY],
           'int_min_col' => nil, 'bigint_umax_col' => nil, 'decimal_col' => nil,
-          'float_col' => nil, 'date_col' => nil, 'datetime_col' => nil,
+          'float_col' => nil, 'double_col' => nil, 'date_col' => nil, 'datetime_col' => nil,
           'time_col' => nil, 'year_col' => nil, 'bit_col' => nil,
           'tiny1_col' => nil, 'varchar_utf8_col' => nil,
           'varchar_latin1_col' => nil, 'blob_col' => nil, 'varbinary_col' => nil,
@@ -1712,7 +1718,7 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
         {
           'row_id' => ["3", Encoding::BINARY],
           'int_min_col' => nil, 'bigint_umax_col' => nil, 'decimal_col' => nil,
-          'float_col' => nil, 'date_col' => nil, 'datetime_col' => nil,
+          'float_col' => nil, 'double_col' => nil, 'date_col' => nil, 'datetime_col' => nil,
           'time_col' => nil, 'year_col' => nil, 'bit_col' => nil,
           'tiny1_col' => nil,
           'varchar_utf8_col' => ["", Encoding::UTF_8],
@@ -1810,14 +1816,100 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
       expect(result.fields).to eql(column_names)
     end
 
-    it "does not fast-path prepared statements: cast: false still warns and fully casts" do
-      statement = @client.prepare("SELECT int_min_col, date_col, varchar_utf8_col FROM mysql2_cast_false_test WHERE row_id = 1")
-      row = nil
-      expect { row = statement.execute(cast: false).first }
-        .to output(/:cast is forced for prepared statements/).to_stderr
-      expect(row['int_min_col']).to eql(-2147483648)
-      expect(row['date_col']).to eql(Date.new(2010, 4, 4))
-      expect(row['varchar_utf8_col']).to eql("héllo ☃")
+    # The prepared-statement (binary protocol) specs below assert the same
+    # expected literals as the text-protocol specs above: the parity matrix.
+    # The client library converts every string-bound value, so byte equality
+    # with the text protocol is an empirical property of the client library,
+    # not a guarantee -- these pin it per column type so any client-library
+    # divergence surfaces as a named, visible failure rather than silently.
+    it "honors cast: false on prepared statements without a warning" do
+      statement = @client.prepare(parity_select)
+      rows = nil
+      expect { rows = statement.execute(cast: false).to_a }
+        .not_to output(/:cast is forced/).to_stderr
+      expect_raw_rows(rows, column_names)
+    end
+
+    [false, true].each do |stream|
+      [false, true].each do |symbolize|
+        variant = "stream: #{stream}, symbolize_keys: #{symbolize}"
+
+        it "returns raw strings and nils in prepared-statement hash rows (#{variant})" do
+          statement = @client.prepare(parity_select)
+          rows = statement.execute(cast: false, stream: stream, cache_rows: !stream, symbolize_keys: symbolize).to_a
+          expect_raw_rows(rows, symbolize ? column_names.map(&:to_sym) : column_names)
+        end
+
+        it "returns raw strings and nils in prepared-statement array rows (#{variant})" do
+          statement = @client.prepare(parity_select)
+          result = statement.execute(cast: false, as: :array, stream: stream, cache_rows: !stream, symbolize_keys: symbolize)
+          expect_raw_rows(result.to_a, column_names)
+          expect(result.fields).to eql(symbolize ? column_names.map(&:to_sym) : column_names)
+        end
+      end
+    end
+
+    it "applies Encoding.default_internal to prepared-statement raw strings exactly as the text protocol does" do
+      with_internal_encoding Encoding::UTF_8 do
+        row = @client.prepare(parity_select).execute(cast: false).first
+        expect(row['blob_col'].encoding).to eql(Encoding::BINARY)
+        expect(row['date_col'].encoding).to eql(Encoding::BINARY)
+        expect(row['int_min_col']).to eql("-2147483648")
+        expect(row['int_min_col'].encoding).to eql(Encoding::UTF_8)
+        expect(row['varchar_latin1_col']).to eql("héllo")
+        expect(row['varchar_latin1_col'].encoding).to eql(Encoding::UTF_8)
+      end
+    end
+
+    it "grows string-bound variable-length columns past their initial buffer mid-stream" do
+      # The streaming twin of the buffered parity specs above: no
+      # mysql_stmt_store_result means no max_length, so variable-length
+      # columns start with zero-length buffers and rely on the
+      # MYSQL_DATA_TRUNCATED grow-and-refetch path -- under string binds
+      # here, exactly as under server-type binds in the #1058 regression
+      # spec in statement_spec.rb.
+      @client.query("DROP TABLE IF EXISTS stream_cast_false_truncation_test")
+      @client.query("CREATE TABLE stream_cast_false_truncation_test (id INT PRIMARY KEY AUTO_INCREMENT, data MEDIUMBLOB)")
+      sizes = [10, 1024, 65_540, 512]
+      begin
+        ins = @client.prepare("INSERT INTO stream_cast_false_truncation_test (data) VALUES (?)")
+        sizes.each { |n| ins.execute("x" * n) }
+
+        stmt = @client.prepare("SELECT data FROM stream_cast_false_truncation_test ORDER BY id")
+        rows = stmt.execute(cast: false, stream: true, cache_rows: false).to_a
+        # Byte-for-byte, not just size: a truncated fetch still reports the
+        # full length, so only the content proves the buffer was grown and
+        # the column re-fetched.
+        expect(rows.map { |row| row['data'] }).to eql(sizes.map { |n| "x" * n })
+        expect(rows.first['data'].encoding).to eql(Encoding::BINARY)
+      ensure
+        @client.query("DROP TABLE IF EXISTS stream_cast_false_truncation_test")
+      end
+    end
+
+    it "re-elects bind types when a later #each switches cast mode mid-stream" do
+      # No temporal columns: the full-cast side of the switch would trip the
+      # pre-existing stmt-path limitation that a TIME outside 00..23 hours
+      # raises in Time.local.
+      statement = @client.prepare("SELECT row_id, int_min_col FROM mysql2_cast_false_test ORDER BY row_id")
+
+      result = statement.execute(cast: false, stream: true, cache_rows: false)
+      result.each do |row| # rubocop:disable Lint/UnreachableLoop
+        expect(row['row_id']).to eql("1")
+        break
+      end
+      rest = []
+      result.each(cast: true) { |row| rest << row['row_id'] }
+      expect(rest).to eql([2, 3])
+
+      result = statement.execute(cast: true, stream: true, cache_rows: false)
+      result.each do |row| # rubocop:disable Lint/UnreachableLoop
+        expect(row['row_id']).to eql(1)
+        break
+      end
+      rest = []
+      result.each(cast: false) { |row| rest << row['row_id'] }
+      expect(rest).to eql(%w[2 3])
     end
   end
 
@@ -2061,14 +2153,49 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
       expect(result.fields).to eql(column_names)
     end
 
-    it "does not fast-path prepared statements: cast: :fast still warns and fully casts" do
-      statement = @client.prepare("SELECT decimal_col, date_col, bigint_min_col FROM mysql2_cast_fast_test WHERE row_id = 1")
-      row = nil
-      expect { row = statement.execute(cast: :fast).first }
-        .to output(/:cast is forced for prepared statements/).to_stderr
+    # The prepared-statement specs below assert the same expected literals
+    # as the text-protocol specs above: the parity matrix. See the matching
+    # note in the cast: false context.
+    it "honors cast: :fast on prepared statements without a warning" do
+      statement = @client.prepare(fast_select)
+      rows = nil
+      expect { rows = statement.execute(cast: :fast).to_a }
+        .not_to output(/:cast is forced/).to_stderr
+      expect_fast_rows(rows, column_names)
+    end
+
+    [false, true].each do |stream|
+      variant = "stream: #{stream}"
+
+      it "casts cheap types and defers expensive ones in prepared-statement hash rows (#{variant})" do
+        statement = @client.prepare(fast_select)
+        rows = statement.execute(cast: :fast, stream: stream, cache_rows: !stream).to_a
+        expect_fast_rows(rows, column_names)
+      end
+
+      it "casts cheap types and defers expensive ones in prepared-statement array rows (#{variant})" do
+        statement = @client.prepare(fast_select)
+        result = statement.execute(cast: :fast, as: :array, stream: stream, cache_rows: !stream)
+        expect_fast_rows(result.to_a, column_names)
+        expect(result.fields).to eql(column_names)
+      end
+    end
+
+    it "casts TINYINT(1) and BIT(1) as booleans on prepared statements when :cast_booleans is enabled" do
+      row = @client.prepare(fast_select).execute(cast: :fast, cast_booleans: true).first
+      expect(row['tiny1_col']).to be true
+      expect(row['single_bit_col']).to be true
+      expect(row['bigint_min_col']).to eql(-9_223_372_036_854_775_808)
+      expect(row['decimal_col']).to eql("10.300")
+    end
+
+    it "does not treat unrecognized truthy :cast values as :fast on prepared statements" do
+      # No TIME column: under the full cast this select gets, the
+      # pre-existing stmt-path limitation that a TIME outside 00..23 hours
+      # raises in Time.local would trip on time_col.
+      row = @client.prepare("SELECT decimal_col, date_col FROM mysql2_cast_fast_test WHERE row_id = 1").execute(cast: :bogus).first
       expect(row['decimal_col']).to eql(BigDecimal("10.3"))
       expect(row['date_col']).to eql(Date.new(2010, 4, 4))
-      expect(row['bigint_min_col']).to eql(-9_223_372_036_854_775_808)
     end
   end
 


### PR DESCRIPTION
Proposed in #1526.

Prepared-statement results bind every column as its server type -- buffer_type = fields[i].type unconditionally (formerly result.c:959) -- so the binary protocol delivers native ints/doubles/MYSQL_TIME and full casting is the only behavior the fetch loop can produce. The cast option is then forcibly overridden with ":cast is forced for prepared statements" (formerly result.c:2024, spec-pinned). cast: false and cast: :fast (#1489/#1490) exist only on the text path, which has made prepared statements the slow path for any consumer that wants raw strings or deferred casting. Requested in #1314 since 2022.

This elects buffer_type from the cast mode instead of copying the server type (rb_mysql_result_alloc_result_buffers):

* cast: false / :fast bind MYSQL_TYPE_STRING for every column. The client library converts each value to its string form on fetch (the documented mysql_stmt_bind_result conversion behavior), so the fetch loop receives text-shaped cells: cast: false materializes them with the exact twin of the text path's cast-none loop, and cast: :fast dispatches on the server type to cast the cheap types from their string bytes with the same mechanisms the text path uses (mysql2_cast_integer, Kernel#Float, the :cast_booleans checks) while deferring DECIMAL and temporals as tagged Strings.
* cast: true keeps today's server-type binds and decode arms byte for byte.
* The forced-cast warning is lifted, and the fetch path re-elects (frees, reallocates, rebinds) the buffers if a later #each switches cast mode mid-result -- reachable only when an earlier iteration stopped short, since non-streaming Statement#execute materializes every row up front with the execute-time options. Per-#each options never apply to already-materialized rows; that pre-existing semantic is unchanged.

Buffer sizing (issue burden 1): for a stored result fields[i].max_length is the binary wire length (4 bytes for an INT), not the converted string width, and for a streaming result it is 0. String binds for fixed-width types therefore get type-derived sizes -- the widest value the type can print -- widened to fields[i].length for ZEROFILL display padding, with FLOAT/DOUBLE given enough headroom (512) that libmysql's my_gcvt never has to round to fit: it silently reduces precision to the bind's buffer_length rather than reporting truncation, so the undersized case has to be unreachable, and is. Variable-length types keep max_length sizing and the MYSQL_DATA_TRUNCATED grow-and-refetch backstop (#1500), which works under string binds exactly as under server-type binds; the new streaming spec pins that byte-for-byte, because a truncated fetch still reports the full length and a size-only assertion passes with garbage bytes.

Per-bind error flag (issue burden 2): under string binds the only condition the client library flags is truncation, which the per-column wrapper->error[] consult in the MYSQL_DATA_TRUNCATED arm already reads (#1500); server-type-to-string conversion is total, so no reachable "real conversion error" is left to raise on, and no new error path is added.

Formatting parity -- the honest risk in the proposal -- was measured, not assumed: a parity matrix comparing text cast: false/:fast against stmt cast: false/:fast came back byte-identical, values and encodings, for every probed column type on both client libraries.

    matrix: TINYINT/SMALLINT/MEDIUMINT/INT/BIGINT (signed and unsigned
    boundaries, ZEROFILL), DECIMAL(10,3)/(10,0), FLOAT and FLOAT(10,3),
    DOUBLE (DBL_MAX/DBL_MIN shortest-round-trip formatting) and
    DOUBLE(30,20), DATE, DATETIME(0)/(6), TIMESTAMP(6), TIME(0)/(6)
    including -838:59:59, YEAR, BIT(1)/(64), CHAR/VARCHAR (utf8mb4 and
    latin1), BLOB/VARBINARY with embedded NULs, ENUM, SET, JSON, GEOMETRY,
    zero and partial-zero dates (sql_mode=''), NULLs, empty strings

    libs: libmysqlclient 9.6.0 (macOS/arm64) and MariaDB Connector/C 3.4.9
    (Linux/x86_64), against MySQL Server 9.6

Byte parity is an empirical property of those client libraries, not a documented guarantee; the contract this change promises is value equivalence. The spec parity contexts now run their literal byte-and-encoding expectations through prepared statements as well as text queries, so a future client-library divergence fails a named spec instead of shifting bytes silently.

Benchmarks (Ryzen 9 7950X Linux host, MariaDB Connector/C 3.4.9, MySQL 9.6 in Docker, load < 0.5, three serial alternating base/branch pairs, 20k rows, each figure the median of 15 samples of min-of-5 full materializations; base = c7a682a):

shape "heavy" (4x DATETIME(6), 4x DECIMAL(10,3), 4x INT, 4x VARCHAR(16))
| mode              | base        | branch      | delta        |
|-------------------|-------------|-------------|--------------|
| stmt cast: true   | 58.7-61.6ms | 59.9-63.2ms | unchanged    |
| stmt cast: :fast  | 58.5-63.7ms | 33.0-35.7ms | about -44%   |
| stmt cast: false  | 58.8-62.9ms | 33.2-37.7ms | about -44%   |
| text cast: false  | 21.8-22.3ms | 20.9-23.0ms | reference    |

shape "ints" (16x INT)
| mode              | base        | branch      | delta        |
|-------------------|-------------|-------------|--------------|
| stmt cast: true   | 10.9-11.1ms | 10.9-11.8ms | unchanged    |
| stmt cast: :fast  | 10.9-11.3ms | 20.9-21.6ms | about +90%   |
| stmt cast: false  | 11.1-11.4ms | 22.4-22.8ms | see below    |

Two honest readings of those numbers. String binds cost about 2x on integer-heavy shapes -- the client library renders text that the fetch loop then re-parses -- so cast: :fast pays off on the decimal/temporal-heavy shapes it exists for rather than as a universal default; the same election point could bind cheap types natively under :fast as a follow-on. (The ints cast: false base column is a forced full cast producing Integers, so its delta is not like-for-like.) And stmt cast: false (~35ms) still trails text cast: false (~22ms) on the heavy shape: this makes the cast modes work on statements, it does not yet make statements the fastest raw path.

Behavior changes to call out in release notes: the ":cast is forced for prepared statements" warning is gone (its two pinned specs now assert the new behavior), and code passing cast: false / :fast to Statement#execute -- or carrying it in query defaults -- now receives Strings where it previously got fully cast values plus a warning.

Out of scope, unchanged: stmt cast: true still raises ArgumentError for TIME values outside 00..23 hours (Time.local(838, ...)), a pre-existing binary-path limitation the text path does not share; the new modes return such values as strings, byte-identical to the text path.

Built against master c7a682a; #1520/#1525 touch neighboring result.c code and whichever lands second will need a mechanical rebase.
