### PR TITLE
Harden the symbol-pinning spec: assert mortality, not collection

### DIFF
--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -188,23 +188,29 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
     end
 
     it "should not permanently pin symbols for dynamically-named columns" do
-      skip "dynamic symbols are only GC-able on Ruby 2.2+" if RUBY_VERSION < "2.2"
+      require "objspace"
+      skip "needs ObjectSpace.count_symbols (CRuby 2.2+)" unless ObjectSpace.respond_to?(:count_symbols)
+
+      # A pinned (immortal) symbol can never be collected; a mortal dynamic
+      # symbol can. Assert mortality directly from the intern-table
+      # bookkeeping rather than waiting for the GC to actually reclaim the
+      # symbol: conservative stack/register scanning can keep a dead symbol
+      # alive indefinitely, but it cannot change which table the symbol was
+      # interned into, so this holds regardless of GC timing.
+      immortal_symbols = -> { ObjectSpace.count_symbols[:immortal_symbol] }
+
+      # Absorb first-use interning (lazy autoloads, inline caches) outside
+      # the measured window with an identically-shaped query and count.
+      @client.query("SELECT 1 AS sym_warmup_#{rand(2**32)}", symbolize_keys: true).first
+      immortal_symbols.call
 
       name = "sym_gc_col_#{rand(2**32)}"
+      before = immortal_symbols.call
+      row = @client.query("SELECT 1 AS #{name}", symbolize_keys: true).first
+      pinned = immortal_symbols.call - before
 
-      # Run the query on its own thread so its stack -- and any stale
-      # references conservative scanning would find there -- is gone before
-      # the collection check below.
-      Thread.new do
-        @client.query("SELECT 1 AS #{name}", symbolize_keys: true).each { |_| }
-        nil
-      end.join
-
-      collected = 10.times.any? do
-        GC.start
-        Symbol.all_symbols.none? { |sym| sym.to_s == name }
-      end
-      expect(collected).to be true
+      expect(row.keys.first).to eql(name.to_sym)
+      expect(pinned).to eql(0), "column-name symbol :#{name} was interned as immortal"
     end
 
     it "should be able to return results as an array" do


### PR DESCRIPTION
Hardens the collection spec that merged in #1554 after it flaked twice on unrelated PRs' CI: #1553's mysql97 leg (run 31778901056, job 94700154268) and #1566's mariadb12.3 leg (run 31846188905, job 94913002007) -- both times `expected true / got false`, both times as the leg's only failure.

The spec fetched a randomly-named column under `symbolize_keys` on a discarded thread, then required the symbol to vanish from `Symbol.all_symbols` within ten GC passes.

Mechanism: CRuby scans machine stacks and registers conservatively, so any stale word aliasing the symbol -- or the Result whose `wrapper->fields` keeps it alive transitively -- survives every GC pass. The discarded thread narrows that window; nothing can close it. Whether collection happens within N passes is a property of what junk the C stack holds on that box, that day.

Collection was always a proxy. The property #1554 claims is that the column-name symbol is not *permanently pinned* -- that it is interned as a mortal dynamic symbol rather than an immortal one. CRuby exposes that distinction directly: `ObjectSpace.count_symbols[:immortal_symbol]`. Assert that the query does not grow the immortal count, and separately that the row key is the expected symbol. Presence plus not-immortal is mortality, the exact negation of pinned.

Why this cannot flake: the immortal count is monotonic intern-table bookkeeping. Conservative scanning can delay a mortal symbol's collection indefinitely, but it cannot change which table the symbol was interned into, so GC timing is invisible to the assertion. Probed both ways through the live query path: the `rb_check_symbol_cstr` build yields `mortal_dynamic_symbol` +1 / `immortal_symbol` +0; an `rb_intern3` build yields +0 / +1. Verified with `GC.stress = true` across the measured window -- a full GC on every allocation, the maximal version of what any CI box can do -- and the deltas are unchanged. 35 consecutive runs green: 12 plain, 15 under varied `RUBY_GC_*` tunings, 5 with in-window `GC.stress`, 3 whole-file.

Alternatives considered: forking the symbol-creating work into a subprocess only relocates the conservative-scanning problem -- the child's own stack holds the symbol during the query -- and `fork` does not exist on the Windows legs that run this file. Demoting to the semantic-parity spec alone (the fallback #1554's adjudication recorded) would drop the CI assertion that bites on the fix; not needed, since mortality is assertable deterministically.

The `RUBY_VERSION < "2.2"` skip becomes a skip on `ObjectSpace.count_symbols` availability -- the method is CRuby 2.2+, the same boundary, and on older Rubies the `rb_intern3` fallback pins every symbol so the spec must still skip.

Coverage honesty: this proves the symbol is *interned mortal*, i.e. GC-eligible; that the GC then actually reclaims it is CRuby's contract, demonstrated out-of-band by #1554's 10,000-alias experiment (delta 0 after GC). The immortal count is process-global, so an unrelated immortal intern inside the two-statement measured window would false-fail; an identically-shaped warmup query and count absorb first-use interning, and no such intern appeared in any of the 35 runs. Nothing in the window calls `rb_sym2id` on the key, so no mortal-to-immortal promotion can occur either.

Bite check preserved: with the result.c intern site reverted to `rb_intern3`, this spec fails 3/3 isolated runs ("column-name symbol :sym_gc_col_... was interned as immortal") and is the whole file's only failure (225 examples, 1 failure).

Full suite: 545 examples, 0 failures, 11 pending (SSL-gated). RuboCop clean.
