### PR TITLE
Add regression coverage for #879: verify_identity must reject a hostname mismatch

### DIFF
--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -236,6 +236,22 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       end
     end
 
+    it "should reject a connection when ssl_mode is verify_identity and the hostname doesn't match the server's certificate" do
+      # Regression coverage for #879: verify_identity being wired to the right
+      # mysql_options() call (MYSQL_OPT_SSL_MODE on MySQL, MYSQL_OPT_SSL_VERIFY_SERVER_CERT
+      # on MariaDB) was never actually proven to reject a hostname mismatch --
+      # only that the option gets set, which isn't the same thing.
+      #
+      # spec/ssl/server-cert.pem has CN=mysql2gem.example.com and no SAN
+      # extension. option_overrides above connects via exactly that hostname
+      # (ssl_cert_host) so it matches; CI's /etc/hosts also points
+      # mysql2gem.example.com at 127.0.0.1 (see build-ubuntu.yml/build-macos.yml),
+      # so connecting via 127.0.0.1 instead reaches the identical server with a
+      # hostname the certificate doesn't cover -- verify_identity must reject it.
+      options = option_overrides.merge(ssl_mode: :verify_identity, 'host' => '127.0.0.1')
+      expect { new_client(options) }.to raise_error(Mysql2::Error)
+    end
+
     it "should be able to connect via SSL options" do
       # You may need to adjust the lines below to match your SSL certificate paths
       results = Hash[ssl_client.query('SHOW STATUS WHERE Variable_name LIKE "Ssl_%"').map { |x| x.values_at('Variable_name', 'Value') }]


### PR DESCRIPTION
## Why

#879 has been open since 2018: does mysql2 actually reject a connection under `ssl_mode: :verify_identity` when the server's certificate doesn't cover the hostname you connected with? #1506 (merged) fixed the sibling `:verify_ca` gap and, in tracing that fix, established that `:verify_identity` is wired to the right underlying call on both engines (`MYSQL_OPT_SSL_MODE` on MySQL, `MYSQL_OPT_SSL_VERIFY_SERVER_CERT` on MariaDB Connector/C) -- but "the option gets set" was never actually proven to mean "a mismatch gets rejected." Discussion: #1480 (comment).

This PR is test-only. It doesn't re-chase the original 2018-era Connector/C 2.3.0 report -- scope is current versions only (MariaDB Connector/C 3.4+, MySQL 8.0+/9.x), per the standard set in the #1480/#1506 thread.

## What

New spec in the `SSL` context (`spec/mysql2/client_spec.rb`): connects via `127.0.0.1` under `ssl_mode: :verify_identity`, reusing the existing `spec/ssl/server-cert.pem` fixture, whose subject is `CN=mysql2gem.example.com` with no SAN extension. CI's own `/etc/hosts` entry (`build-ubuntu.yml`/`build-macos.yml`) points `mysql2gem.example.com` at `127.0.0.1`, so both hostnames reach the identical server -- one matches the certificate, one doesn't. No new fixtures needed.

Expected: `Mysql2::Error` when connecting via the mismatched hostname. If CI shows otherwise, that's the actual answer to #879 and tells us where real code needs to change.

## Verification

- `bundle exec rubocop spec/mysql2/client_spec.rb` -- clean.
- `bundle exec rspec` (full suite, without forcing the SSL cert-dir env var so the SSL context's own skip-if-missing-fixture guard behaves normally) -- 546 examples, 0 failures, 12 expected pending.
- **Could not verify the new assertion itself locally.** This machine's local `mysqld` serves its own auto-generated self-signed certificate rather than `spec/ssl/*`, so every SSL-context test -- not just this one -- fails with a CA verification error before ever reaching hostname-check logic. Reconfiguring the local server to serve the repo's fixture certs would mean restarting an instance other local sessions may depend on, so I didn't. CI installs the server with `spec/ssl/*` as its actual cert and is the real verification venue for this test.
