### PR TITLE
Enforce hostname verification for ssl_mode: :verify_identity on MariaDB (#879)

### DIFF
--- a/.github/workflows/build-fedora.yml
+++ b/.github/workflows/build-fedora.yml
@@ -20,8 +20,8 @@ jobs:
           # (nothing's been dnf-installed yet at that point in the job), so
           # these rows test whatever Ruby version Fedora currently packages
           # rather than a chosen version.
-          - {os: ubuntu-24.04, ruby: 'system', db: 'fedora:latest', container: {image: 'fedora:latest', options: '--cap-add=SYS_PTRACE --security-opt seccomp=unconfined --add-host=mysql2gem.example.com:127.0.0.1'}}
-          - {os: ubuntu-24.04, ruby: 'system', db: 'fedora:rawhide', container: {image: 'fedora:rawhide', options: '--cap-add=SYS_PTRACE --security-opt seccomp=unconfined'}, ssl_cert_dir: '/tmp/mysql2', ssl_cert_host: 'localhost'}
+          - {os: ubuntu-24.04, ruby: 'system', db: 'fedora:latest', container: {image: 'fedora:latest', options: '--cap-add=SYS_PTRACE --security-opt seccomp=unconfined --add-host=mysql2gem.example.com:127.0.0.1 --add-host=wrong.mysql2gem.example.com:127.0.0.1'}}
+          - {os: ubuntu-24.04, ruby: 'system', db: 'fedora:rawhide', container: {image: 'fedora:rawhide', options: '--cap-add=SYS_PTRACE --security-opt seccomp=unconfined --add-host=mysql2gem.example.com:127.0.0.1 --add-host=wrong.mysql2gem.example.com:127.0.0.1'}, ssl_cert_dir: '/tmp/mysql2'}
       fail-fast: false
     env:
       BUNDLE_WITHOUT: development

--- a/.github/workflows/build-macos.yml
+++ b/.github/workflows/build-macos.yml
@@ -26,7 +26,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - run: sudo echo "127.0.0.1 mysql2gem.example.com" | sudo tee -a /etc/hosts
+      - run: sudo echo "127.0.0.1 mysql2gem.example.com wrong.mysql2gem.example.com" | sudo tee -a /etc/hosts
       - run: echo 'DB=${{ matrix.db }}' >> $GITHUB_ENV
       - run: bash ci/setup.sh
       # Set the verbose option in the Makefile to print compiling command lines.

--- a/.github/workflows/build-ubuntu.yml
+++ b/.github/workflows/build-ubuntu.yml
@@ -60,7 +60,7 @@ jobs:
         with:
           ruby-version: ${{ matrix.ruby }}
           bundler-cache: true # runs 'bundle install' and caches installed gems automatically
-      - run: sudo echo "127.0.0.1 mysql2gem.example.com" | sudo tee -a /etc/hosts
+      - run: sudo echo "127.0.0.1 mysql2gem.example.com wrong.mysql2gem.example.com" | sudo tee -a /etc/hosts
       - run: echo 'DB=${{ matrix.db }}' >> $GITHUB_ENV
       - run: bash ci/setup.sh
       # Set the verbose option in the Makefile to print compiling command lines.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,7 +39,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 153
+  Max: 164
 
 # Offense count: 3
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/README.md
+++ b/README.md
@@ -331,20 +331,71 @@ the `:sslverify` boolean. For details on each of the `:ssl_mode` options, see
 
 The `:ssl_mode` option will also set the appropriate MariaDB connection flags:
 
-| `:ssl_mode`        | MariaDB option value                 |
-| ---                | ---                                  |
-| `:disabled`        | MYSQL_OPT_SSL_ENFORCE = 0            |
-| `:required`        | MYSQL_OPT_SSL_ENFORCE = 1            |
-| `:verify_ca`       | MYSQL_OPT_SSL_VERIFY_SERVER_CERT = 1 |
-| `:verify_identity` | MYSQL_OPT_SSL_VERIFY_SERVER_CERT = 1 |
+| `:ssl_mode`        | MariaDB option value                                |
+| ---                | ---                                                 |
+| `:disabled`        | MYSQL_OPT_SSL_ENFORCE = 0                           |
+| `:required`        | MYSQL_OPT_SSL_ENFORCE = 1                           |
+| `:verify_ca`       | MYSQL_OPT_SSL_VERIFY_SERVER_CERT = 1                |
+| `:verify_identity` | MYSQL_OPT_SSL_VERIFY_SERVER_CERT = 1 + mysql2's own hostname verification |
 
-MariaDB Connector/C has no CA-only verification mode, so `:verify_ca` gets
-the same full verification (CA and hostname) that `:verify_identity` gets --
-MYSQL_OPT_SSL_VERIFY_SERVER_CERT is the only verification it offers. MariaDB
-does not support the `:preferred` option; there's no equivalent to fall back
-to. For more information about SSL/TLS in MariaDB, see
+MYSQL_OPT_SSL_VERIFY_SERVER_CERT verifies the CA at most: despite its
+MySQL-derived name, MariaDB Connector/C decides whether to check the
+hostname from the peer address, and never checks it for peers it considers
+local (127.0.0.1, ::1, or socket connections). mysql2 enforces
+`:verify_identity` on MariaDB itself, by registering a TLS
+verification callback (MariaDB Connector/C 3.4+) that verifies the
+certificate chain and the hostname (SAN, wildcard, and IP-address matching
+via OpenSSL) on every connection, local peers included.
+
+Two things worth knowing:
+
+* With `:sslca`/`:sslcapath` left unset, the TLS backend resolves its
+  default trust store natively (OpenSSL's default verify paths,
+  `SSL_CERT_FILE`/`SSL_CERT_DIR`, or the platform certificate store) --
+  publicly-CA-signed servers verify with no CA option passed. Under
+  `:verify_identity`, an unverifiable chain is refused at connect time.
+* If the mysql2 build cannot enforce the hostname check (MariaDB
+  Connector/C older than 3.4, or no OpenSSL headers at build time),
+  `ssl_mode: :verify_identity` raises instead of connecting.
+  `Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION` reports the mechanism
+  in effect: `:native` (libmysqlclient), `:callback` (MariaDB + mysql2's
+  verification callback), or `nil` (unenforceable).
+
+MariaDB does not support the `:preferred` option; there's no equivalent to
+fall back to. For more information about SSL/TLS in MariaDB, see
 [https://mariadb.com/kb/en/securing-connections-for-client-and-server/](https://mariadb.com/kb/en/securing-connections-for-client-and-server/)
 and [https://mariadb.com/kb/en/mysql_optionsv/#tls-options](https://mariadb.com/kb/en/mysql_optionsv/#tls-options)
+
+On MariaDB Connector/C 3.4+, the server certificate can be pinned by
+fingerprint instead of a CA -- an alternative trust model to
+`:verify_ca`/`:verify_identity` (the connector runs the fingerprint check
+*instead of* the CA/hostname checks, so combining them raises):
+
+``` ruby
+Mysql2::Client.new(
+  # ...options as above...,
+  :tls_peer_fingerprint => 'c3ab8ff13720e8ad9047dd39466b3c8974e592c2fa383d4a3960714caef0c4f2', # SHA-256 hex
+  # or a file of acceptable fingerprints, one per line:
+  :tls_peer_fingerprint_list => '/path/to/fingerprints',
+  )
+```
+
+On client libraries without pinning support (libmysqlclient, MariaDB
+Connector/C before 3.4) these options raise rather than silently
+connecting unpinned.
+
+After connecting, `Client#tls_info` describes the TLS session as the
+client library observed it: negotiated protocol and cipher, the peer
+certificate the server actually presented (subject, issuer, validity,
+SHA-256 fingerprint), the bitmask of verification checks the connector
+recorded as failed (`:verify_status`, decodable with the
+`Mysql2::Client::TLS_VERIFY_*` constants -- note a CA-less pinned
+connection legitimately carries `TLS_VERIFY_TRUST`, since the pin rather
+than the chain is its trust anchor), and whether mysql2's
+`:verify_identity` enforcement confirmed chain and hostname verification
+for this connection (`:identity_verified`). It returns `nil` for non-TLS
+connections and on client libraries without the introspection API
+(libmysqlclient, MariaDB Connector/C before 3.4).
 
 To set the TLS Server Name Indication (SNI) hostname sent during the TLS
 handshake, e.g. when connecting through a proxy that routes by hostname:

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -17,7 +17,7 @@
 #include "mysql_enc_name_to_ruby.h"
 
 VALUE cMysql2Client;
-extern VALUE mMysql2, cMysql2Error, cMysql2TimeoutError;
+extern VALUE mMysql2, cMysql2Error, cMysql2ConnectionError, cMysql2TimeoutError;
 static VALUE sym_id, sym_version, sym_header_version, sym_async, sym_symbolize_keys, sym_as, sym_array, sym_stream;
 static ID intern_brackets, intern_merge, intern_merge_bang, intern_new_with_args,
   intern_current_query_options, intern_read_timeout, intern_values;
@@ -77,11 +77,14 @@ static ID intern_brackets, intern_merge, intern_merge_bang, intern_new_with_args
  */
 #ifdef HAVE_CONST_MYSQL_OPT_SSL_VERIFY_SERVER_CERT
   #define SSL_MODE_VERIFY_IDENTITY 5
-  /* MYSQL_OPT_SSL_VERIFY_SERVER_CERT is the only verification this client
-   * library offers -- it checks the CA and the hostname together, with no
-   * way to ask for one without the other. SSL_MODE_VERIFY_CA maps to the
-   * same option: full verification is the closest honest behavior available,
-   * and strictly safer than the alternative of accepting any CA silently. */
+  /* MYSQL_OPT_SSL_VERIFY_SERVER_CERT is the only verification option this
+   * client library offers, and despite its MySQL-derived name it verifies
+   * the CA at most -- hostname verification is decided by the connector's
+   * local-peer heuristic, not by this option, and is skipped entirely for
+   * 127.0.0.1/::1/socket peers (#879). Both verify modes map to it;
+   * verify_identity additionally installs mysql2's own verification
+   * callback (see rb_set_ssl_mode_option) to enforce the hostname check
+   * the option alone never provides. */
   #define SSL_MODE_VERIFY_CA 4
   #define HAVE_CONST_SSL_MODE_VERIFY_IDENTITY
   #define HAVE_CONST_SSL_MODE_VERIFY_CA
@@ -140,6 +143,183 @@ struct nogvl_select_db_args {
   struct query_completion completion;
 };
 
+static VALUE rb_mysql_client_close(VALUE self);
+
+/*
+ * ssl_mode: :verify_identity enforcement for MariaDB Connector/C.
+ *
+ * The connector's default TLS verifier decides which checks run from the
+ * peer address, not from the requested verification mode:
+ * MYSQL_OPT_SSL_VERIFY_SERVER_CERT only clears the skip-everything gate
+ * (tls_allow_invalid_server_cert), while hostname verification is added
+ * only for peers the connector considers non-local -- 127.0.0.1, ::1, and
+ * socket transports never get it (plugins/auth/my_auth.c,
+ * is_local_connection). A :verify_identity connection to 127.0.0.1 never
+ * executes X509_check_host at all: it reports success without the identity
+ * ever being verified (#879).
+ *
+ * MARIADB_OPT_TLS_VERIFICATION_CALLBACK (Connector/C 3.4+, CONC-724)
+ * replaces the whole verifier, so mysql2 registers the callback below for
+ * :verify_identity connections. The connector's own verifier
+ * (ma_pvio_tls_verify_server_cert) would be the natural delegate for it,
+ * but distro builds hide that symbol behind a version script (local: *),
+ * so the callback verifies the TLS session directly with OpenSSL instead:
+ * certificate-chain trust via the handshake's recorded status plus
+ * SSL_get_verify_result, and the hostname via X509_check_host /
+ * X509_check_ip_asc -- real SAN, wildcard, and IP-address matching,
+ * applied unconditionally, local peers included. Verification runs inside
+ * the TLS handshake, before any credentials are sent, and a failure
+ * refuses the connection there.
+ *
+ * The callback runs inside mysql_real_connect without the GVL: pure C
+ * only, no Ruby calls.
+ */
+#ifdef MYSQL2_VERIFY_IDENTITY_SHIM
+
+/* Included without HAVE_TLS defined, which leaves MARIADB_TLS an opaque
+ * void in the MARIADB_PVIO struct -- the real MARIADB_TLS definition lives
+ * in ma_tls.h, which #includes the not-installed ma_hash.h and so cannot
+ * be consumed here. */
+#ifdef HAVE_MYSQL_H
+#include <ma_pvio.h>
+#else
+#include <mysql/ma_pvio.h>
+#endif
+#include <openssl/ssl.h>
+#include <openssl/x509v3.h>
+
+/* The leading members of MARIADB_TLS (struct st_ma_pvio_tls in the
+ * installed ma_tls.h), mirrored for the reason above; the MARIADB_X509_INFO
+ * tail is unused here and omitted. The callback validates the layout
+ * before trusting it -- the pvio read through this struct must point back
+ * at the same ctls the connector passed in, and the SSL session's app_data
+ * must be the MYSQL handle the pvio names -- and refuses the connection on
+ * any mismatch. */
+typedef struct {
+  void *data;
+  MARIADB_PVIO *pvio;
+  void *ssl;
+} mysql2_mariadb_tls_head;
+
+/* Report through the public NET error fields -- the same fields the
+ * connector's my_set_error fills -- so mysql_error() surfaces the real
+ * reason for the refused connection. */
+static void mysql2_tls_set_error(MYSQL *mysql, const char *detail) {
+  mysql->net.last_errno = CR_SSL_CONNECTION_ERROR;
+  snprintf(mysql->net.last_error, sizeof(mysql->net.last_error),
+           "SSL connection error: verify_identity: %s", detail);
+  memcpy(mysql->net.sqlstate, "HY000", 6);
+}
+
+/* Verify the live TLS session's peer identity: certificate chain against
+ * the configured CA, and hostname against the certificate's SAN/CN.
+ * Returns NULL on success; on failure returns a description -- static, or
+ * formatted into the caller's detail buffer with the specifics (hostname
+ * checked, CA in effect, OpenSSL's chain-failure reason) and the remedy,
+ * since this refusal is what a misconfigured caller actually sees -- and
+ * sets *status to the matching MARIADB_TLS_VERIFY_* bit. */
+static const char *mysql2_tls_check_peer_identity(MYSQL *mysql, mysql2_mariadb_tls_head *ctls, unsigned int *status, char *detail, size_t detail_len) {
+  const char *tls_library = NULL;
+  const char *host;
+  const char *ca;
+  SSL *ssl;
+  X509 *cert;
+  long chain_result;
+  int host_ok;
+
+  *status = MARIADB_TLS_VERIFY_UNKNOWN;
+
+  /* ctls->ssl is only an OpenSSL SSL* when the connector was built against
+   * OpenSSL or LibreSSL; under Schannel or GnuTLS it is a different
+   * animal entirely and this shim cannot verify anything -- refuse rather
+   * than guess. */
+  if (mariadb_get_infov(mysql, MARIADB_TLS_LIBRARY, (void *)&tls_library) != 0 ||
+      tls_library == NULL ||
+      (strncmp(tls_library, "OpenSSL", 7) != 0 && strncmp(tls_library, "LibreSSL", 8) != 0))
+    return "hostname verification requires an OpenSSL-based MariaDB Connector/C build";
+
+  ssl = (SSL *)ctls->ssl;
+  if (ssl == NULL || (MYSQL *)SSL_get_app_data(ssl) != mysql)
+    return "TLS session unavailable for verification";
+
+  /* The connector's handshake verify callback records chain failures
+   * (untrusted, expired, revoked) without aborting the handshake; the
+   * session still holds OpenSSL's specific reason. Name the CA actually in
+   * effect too -- "none" means the caller passed nothing and the backend's
+   * default trust store resolution was what failed to verify the chain. */
+  chain_result = SSL_get_verify_result(ssl);
+  if (mysql->net.tls_verify_status != 0 || chain_result != X509_V_OK) {
+    *status = mysql->net.tls_verify_status != 0 ? mysql->net.tls_verify_status : MARIADB_TLS_VERIFY_TRUST;
+    ca = mysql->options.ssl_ca != NULL ? mysql->options.ssl_ca :
+         mysql->options.ssl_capath != NULL ? mysql->options.ssl_capath : "none";
+    snprintf(detail, detail_len,
+             "certificate verification failed (%s; CA in effect: %s); pass the CA that "
+             "signed the server certificate as :sslca",
+             chain_result != X509_V_OK ? X509_verify_cert_error_string(chain_result)
+                                       : "recorded during the TLS handshake",
+             ca);
+    return detail;
+  }
+
+  host = mysql->host;
+  if (host == NULL || host[0] == '\0') {
+    *status = MARIADB_TLS_VERIFY_HOST;
+    return "no hostname to verify the certificate against";
+  }
+
+  cert = SSL_get_peer_certificate(ssl);
+  if (cert == NULL)
+    return "server presented no certificate";
+
+  host_ok = X509_check_host(cert, host, strlen(host), 0, NULL) == 1 ||
+            X509_check_ip_asc(cert, host, 0) == 1;
+  X509_free(cert);
+
+  if (!host_ok) {
+    *status = MARIADB_TLS_VERIFY_HOST;
+    snprintf(detail, detail_len,
+             "hostname \"%s\" does not match the server certificate; connect via a name "
+             "the certificate covers, or pin the certificate with :tls_peer_fingerprint",
+             host);
+    return detail;
+  }
+
+  return NULL;
+}
+
+static int mysql2_tls_verification_callback(void *vctls, unsigned int flags) {
+  mysql2_mariadb_tls_head *ctls = (mysql2_mariadb_tls_head *)vctls;
+  MYSQL *mysql;
+  unsigned int status = MARIADB_TLS_VERIFY_UNKNOWN;
+  char detail[MYSQL_ERRMSG_SIZE];
+  const char *failure;
+
+  /* The connector's flags encode its local-peer leniency -- the policy
+   * this callback exists to override. Full verification runs regardless. */
+  (void)flags;
+
+  if (ctls == NULL || ctls->pvio == NULL ||
+      (void *)ctls->pvio->ctls != vctls ||
+      (mysql = ctls->pvio->mysql) == NULL ||
+      mysql->net.pvio != ctls->pvio)
+    return 1; /* layout mismatch: refuse; there is no MYSQL handle to report through */
+
+  failure = mysql2_tls_check_peer_identity(mysql, ctls, &status, detail, sizeof(detail));
+  if (failure != NULL) {
+    /* Force a status the caller cannot forgive: my_auth.c treats a failed
+     * verification carrying only HOST/TRUST bits with no CA configured as
+     * acceptable for its self-signed leniency path and completes the
+     * connection anyway. MARIADB_TLS_VERIFY_ERROR keeps the refusal a
+     * refusal even if no CA reached the C layer. */
+    mysql->net.tls_verify_status |= status | MARIADB_TLS_VERIFY_ERROR;
+    mysql2_tls_set_error(mysql, failure);
+    return 1;
+  }
+  return 0;
+}
+
+#endif /* MYSQL2_VERIFY_IDENTITY_SHIM */
+
 static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
   unsigned long version = mysql_get_client_version();
   const char *version_str = mysql_get_client_info();
@@ -164,20 +344,73 @@ static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
   GET_CLIENT(self);
   int val = NUM2INT(setting);
 
-  /* Expected code path for MariaDB 10.x and MariaDB Connector/C 3.x
+  /* Expected code path for MariaDB 10.x+ and MariaDB Connector/C 3.x+
    * Workaround code path for MySQL 5.7.3 - 5.7.10 and MySQL Connector/C 6.1.3 - 6.1.x
-   */
-  if (version >= 100000                         // MariaDB (all versions numbered 10.x)
-    || (version >= 30000 && version < 40000)    // MariaDB Connector/C (all versions numbered 3.x)
-    || (version >= 50703 && version < 50711)    // Workaround for MySQL 5.7.3 - 5.7.10
-    || (version >= 60103 && version < 60200)) { // Workaround for MySQL Connector/C 6.1.3 - 6.1.x
+   *
+   * The MySQL tiers verify the hostname natively under
+   * MYSQL_OPT_SSL_VERIFY_SERVER_CERT. Everything else new enough to reach
+   * this branch is treated as the MariaDB family -- open-ended rather than
+   * a closed version window, so a future Connector/C major version lands on
+   * the verify_identity enforcement (or its fail-closed refusal) below
+   * instead of falling through to the unverified #879 path with no signal. */
+  int mysql_native_verify = (version >= 50703 && version < 50711)   // MySQL 5.7.3 - 5.7.10
+                         || (version >= 60103 && version < 60200);  // MySQL Connector/C 6.1.3 - 6.1.x
+  int mariadb_family = !mysql_native_verify && version >= 30000;    // MariaDB 10.x+ servers (100000+) and Connector/C 3.x+
+
+  if (mariadb_family || mysql_native_verify) {
 #ifdef HAVE_CONST_MYSQL_OPT_SSL_VERIFY_SERVER_CERT
-    /* This client library has no CA-only verification mode -- verify_ca
-     * gets the same full verification as verify_identity, since that's the
-     * only real verification MYSQL_OPT_SSL_VERIFY_SERVER_CERT offers. */
+    /* On MariaDB Connector/C, MYSQL_OPT_SSL_VERIFY_SERVER_CERT is CA
+     * verification at most: it clears the connector's skip-everything gate,
+     * but which checks actually run is chosen by the connector's local-peer
+     * heuristic, and hostname verification never runs against 127.0.0.1,
+     * ::1, or socket peers (#879). verify_ca maps here as the CA-only mode
+     * it is; verify_identity additionally registers mysql2's own
+     * verification callback below to make the hostname check real. */
     if (val == SSL_MODE_VERIFY_IDENTITY || val == SSL_MODE_VERIFY_CA) {
       my_bool b = 1;
       int result = mysql_options(wrapper->client, MYSQL_OPT_SSL_VERIFY_SERVER_CERT, &b);
+      /* The MySQL native-verify tiers share this branch but verify the
+       * hostname themselves under this option, so the shim (and the refusal
+       * when it isn't available) is MariaDB-only. */
+      if (val == SSL_MODE_VERIFY_IDENTITY && mariadb_family) {
+#ifdef MYSQL2_VERIFY_IDENTITY_SHIM
+        /* Both registrations are checked: a runtime client library that
+         * rejects either option (say, an older libmariadb.so than the
+         * headers this gem was built against) cannot enforce verification
+         * inside the handshake, and must refuse here -- before any connect
+         * -- rather than silently demote enforcement to the post-connect
+         * tripwire, which refuses only after credentials have already
+         * crossed the wire to the unverified peer. */
+#ifdef HAVE_CONST_MYSQL_OPT_SSL_ENFORCE
+        /* verify_identity implies a required TLS connection, as it does on
+         * MySQL -- a connection that never negotiates TLS must not bypass
+         * verification. */
+        if (mysql_options(wrapper->client, MYSQL_OPT_SSL_ENFORCE, &b) != 0)
+          rb_raise(cMysql2ConnectionError,
+                   "ssl_mode: :verify_identity cannot be enforced: the runtime client library "
+                   "(%s) rejected MYSQL_OPT_SSL_ENFORCE, so an unverified non-TLS connection "
+                   "could not be ruled out. Refusing to connect (#879).", version_str);
+#endif
+        if (mysql_options(wrapper->client, MARIADB_OPT_TLS_VERIFICATION_CALLBACK,
+                          (const void *)mysql2_tls_verification_callback) != 0)
+          rb_raise(cMysql2ConnectionError,
+                   "ssl_mode: :verify_identity cannot be enforced: the runtime client library "
+                   "(%s) rejected the TLS verification callback, which needs MariaDB "
+                   "Connector/C 3.4+ at runtime as well as at gem build time. Refusing to "
+                   "connect with the hostname check silently skipped (#879).", version_str);
+        wrapper->tls_verify_identity = 1;
+#else
+        /* Connecting anyway with the hostname check silently skipped is
+         * exactly the failure #879 describes -- refuse instead. */
+        rb_raise(cMysql2ConnectionError,
+                 "ssl_mode: :verify_identity cannot be enforced by this mysql2 build "
+                 "(client library %s): hostname verification needs MariaDB Connector/C 3.4+ "
+                 "and OpenSSL headers at gem build time. Refusing to connect with the check "
+                 "silently skipped (#879). Use ssl_mode: :verify_ca, pin the server "
+                 "certificate with :tls_peer_fingerprint, or rebuild mysql2 against a newer "
+                 "client library.", version_str);
+#endif
+      }
       return INT2NUM(result);
     }
 #endif
@@ -649,6 +882,8 @@ static VALUE allocate(VALUE klass) {
   wrapper->connect_timeout = 0;
   wrapper->initialized = 0; /* will be set true after calling mysql_init */
   wrapper->closed = 1; /* will be set false after calling mysql_real_connect */
+  wrapper->tls_verify_identity = 0;
+  wrapper->tls_identity_verified = 0;
   wrapper->refcount = 1;
   wrapper->affected_rows = -1;
   wrapper->query_start = 0;
@@ -757,6 +992,116 @@ static VALUE rb_mysql_get_ssl_cipher(VALUE self)
   return rb_str;
 }
 
+#ifdef MYSQL2_TLS_INFO
+static VALUE mysql2_tm_to_time(const struct tm *tm) {
+  if (tm->tm_year == 0 && tm->tm_mon == 0 && tm->tm_mday == 0)
+    return Qnil;
+  return rb_funcall(rb_cTime, rb_intern("utc"), 6,
+                    INT2NUM(tm->tm_year + 1900), INT2NUM(tm->tm_mon + 1), INT2NUM(tm->tm_mday),
+                    INT2NUM(tm->tm_hour), INT2NUM(tm->tm_min), INT2NUM(tm->tm_sec));
+}
+
+static VALUE mysql2_utf8_str_or_nil(const char *str) {
+  VALUE rb_str;
+  if (str == NULL)
+    return Qnil;
+  rb_str = rb_str_new2(str);
+  rb_enc_associate(rb_str, rb_utf8_encoding());
+  return rb_str;
+}
+#endif
+
+/* call-seq: client.tls_info
+ *
+ * Describes the connection's TLS session as observed after the handshake:
+ * negotiated protocol and cipher, the peer certificate the server actually
+ * presented (subject, issuer, validity period, SHA-256 fingerprint), the
+ * MARIADB_TLS_VERIFY_* bitmask of verification checks the client library
+ * recorded as failed, and whether mysql2's own :verify_identity
+ * enforcement confirmed certificate-chain and hostname verification for
+ * this connection.
+ *
+ * Returns nil when the connection is not using TLS, and on client
+ * libraries without the introspection API (libmysqlclient, and MariaDB
+ * Connector/C before 3.4). On a returned hash every key is present:
+ * :verify_status and :peer_cert are nil if the library cannot report them.
+ */
+static VALUE rb_mysql_client_tls_info(VALUE self) {
+  GET_CLIENT(self);
+  REQUIRE_CONNECTED(wrapper);
+#ifdef MYSQL2_TLS_INFO
+  {
+    VALUE info, peer;
+    const char *tls_version = NULL;
+    unsigned int verify_status = 0;
+    MARIADB_X509_INFO *cert = NULL;
+
+    if (mariadb_get_infov(wrapper->client, MARIADB_CONNECTION_TLS_VERSION, (void *)&tls_version) != 0 ||
+        tls_version == NULL)
+      return Qnil; /* no TLS session on this connection */
+
+    info = rb_hash_new();
+    rb_hash_aset(info, ID2SYM(rb_intern("tls_version")), mysql2_utf8_str_or_nil(tls_version));
+    rb_hash_aset(info, ID2SYM(rb_intern("cipher")), mysql2_utf8_str_or_nil(mysql_get_ssl_cipher(wrapper->client)));
+    /* The hash's shape is invariant: every key is always present, with nil
+     * for anything the client library could not report. */
+    rb_hash_aset(info, ID2SYM(rb_intern("verify_status")),
+                 mariadb_get_infov(wrapper->client, MARIADB_TLS_VERIFY_STATUS, (void *)&verify_status) == 0 ?
+                   UINT2NUM(verify_status) : Qnil);
+    rb_hash_aset(info, ID2SYM(rb_intern("identity_verified")), wrapper->tls_identity_verified ? Qtrue : Qfalse);
+
+    /* 256 selects the SHA-256 fingerprint of the peer certificate. */
+    peer = Qnil;
+    if (mariadb_get_infov(wrapper->client, MARIADB_TLS_PEER_CERT_INFO, (void *)&cert, 256) == 0 && cert != NULL) {
+      peer = rb_hash_new();
+      rb_hash_aset(peer, ID2SYM(rb_intern("version")), INT2NUM(cert->version));
+      rb_hash_aset(peer, ID2SYM(rb_intern("subject")), mysql2_utf8_str_or_nil(cert->subject));
+      rb_hash_aset(peer, ID2SYM(rb_intern("issuer")), mysql2_utf8_str_or_nil(cert->issuer));
+      rb_hash_aset(peer, ID2SYM(rb_intern("fingerprint")), mysql2_utf8_str_or_nil(cert->fingerprint));
+      rb_hash_aset(peer, ID2SYM(rb_intern("not_before")), mysql2_tm_to_time(&cert->not_before));
+      rb_hash_aset(peer, ID2SYM(rb_intern("not_after")), mysql2_tm_to_time(&cert->not_after));
+    }
+    rb_hash_aset(info, ID2SYM(rb_intern("peer_cert")), peer);
+    return info;
+  }
+#else
+  return Qnil;
+#endif
+}
+
+/* :tls_peer_fingerprint / :tls_peer_fingerprint_list -- CA-less pinned TLS
+ * on MariaDB Connector/C 3.4+ (MARIADB_OPT_TLS_PEER_FP/_LIST). A pin the
+ * client library cannot apply is a security control silently not applied
+ * -- the same failure class as #879 -- so unsupported builds raise instead
+ * of warning and connecting unpinned. */
+static VALUE rb_set_tls_peer_fingerprint(VALUE self, VALUE fingerprint) {
+#ifdef HAVE_CONST_MARIADB_OPT_TLS_PEER_FP
+  GET_CLIENT(self);
+  mysql_options(wrapper->client, MARIADB_OPT_TLS_PEER_FP, StringValueCStr(fingerprint));
+  return fingerprint;
+#else
+  (void)self; (void)fingerprint;
+  rb_raise(cMysql2ConnectionError,
+           ":tls_peer_fingerprint requires MariaDB Connector/C 3.4+; this client library "
+           "(%s) cannot pin the server certificate, and connecting unpinned would silently "
+           "drop the verification you asked for", mysql_get_client_info());
+#endif
+}
+
+static VALUE rb_set_tls_peer_fingerprint_list(VALUE self, VALUE path) {
+#ifdef HAVE_CONST_MARIADB_OPT_TLS_PEER_FP_LIST
+  GET_CLIENT(self);
+  mysql_options(wrapper->client, MARIADB_OPT_TLS_PEER_FP_LIST, StringValueCStr(path));
+  return path;
+#else
+  (void)self; (void)path;
+  rb_raise(cMysql2ConnectionError,
+           ":tls_peer_fingerprint_list requires MariaDB Connector/C 3.4+; this client library "
+           "(%s) cannot pin the server certificate, and connecting unpinned would silently "
+           "drop the verification you asked for", mysql_get_client_info());
+#endif
+}
+
 #ifdef CLIENT_CONNECT_ATTRS
 static int opt_connect_attr_add_i(VALUE key, VALUE value, VALUE arg)
 {
@@ -848,6 +1193,49 @@ static VALUE rb_mysql_connect(VALUE self, VALUE user, VALUE pass, VALUE host, VA
   wrapper->connect_pid = getpid();
 #endif
   wrapper->server_version = mysql_get_server_version(wrapper->client);
+
+#ifdef MYSQL2_VERIFY_IDENTITY_SHIM
+  /* Tripwire for the #879 bug class: verify_identity enforcement was
+   * promised via the verification callback, so prove it ran against a live
+   * TLS session before handing the connection back -- a connect that
+   * somehow completed without TLS, or without invoking the callback, must
+   * be refused rather than silently degraded to an unverified one. The
+   * re-check is cheap (the session is already established) and fails
+   * closed on every path the callback cannot see. */
+  if (wrapper->tls_verify_identity) {
+    MARIADB_PVIO *pvio = wrapper->client->net.pvio;
+    mysql2_mariadb_tls_head *ctls = pvio ? (mysql2_mariadb_tls_head *)pvio->ctls : NULL;
+    unsigned int status;
+    char detail[MYSQL_ERRMSG_SIZE];
+    const char *failure;
+
+    if (ctls == NULL) {
+      failure = "connection did not negotiate TLS";
+    } else if (pvio->mysql != wrapper->client || ctls->pvio != pvio) {
+      failure = "TLS session unavailable for verification";
+    } else {
+      failure = mysql2_tls_check_peer_identity(wrapper->client, ctls, &status, detail, sizeof(detail));
+    }
+
+    if (failure != NULL) {
+      VALUE error, error_msg;
+      mysql2_tls_set_error(wrapper->client, failure);
+      error_msg = rb_str_new2(mysql_error(wrapper->client));
+      rb_enc_associate(error_msg, rb_utf8_encoding());
+      error = rb_funcall(cMysql2Error, intern_new_with_args, 4,
+                         error_msg,
+                         LONG2FIX(wrapper->server_version),
+                         UINT2NUM(mysql_errno(wrapper->client)),
+                         rb_usascii_str_new_cstr("HY000"));
+      /* Close before raising: an identity-unverified connection must not
+       * outlive this method, even unreachable and pending GC. */
+      rb_mysql_client_close(self);
+      rb_exc_raise(error);
+    }
+    wrapper->tls_identity_verified = 1;
+  }
+#endif
+
   return self;
 }
 
@@ -2408,6 +2796,7 @@ void init_mysql2_client(void) {
   rb_define_method(cMysql2Client, "warning_count", rb_mysql_client_warning_count, 0);
   rb_define_method(cMysql2Client, "query_info_string", rb_mysql_info, 0);
   rb_define_method(cMysql2Client, "ssl_cipher", rb_mysql_get_ssl_cipher, 0);
+  rb_define_method(cMysql2Client, "tls_info", rb_mysql_client_tls_info, 0);
   rb_define_method(cMysql2Client, "encoding", rb_mysql_client_encoding, 0);
   rb_define_method(cMysql2Client, "session_track", rb_mysql_client_session_track, 1);
   rb_define_method(cMysql2Client, "database", rb_mysql_client_database, 0);
@@ -2425,6 +2814,8 @@ void init_mysql2_client(void) {
   rb_define_private_method(cMysql2Client, "default_auth=", set_default_auth, 1);
   rb_define_private_method(cMysql2Client, "ssl_set", set_ssl_options, 5);
   rb_define_private_method(cMysql2Client, "ssl_mode=", rb_set_ssl_mode_option, 1);
+  rb_define_private_method(cMysql2Client, "tls_peer_fingerprint=", rb_set_tls_peer_fingerprint, 1);
+  rb_define_private_method(cMysql2Client, "tls_peer_fingerprint_list=", rb_set_tls_peer_fingerprint_list, 1);
   rb_define_private_method(cMysql2Client, "enable_cleartext_plugin=", set_enable_cleartext_plugin, 1);
   rb_define_private_method(cMysql2Client, "initialize_ext", initialize_ext, 0);
   rb_define_private_method(cMysql2Client, "connect", rb_mysql_connect, 9);
@@ -2635,5 +3026,40 @@ void init_mysql2_client(void) {
   rb_const_set(cMysql2Client, rb_intern("ESCAPE_QUOTE_SUPPORTED"), Qtrue);
 #else
   rb_const_set(cMysql2Client, rb_intern("ESCAPE_QUOTE_SUPPORTED"), Qfalse);
+#endif
+
+  /* How this build enforces the hostname check ssl_mode: :verify_identity
+   * promises: :native (libmysqlclient's own MYSQL_OPT_SSL_MODE), :callback
+   * (mysql2's verification callback on MariaDB Connector/C 3.4+), or nil
+   * (unenforceable -- :verify_identity raises on MariaDB rather than
+   * connecting with the check silently skipped, see #879). */
+#if defined(FULL_SSL_MODE_SUPPORT)
+  rb_const_set(cMysql2Client, rb_intern("TLS_PEER_IDENTITY_VERIFICATION"), ID2SYM(rb_intern("native")));
+#elif defined(MYSQL2_VERIFY_IDENTITY_SHIM)
+  rb_const_set(cMysql2Client, rb_intern("TLS_PEER_IDENTITY_VERIFICATION"), ID2SYM(rb_intern("callback")));
+#else
+  rb_const_set(cMysql2Client, rb_intern("TLS_PEER_IDENTITY_VERIFICATION"), Qnil);
+#endif
+
+#ifdef HAVE_CONST_MARIADB_OPT_TLS_PEER_FP
+  rb_const_set(cMysql2Client, rb_intern("TLS_PEER_FINGERPRINT_SUPPORTED"), Qtrue);
+#else
+  rb_const_set(cMysql2Client, rb_intern("TLS_PEER_FINGERPRINT_SUPPORTED"), Qfalse);
+#endif
+
+  /* The MARIADB_TLS_VERIFY_* bits reported by Client#tls_info's
+   * :verify_status -- which verification checks the client library
+   * recorded as failed. A check can be recorded without being requested:
+   * a CA-less fingerprint-pinned connection legitimately carries
+   * TLS_VERIFY_TRUST, since the pin, not the chain, is its trust anchor. */
+#ifdef MARIADB_TLS_VERIFY_TRUST
+  rb_const_set(cMysql2Client, rb_intern("TLS_VERIFY_OK"), INT2NUM(MARIADB_TLS_VERIFY_OK));
+  rb_const_set(cMysql2Client, rb_intern("TLS_VERIFY_TRUST"), INT2NUM(MARIADB_TLS_VERIFY_TRUST));
+  rb_const_set(cMysql2Client, rb_intern("TLS_VERIFY_HOST"), INT2NUM(MARIADB_TLS_VERIFY_HOST));
+  rb_const_set(cMysql2Client, rb_intern("TLS_VERIFY_FINGERPRINT"), INT2NUM(MARIADB_TLS_VERIFY_FINGERPRINT));
+  rb_const_set(cMysql2Client, rb_intern("TLS_VERIFY_PERIOD"), INT2NUM(MARIADB_TLS_VERIFY_PERIOD));
+  rb_const_set(cMysql2Client, rb_intern("TLS_VERIFY_REVOKED"), INT2NUM(MARIADB_TLS_VERIFY_REVOKED));
+  rb_const_set(cMysql2Client, rb_intern("TLS_VERIFY_UNKNOWN"), INT2NUM(MARIADB_TLS_VERIFY_UNKNOWN));
+  rb_const_set(cMysql2Client, rb_intern("TLS_VERIFY_ERROR"), INT2NUM(MARIADB_TLS_VERIFY_ERROR));
 #endif
 }

--- a/ext/mysql2/client.h
+++ b/ext/mysql2/client.h
@@ -69,6 +69,15 @@ typedef struct {
    * separate Ruby call on the async path: Client#query with :async returns
    * right after the send, and #async_result reads the response later. */
   double query_start;
+  /* ssl_mode: :verify_identity on MariaDB Connector/C: set when mysql2's
+   * TLS verification callback is registered for this connection, so the
+   * post-connect check in rb_mysql_connect knows enforcement was promised
+   * and must refuse the connection if it cannot prove verification ran. */
+  int tls_verify_identity;
+  /* The post-connect check confirmed certificate-chain and hostname
+   * verification against the live TLS session. Reported by Client#tls_info
+   * as :identity_verified. */
+  int tls_identity_verified;
   MYSQL *client;
   mysql2_client_state_t state;
   /* The pid that established this connection (set on every successful

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -191,6 +191,76 @@ have_const('MYSQL_OPT_TLS_SNI_SERVERNAME', mysql_h) # Added in MySQL 8.1; no Mar
 # to retain compatibility with the typedef in earlier MySQLs.
 have_type('my_bool', mysql_h)
 
+### MariaDB Connector/C TLS verification surface (#879, #1480)
+
+# Client#tls_info wants the whole 3.4-era introspection set or nothing, so
+# its contract stays binary: a hash describing the TLS session on MariaDB
+# Connector/C 3.4+ builds, nil everywhere else.
+have_tls_introspection =
+  have_func('mariadb_get_infov', mysql_h) &&
+  have_const('MARIADB_CONNECTION_TLS_VERSION', mysql_h) &&
+  have_const('MARIADB_TLS_PEER_CERT_INFO', mysql_h) &&
+  have_const('MARIADB_TLS_VERIFY_STATUS', mysql_h)
+$CFLAGS << ' -DMYSQL2_TLS_INFO' if have_tls_introspection
+
+# Certificate-fingerprint pinning passthrough (:tls_peer_fingerprint and
+# :tls_peer_fingerprint_list); the options raise on builds without these.
+# The MARIADB_OPT_TLS_PEER_FP option itself predates Connector/C 3.4, but
+# older connectors compare against a hardcoded SHA-1 fingerprint of the peer
+# certificate, so the SHA-2 pins these options take can never match there.
+# Connector/C 3.4+ picks the digest from the pin's length (SHA-256/384/512).
+have_sha2_fingerprint_verification =
+  checking_for('MariaDB Connector/C 3.4+ SHA-2 fingerprint verification') do
+    try_compile(<<-SRC)
+#include <#{mysql_h}>
+#if !defined(MARIADB_PACKAGE_VERSION_ID) || MARIADB_PACKAGE_VERSION_ID < 30400
+#error fingerprint verification is SHA-1 only before Connector/C 3.4
+#endif
+int main(void) { return 0; }
+    SRC
+  end
+if have_sha2_fingerprint_verification
+  have_const('MARIADB_OPT_TLS_PEER_FP', mysql_h)
+  have_const('MARIADB_OPT_TLS_PEER_FP_LIST', mysql_h)
+end
+
+# The ssl_mode: :verify_identity enforcement callback (#879). Everything it
+# needs, or :verify_identity refuses to connect on MariaDB rather than
+# silently skipping hostname verification:
+# - MARIADB_OPT_TLS_VERIFICATION_CALLBACK (Connector/C 3.4+) to replace the
+#   connector's default verifier, whose local-peer heuristic skips the
+#   hostname check for 127.0.0.1/::1/socket peers;
+# - mariadb_get_infov + MARIADB_TLS_LIBRARY to confirm at runtime that the
+#   connector's TLS backend is OpenSSL, since the callback verifies the SSL
+#   session handle directly (a Schannel/GnuTLS build fails closed);
+# - OpenSSL itself, for SSL_get_verify_result and X509_check_host;
+# - the installed ma_pvio.h MARIADB_PVIO layout, which is how the callback
+#   reaches the MYSQL handle and the TLS session from its argument.
+have_verify_identity_shim =
+  have_tls_introspection &&
+  have_const('MARIADB_OPT_TLS_VERIFICATION_CALLBACK', mysql_h) &&
+  have_const('MARIADB_TLS_LIBRARY', mysql_h) &&
+  have_header('openssl/ssl.h') &&
+  have_header('openssl/x509v3.h') &&
+  have_library('crypto', 'X509_check_host', 'openssl/x509v3.h') &&
+  have_library('ssl', 'SSL_get_verify_result', 'openssl/ssl.h') &&
+  checking_for('MARIADB_PVIO layout for the verify_identity callback') do
+    pvio_h = [prefix, 'ma_pvio.h'].compact.join('/')
+    try_compile(<<-SRC)
+#include <#{mysql_h}>
+#include <#{pvio_h}>
+int main(void) {
+  MARIADB_PVIO pvio;
+  MYSQL mysql;
+  pvio.ctls = (void *)0;
+  pvio.mysql = &mysql;
+  mysql.net.pvio = &pvio;
+  return 0;
+}
+    SRC
+  end
+$CFLAGS << ' -DMYSQL2_VERIFY_IDENTITY_SHIM' if have_verify_identity_shim
+
 # detect mysql functions
 have_func('mysql_ssl_set', mysql_h)
 have_func('mysql_next_result_nonblocking', mysql_h) # Added in MySQL 8.0.16; no MariaDB Connector/C equivalent under this name (see mysql_next_result_start/_cont)

--- a/ext/mysql2/mysql2_ext.c
+++ b/ext/mysql2/mysql2_ext.c
@@ -1,6 +1,6 @@
 #include <mysql2_ext.h>
 
-VALUE mMysql2, cMysql2Error, cMysql2TimeoutError;
+VALUE mMysql2, cMysql2Error, cMysql2ConnectionError, cMysql2TimeoutError;
 
 /* Ruby Extension initializer */
 void Init_mysql2(void) {
@@ -9,6 +9,9 @@ void Init_mysql2(void) {
 
   cMysql2Error = rb_const_get(mMysql2, rb_intern("Error"));
   rb_global_variable(&cMysql2Error);
+
+  cMysql2ConnectionError = rb_const_get(cMysql2Error, rb_intern("ConnectionError"));
+  rb_global_variable(&cMysql2ConnectionError);
 
   cMysql2TimeoutError = rb_const_get(cMysql2Error, rb_intern("TimeoutError"));
   rb_global_variable(&cMysql2TimeoutError);

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -50,9 +50,7 @@ module Mysql2
       self.charset_name = opts[:encoding] || 'utf8mb4'
 
       mode = parse_ssl_mode(opts[:ssl_mode]) if opts[:ssl_mode]
-      if (mode == SSL_MODE_VERIFY_CA || mode == SSL_MODE_VERIFY_IDENTITY) && !opts[:sslca]
-        opts[:sslca] = find_default_ca_path
-      end
+      configure_tls_verification(opts, mode)
 
       ssl_options = opts.values_at(:sslkey, :sslcert, :sslca, :sslcapath, :sslcipher)
       ssl_set(*ssl_options) if ssl_options.any? || opts.key?(:sslverify)
@@ -118,6 +116,34 @@ module Mysql2
           memo
         end
       end
+    end
+
+    # Enforce the coherence of the TLS verification options before any of
+    # them reach the client library, so a verification the caller asked for
+    # can never be silently skipped (the #879 failure mode).
+    #
+    # :sslca/:sslcapath left unset means the TLS backend resolves its default
+    # trust store natively (OpenSSL's default verify paths,
+    # SSL_CERT_FILE/SSL_CERT_DIR, or the platform certificate store). Whether
+    # verification actually succeeded is proven at connect time -- the
+    # verification callback and the post-connect tripwire fail closed on any
+    # connection whose chain or hostname cannot be shown verified.
+    def configure_tls_verification(opts, mode)
+      # The mode != 0 guard keeps ancient no-ssl_mode builds (where every
+      # SSL_MODE_* constant collapses to 0) out of the verify-tier handling.
+      verify_mode = (mode == SSL_MODE_VERIFY_CA || mode == SSL_MODE_VERIFY_IDENTITY) && mode != 0
+
+      return unless opts[:tls_peer_fingerprint] || opts[:tls_peer_fingerprint_list]
+
+      # Fingerprint pinning and CA/hostname verification are alternative
+      # trust models in MariaDB Connector/C: a pinned connection runs the
+      # FINGERPRINT check instead of the HOST/TRUST checks, so combining
+      # them would silently drop whichever one loses. Refuse the ambiguity.
+      raise Mysql2::Error::ConnectionError, ":tls_peer_fingerprint pinning and ssl_mode: #{opts[:ssl_mode]} are mutually exclusive verification models; pick one" \
+        if verify_mode
+
+      self.tls_peer_fingerprint = opts[:tls_peer_fingerprint].to_s if opts[:tls_peer_fingerprint]
+      self.tls_peer_fingerprint_list = opts[:tls_peer_fingerprint_list].to_s if opts[:tls_peer_fingerprint_list]
     end
 
     # Find any default system CA paths to handle system roots

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -179,9 +179,11 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
 
     # 'preferred' is only in MySQL 5.6.36+, 5.7.11+, 8.0+ -- MariaDB Connector/C
     # has no equivalent option, so mysql2 can't do anything for it there.
-    # 'verify_ca' works everywhere: MariaDB Connector/C has no CA-only
-    # verification mode, so rb_set_ssl_mode_option maps it to the same full
-    # verification 'verify_identity' uses (MYSQL_OPT_SSL_VERIFY_SERVER_CERT).
+    # 'verify_ca' works everywhere: on MariaDB Connector/C it maps to
+    # MYSQL_OPT_SSL_VERIFY_SERVER_CERT, which is CA verification at most --
+    # the connector never checks the hostname for local peers (#879).
+    # 'verify_identity' maps to the same option plus mysql2's own
+    # verification callback, which makes the hostname check real.
     #
     # The upper bound on the first range stops at 100000 (not left unbounded)
     # because MariaDB's client version numbering starts there (10.x =
@@ -197,9 +199,19 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       %i[disabled required verify_ca verify_identity]
     end
 
+    # On MariaDB-family builds without the enforcement callback,
+    # :verify_identity refuses to connect rather than silently skipping the
+    # hostname check -- the "refuses verify_identity outright" spec under
+    # TLS option validation covers that refusal.
+    mysql_native_verify = (50703...50711).cover?(version) || (60103...60200).cover?(version)
+    verify_identity_unenforceable = version >= 30000 && !mysql_native_verify && Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION.nil?
+
     # MySQL and MariaDB and all versions of Connector/C
     ssl_modes.each do |ssl_mode|
       it "should set ssl_mode option #{ssl_mode}" do
+        skip "this build refuses verify_identity rather than skipping the hostname check (#879)" \
+          if ssl_mode == :verify_identity && verify_identity_unenforceable
+
         options = {
           ssl_mode: ssl_mode,
         }
@@ -245,6 +257,142 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       expect(ssl_client.ssl_cipher).not_to be_empty
       expect(results['Ssl_cipher']).to eql(ssl_client.ssl_cipher)
     end
+
+    context "peer identity verification (#879)" do
+      # The server certificate's CN is ssl_cert_host (mysql2gem.example.com,
+      # no SAN extension), and CI's /etc/hosts aliases both that name and
+      # ssl_cert_wrong_host to 127.0.0.1 -- so every leg below reaches the
+      # identical server, differing only in the hostname the certificate is
+      # checked against.
+      let(:verification) { Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION }
+
+      it "accepts verify_identity when the hostname matches the server certificate" do
+        skip "verify_identity is not enforceable on this build" if verification.nil?
+
+        new_client(option_overrides.merge(ssl_mode: :verify_identity)) do |client|
+          expect(client.query('SELECT 1 AS one').first['one']).to eql(1)
+        end
+      end
+
+      it "proves via tls_info which verification rung ran" do
+        skip "requires mysql2's callback enforcement (MariaDB Connector/C 3.4+ build)" unless verification == :callback
+
+        new_client(option_overrides.merge(ssl_mode: :verify_identity)) do |client|
+          info = client.tls_info
+          expect(info[:identity_verified]).to be true
+          expect(info[:verify_status]).to eql(0)
+        end
+      end
+
+      it "rejects verify_identity connecting by an IP address the certificate does not cover" do
+        # The #879 regression leg: the connector's default verifier decides
+        # which checks run from the peer address and classifies 127.0.0.1 as
+        # local, skipping hostname verification entirely -- before mysql2's
+        # callback enforcement this connection SUCCEEDED with the server's
+        # identity never verified.
+        options = option_overrides.merge(ssl_mode: :verify_identity, 'host' => '127.0.0.1')
+        if verification == :callback
+          expect { new_client(options) }.to raise_error(Mysql2::Error::ConnectionError, /verify_identity.+(certificate|hostname)/i)
+        else
+          # :native (libmysqlclient) refuses with its own error message; a
+          # build that cannot enforce refuses at Client.new instead of
+          # silently degrading.
+          expect { new_client(options) }.to raise_error(Mysql2::Error::ConnectionError)
+        end
+      end
+
+      it "fails closed at connect time, not Client.new, when no CA is configured" do
+        skip "verify_identity is not enforceable on this build" if verification.nil?
+
+        # Unset :sslca/:sslcapath is not pre-flighted in Ruby: the TLS
+        # backend resolves its default trust store natively, and the connect
+        # attempt is the source of truth. The suite's CA never appears in a
+        # system trust store, so the chain cannot verify -- enforcement (the
+        # verification callback and the post-connect tripwire) must refuse
+        # the connection rather than fall through to the connector's no-CA
+        # self-signed leniency.
+        options = option_overrides.reject { |k, _| k.to_s.start_with?("sslca") }.merge(ssl_mode: :verify_identity)
+        expect { new_client(options) }.to raise_error(Mysql2::Error::ConnectionError, /SSL|TLS|certificate/i)
+      end
+
+      it "rejects verify_identity connecting by a hostname the certificate does not cover" do
+        require 'resolv'
+        begin
+          Resolv.getaddress(ssl_cert_wrong_host)
+        rescue Resolv::ResolvError
+          skip("DON'T WORRY, THIS TEST PASSES - but #{ssl_cert_wrong_host} does not resolve here. Alias it to the database server (as CI does in /etc/hosts) to run this leg.")
+        end
+
+        # Guards the by-name topology: a non-local peer name gets the
+        # HOST/TRUST checks even from the connector's own default verifier,
+        # and must stay refused under mysql2's callback too.
+        options = option_overrides.merge(ssl_mode: :verify_identity, 'host' => ssl_cert_wrong_host)
+        expect { new_client(options) }.to raise_error(Mysql2::Error::ConnectionError)
+      end
+    end
+
+    context "Client#tls_info" do
+      it "describes the TLS session" do
+        info = ssl_client.tls_info
+
+        # Introspection ships with the same Connector/C 3.4 surface the
+        # callback enforcement builds against, so :callback builds must
+        # return a hash here; :native (libmysqlclient) has no introspection
+        # API and always returns nil.
+        expect(info).to be_a(Hash) if Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION == :callback
+        skip "tls_info introspection is not available on this build" if info.nil?
+
+        expect(info[:tls_version]).to match(/TLS/i)
+        expect(info[:cipher]).not_to be_empty
+        expect(info[:verify_status]).to eql(0)
+        expect(info[:identity_verified]).to be false # no :verify_identity requested
+        expect(info[:peer_cert][:subject]).to include(ssl_cert_host)
+        expect(info[:peer_cert][:issuer]).not_to be_empty
+        expect(info[:peer_cert][:fingerprint]).to match(/\A\h{64}\z/)
+        expect(info[:peer_cert][:not_after]).to be > info[:peer_cert][:not_before]
+      end
+
+      it "is nil when the connection does not use TLS" do
+        new_client(ssl_mode: :disabled) do |client|
+          expect(client.tls_info).to be_nil
+        end
+      end
+    end
+
+    context "certificate fingerprint pinning" do
+      let(:server_cert_fingerprint) do
+        require 'openssl'
+        OpenSSL::Digest::SHA256.hexdigest(OpenSSL::X509::Certificate.new(File.read("#{ssl_cert_dir}/server-cert.pem")).to_der)
+      end
+
+      it "connects CA-less when the server certificate matches the pinned fingerprint" do
+        skip "fingerprint pinning is not supported by this client library build" unless Mysql2::Client::TLS_PEER_FINGERPRINT_SUPPORTED
+
+        new_client(tls_peer_fingerprint: server_cert_fingerprint) do |client|
+          expect(client.query('SELECT 1 AS one').first['one']).to eql(1)
+          info = client.tls_info
+          next if info.nil?
+
+          # Pinning is its own verification rung: the fingerprint matched,
+          # the hostname rung deliberately did not run, and with no CA
+          # configured the connector records the chain as untrusted
+          # (TLS_VERIFY_TRUST) even though the pin -- not the chain -- is
+          # this connection's trust anchor. Anything beyond that bit would
+          # mean a check we do care about failed.
+          expect(info[:verify_status] & ~Mysql2::Client::TLS_VERIFY_TRUST).to eql(0)
+          expect(info[:identity_verified]).to be false
+          expect(info[:peer_cert][:fingerprint].downcase).to eql(server_cert_fingerprint.downcase)
+        end
+      end
+
+      it "refuses when the server certificate does not match the pinned fingerprint" do
+        skip "fingerprint pinning is not supported by this client library build" unless Mysql2::Client::TLS_PEER_FINGERPRINT_SUPPORTED
+
+        expect do
+          new_client(tls_peer_fingerprint: server_cert_fingerprint.reverse)
+        end.to raise_error(Mysql2::Error, /[Ff]ingerprint/)
+      end
+    end
   end
 
   context "option coherence warnings" do
@@ -284,6 +432,47 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       expect do
         new_client
       end.not_to output(/:sslkey and :sslcert only take effect together|:cache_rows is ignored/).to_stderr
+    end
+  end
+
+  context "TLS option validation" do
+    # These raises all fire in Client#initialize before any connection is
+    # attempted, so they hold on every build and don't need a TLS-enabled
+    # server. The zero-value skips cover ancient no-ssl_mode builds where
+    # every SSL_MODE_* constant collapses to 0.
+
+    it "refuses combining fingerprint pinning with a verifying ssl_mode" do
+      skip "this build has no verifying ssl_mode" if Mysql2::Client::SSL_MODE_VERIFY_IDENTITY.zero?
+
+      # The connector runs the FINGERPRINT check instead of the HOST/TRUST
+      # checks when a fingerprint is pinned: one of the two requested
+      # verification models would silently not run.
+      expect do
+        new_client(tls_peer_fingerprint: 'ab' * 32, ssl_mode: :verify_identity)
+      end.to raise_error(Mysql2::Error::ConnectionError, /mutually exclusive/)
+    end
+
+    it "refuses fingerprint pinning on client libraries that cannot enforce it" do
+      skip "this build supports fingerprint pinning" if Mysql2::Client::TLS_PEER_FINGERPRINT_SUPPORTED
+
+      expect do
+        new_client(tls_peer_fingerprint: 'ab' * 32)
+      end.to raise_error(Mysql2::Error::ConnectionError, /tls_peer_fingerprint/)
+    end
+
+    it "refuses verify_identity outright when this build cannot enforce hostname verification" do
+      # Mirrors rb_set_ssl_mode_option's open-ended MariaDB-family
+      # predicate: everything 3.0+ except the MySQL native-verify tiers.
+      version = Mysql2::Client.info[:id]
+      mysql_native_verify = (50703...50711).cover?(version) || (60103...60200).cover?(version)
+      mariadb = version >= 30000 && !mysql_native_verify
+      skip "this build enforces verify_identity" unless mariadb && Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION.nil?
+
+      # Connecting with the hostname check silently skipped is exactly the
+      # #879 failure mode; an unenforceable build must raise, not degrade.
+      expect do
+        new_client(ssl_mode: :verify_identity, sslca: '/nonexistent/ca.pem')
+      end.to raise_error(Mysql2::Error::ConnectionError, /cannot be enforced/)
     end
   end
 

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -117,6 +117,21 @@ RSpec.configure do |config|
     @ssl_cert_host
   end
 
+  # A hostname that resolves to the same server as ssl_cert_host but that the
+  # server certificate does not cover, for the #879 hostname-mismatch specs.
+  # CI aliases it to 127.0.0.1 in /etc/hosts alongside ssl_cert_host.
+  def ssl_cert_wrong_host
+    return @ssl_cert_wrong_host if @ssl_cert_wrong_host
+
+    host = ENV['TEST_RUBY_MYSQL2_SSL_WRONG_HOST']
+    @ssl_cert_wrong_host = if host && !host.empty?
+      host
+    else
+      'wrong.mysql2gem.example.com'
+    end
+    @ssl_cert_wrong_host
+  end
+
   config.before(:suite) do
     begin
       new_client


### PR DESCRIPTION
Design agreed in #1480; fixes #879.

ssl_mode: :verify_identity on MariaDB Connector/C never verified the server's hostname. MYSQL_OPT_SSL_VERIFY_SERVER_CERT -- the option mysql2 maps both verify modes to -- only clears the connector's skip-everything gate (tls_allow_invalid_server_cert); which checks actually run is chosen by the connector's local-peer heuristic (plugins/auth/my_auth.c, is_local_connection), and the hostname check is added only for peers it considers non-local. 127.0.0.1, ::1, and socket transports never get it, so the canonical Rails-style config -- verify_identity against a local address or a tunneled port -- reported success with the server's identity never checked: X509_check_host never executed. Confirmed by sodabrew's CI evidence and MacPorts repro on #879 and corroborated from a Connector/C 3.4.9 source read on the same thread. Worse, a failed HOST/TRUST verification with no CA configured falls through to the 3.4 self-signed leniency path (my_auth.c) and the connection can still succeed, so even a forced hostname check cannot fail closed without a CA.

This parcel fulfills the #1480/#879 commitments as one cohesive security change, four parts:

1. Enforcement (the core). On MariaDB Connector/C 3.4+ builds, :verify_identity registers a TLS verification callback (MARIADB_OPT_TLS_VERIFICATION_CALLBACK, CONC-724) that replaces the connector's default verifier and verifies the session directly with OpenSSL: chain trust via the handshake's recorded status plus SSL_get_verify_result, hostname via X509_check_host/X509_check_ip_asc (real SAN, wildcard, and IP-address matching), unconditionally -- local peers included -- inside the handshake, before credentials are sent. Delegating to the connector's own ma_pvio_tls_verify_server_cert with forced HOST|TRUST flags would have been simpler, but distro builds hide that symbol behind the version script's local:* (verified against Arch's libmariadb.so.3: not in the dynamic symbol table), so the callback links only public API. It reaches the session through the installed MARIADB_PVIO struct plus a mirrored 3-pointer MARIADB_TLS head (the installed ma_tls.h can't be included: it pulls in the not-installed ma_hash.h), validates that layout via pointer round-trips and SSL app_data identity before trusting it, and fails closed on any mismatch. On failure it also forces MARIADB_TLS_VERIFY_ERROR into net.tls_verify_status so the caller's no-CA leniency path cannot resurrect the connection, and the refusal names the specifics -- the hostname checked, the CA in effect, OpenSSL's chain-failure reason -- plus the remedy, since this error is what a misconfigured caller actually sees. Both option registrations are checked and refuse at configuration time if the runtime client library rejects them: enforcement must not silently demote to a weaker layer. A post-connect tripwire in rb_mysql_connect then re-proves chain+hostname against the live session and refuses (close + raise) any connection where enforcement was promised but verification cannot be shown to have run -- e.g. a connect that never negotiated TLS, the class of silent skip #879 is about.

2. Fail-closed configuration. :sslca/:sslcapath left unset means the TLS backend resolves its default trust store natively (OpenSSL's default verify paths, SSL_CERT_FILE/SSL_CERT_DIR, or the platform certificate store); mysql2 neither guesses system CA paths client-side nor pre-flights their existence. The connect attempt is the source of truth: under :verify_identity the verification callback and the post-connect tripwire refuse any connection whose chain no trust store vouches for, rather than letting it fall through to the connector's no-CA self-signed leniency. All of the pre-connect refusals in this change raise Mysql2::Error::ConnectionError -- the class the equivalent SSL/CA failures have always raised from the C connect path -- so code narrowly rescuing ConnectionError keeps seeing these as connection failures. On MariaDB builds where the callback is unavailable (Connector/C < 3.4, or no OpenSSL headers at gem build time), :verify_identity raises a clear error instead of connecting -- connecting with the check silently skipped is exactly the #879 bug class. The MariaDB-family version gate is open-ended (any Connector/C 3.x+ or 10.x+ server library, not a closed version window), so a future Connector/C major version lands on this enforce-or-refuse pair instead of silently regressing to the unverified path. Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION reports the mechanism in effect (:native / :callback / nil).

3. Pinning passthrough (#1480). :tls_peer_fingerprint and :tls_peer_fingerprint_list map to MARIADB_OPT_TLS_PEER_FP/_LIST for CA-less pinned TLS. Unsupported builds raise rather than connect unpinned (a pin not applied is a control silently dropped -- deliberate departure from the warn-and-degrade additive model of #1405, for the same fail-closed reason as above). Combining pinning with a verifying ssl_mode raises: the connector runs the FINGERPRINT rung instead of HOST|TRUST, so one of the two requested models would silently not run.

4. Introspection (#1480). Client#tls_info returns the negotiated protocol and cipher, the peer certificate actually presented (subject, issuer, validity, SHA-256 fingerprint), the connector's recorded verify-status bitmask (decodable via new TLS_VERIFY_* constants), and :identity_verified -- whether mysql2's enforcement confirmed chain+hostname for this connection. nil for non-TLS connections and on builds without the API (libmysqlclient, Connector/C < 3.4); on a returned hash every key is present, nil for anything the library could not report. Note verify-status records failures among checks that ran: a CA-less pinned connection legitimately carries TLS_VERIFY_TRUST (the pin, not the chain, is its trust anchor), and a clean status alone cannot prove the hostname rung executed -- that is what :identity_verified is for.

The #879 spec matrix: MariaDB mismatch-by-IP refusal (the regression leg: previously connected), mismatch-by-name refusal (guards the connector's own non-local-name topology), match-accepted with tls_info proving which rung ran, MySQL-tier refusal parity, fingerprint pin accept/refuse legs, option-validation legs (pin+verify mutual exclusion, unsupported-build raises), and a CA-less leg proving verify_identity fails closed at connect time -- not via any Client.new pre-flight -- when no CA is configured. Environment-gated like the existing SSL specs; the mismatch-by-name leg needs a wrong.mysql2gem.example.com hosts alias, added to CI alongside the existing one, and skips where unresolvable. The mismatch-by-IP leg supersedes the regression spec from #1568, which fails on real-certificate MariaDB CI legs until this enforcement lands.

Behavior changes, loudly:

* Connections that previously "succeeded" under ssl_mode: :verify_identity on MariaDB with the hostname never verified are now REFUSED unless the certificate actually covers the connected hostname. That includes 127.0.0.1/tunnel topologies -- connect via a name the certificate covers, or pin the certificate instead. This is the fix, not a side effect.
* Unset :sslca is no longer replaced by a guessed system bundle path: the find_default_ca_path probe of four hardcoded paths is no longer called (the helper remains, uncalled, for API compatibility), and the TLS backend's own default trust-store resolution applies instead.
* :verify_identity on MariaDB builds that cannot enforce it now raises (previously: silent CA-only verification at best).
* :verify_identity on MariaDB now implies a required TLS connection (MYSQL_OPT_SSL_ENFORCE), as it always did on MySQL.

Verification: full suite green on Linux/MariaDB 11.8 server with Connector/C 3.4.9 (the exact version from the #879 repro) and on macOS/libmysqlclient; TLS matrix additionally green against MySQL 8.4 with libmysqlclient 8.0.46 on Ubuntu 24.04. Specs verified to bite on deliberately broken builds: with the callback registration removed the post-connect tripwire still refuses the mismatch legs, and with both layers removed the mismatch-by-IP leg reproduces #879 (connects) and fails the suite. An instrumented build confirms the callback executes during the handshake, pre-auth. The CA-less verify_identity leg verified on both tiers: Connector/C 3.4 refuses via the callback ("certificate verification failed (self-signed certificate in certificate chain; CA in effect: none)") and libmysqlclient 8.0.46 refuses natively ("CA certificate is required if ssl-mode is VERIFY_CA or VERIFY_IDENTITY"), both as Mysql2::Error::ConnectionError.

Coverage limits: the callback verifies via OpenSSL only -- on Schannel/GnuTLS Connector/C builds it fails closed (refuses) rather than verifying, and Windows behavior (including the vendored MSYS2 build's TLS backend and the named-pipe transport, where the connector itself disables TLS) is compile-gated by the same extconf probes but untested here; CI's Windows legs skip the SSL context entirely, a pre-existing blind spot flagged on #879. The MARIADB_TLS head mirror is validated at runtime but is still a layout assumption against installed headers, re-verified for Connector/C 3.4.x and 12.3-bundled headers.

