### PR TITLE
Add Client#discard! for fork-safe disposal without QUIT

### DIFF
--- a/README.md
+++ b/README.md
@@ -452,32 +452,6 @@ It is useful if you want to provide session options which survive reconnection.
 Mysql2::Client.new(:init_command => "SET @@SESSION.sql_mode = 'STRICT_ALL_TABLES'")
 ```
 
-### Fork safety and `discard!`
-
-`fork` duplicates the client's socket into the child process, but the server
-session behind it is shared: if either process calls `close` -- or lets the
-garbage collector do it -- a QUIT command (and, under TLS, an SSL shutdown)
-goes down the shared socket and breaks the connection for the other process
-too.
-
-Call `discard!` to safely let go of a connection that another process owns:
-
-``` ruby
-fork do
-  client.discard! # the parent's session is untouched
-  # ... child works with its own, newly-created connections
-end
-```
-
-`discard!` drops this process's reference to the socket and frees client-side
-resources without sending anything to the server. Afterward the client behaves
-like a closed one: `closed?` returns true and further commands raise
-`Mysql2::Error`.
-
-Only discard connections some other process still owns: discarding a
-connection nothing else shares abandons the server session until it hits
-`wait_timeout`. Use `close` for connections this process owns.
-
 ### Multiple result sets
 
 You can also retrieve multiple result sets. For this to work you need to
@@ -542,9 +516,20 @@ next_result: Unknown column 'A' in 'field list' (Mysql2::Error)
 
 ### Fork safety
 
-A `Client`'s connection is not safe to use from a process that merely inherited it across `fork()`. The child shares the same underlying TCP socket as the parent, but its copy of the connection's protocol/TLS state is independent and unsynchronized. Using it can desync the connection or corrupt whatever the parent is doing with it.
+A `Client`'s connection is not safe to share across `fork()`. The child inherits the same underlying TCP socket as the parent, but its copy of the connection's protocol/TLS state is an independent, unsynchronized copy -- using it from both processes can desync the connection or corrupt whatever the other side is doing. Closing it (explicitly, or via the garbage collector) is just as unsafe: `close` sends a real QUIT (and, under TLS, an SSL shutdown) down the *shared* socket, which breaks the connection for whichever process didn't call it.
 
-mysql2 detects this automatically by recording the pid that established the connection and comparing it against the current pid. If a `Client` is garbage collected, queried, pinged, prepared, or executed from a different process than the one that connected it, mysql2 prints a `[WARN]` to stderr. This warning is silent when `automatic_close` has been explicitly set to `false` -- see below.
+mysql2 detects this automatically by recording the pid that established the connection and comparing it against the current pid. If a `Client` is garbage collected, queried, pinged, prepared, or executed from a different process than the one that connected it, mysql2 prints a `[WARN]` to stderr and, for garbage collection, takes care not to send a real close. This warning is silent when `automatic_close` has been explicitly set to `false` -- see below.
+
+Call `discard!`, not `close`, to deliberately let go of a connection another process owns:
+
+``` ruby
+fork do
+  client.discard! # the parent's session is untouched
+  # ... child works with its own, newly-created connections
+end
+```
+
+`discard!` drops this process's reference to the socket and frees client-side resources without sending anything to the server. Afterward the client behaves like a closed one: `closed?` returns true and further commands raise `Mysql2::Error`. Only discard connections some other process still owns -- discarding one nothing else shares just abandons the server session until it hits `wait_timeout`.
 
 By default (`automatic_close` is `true`), a `Client` garbage collected in a process that didn't establish its connection will not send a real close, to avoid interrupting the owning process's connection. Setting `automatic_close` to `false` opts out of automatic closing entirely -- useful if your application intentionally shares a `Client` across a `fork()` and serializes access to it (for example, closing it explicitly in the child once done, which ends the connection for both processes, not just the child's reference to it):
 

--- a/README.md
+++ b/README.md
@@ -452,6 +452,32 @@ It is useful if you want to provide session options which survive reconnection.
 Mysql2::Client.new(:init_command => "SET @@SESSION.sql_mode = 'STRICT_ALL_TABLES'")
 ```
 
+### Fork safety and `discard!`
+
+`fork` duplicates the client's socket into the child process, but the server
+session behind it is shared: if either process calls `close` -- or lets the
+garbage collector do it -- a QUIT command (and, under TLS, an SSL shutdown)
+goes down the shared socket and breaks the connection for the other process
+too.
+
+Call `discard!` to safely let go of a connection that another process owns:
+
+``` ruby
+fork do
+  client.discard! # the parent's session is untouched
+  # ... child works with its own, newly-created connections
+end
+```
+
+`discard!` drops this process's reference to the socket and frees client-side
+resources without sending anything to the server. Afterward the client behaves
+like a closed one: `closed?` returns true and further commands raise
+`Mysql2::Error`.
+
+Only discard connections some other process still owns: discarding a
+connection nothing else shares abandons the server session until it hits
+`wait_timeout`. Use `close` for connections this process owns.
+
 ### Multiple result sets
 
 You can also retrieve multiple result sets. For this to work you need to

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -378,6 +378,20 @@ static VALUE invalidate_fd(int clientfd)
 
   return Qtrue;
 }
+
+/* Drop this process's reference to the connection's socket -- redirect the
+ * fd to /dev/null and forget it -- leaving the underlying connection
+ * untouched for whatever else shares it across a fork. */
+static void invalidate_socket(mysql_client_wrapper *wrapper)
+{
+  if (CONNECTED(wrapper)) {
+    if (invalidate_fd(wrapper->client->net.fd) == Qfalse) {
+      fprintf(stderr, "[WARN] mysql2 failed to invalidate FD safely, closing unsafely\n");
+      close(wrapper->client->net.fd);
+    }
+    wrapper->client->net.fd = -1;
+  }
+}
 #endif /* _WIN32 */
 
 void mysql2_enqueue_pending_stmt_close(mysql_client_wrapper *wrapper, MYSQL_STMT *stmt, uintptr_t wrapper_key)
@@ -841,6 +855,59 @@ static VALUE rb_mysql_client_closed(VALUE self) {
   return CONNECTED(wrapper) ? Qfalse : Qtrue;
 }
 
+/* call-seq:
+ *    client.discard!
+ *
+ * Abandon the connection without disconnecting the underlying server
+ * session: drop this process's reference to the socket and free
+ * client-side resources, but never send a QUIT or shut the socket down.
+ * Use this in place of +close+ to let go of a connection shared with
+ * another process across a fork -- the other process's session, including
+ * its prepared statements, stays intact.
+ *
+ * Afterward the client behaves like a closed one: +closed?+ returns true
+ * and further commands raise Mysql2::Error. Discarding an already-closed
+ * or already-discarded client is a no-op, as is +close+ after +discard!+.
+ *
+ * If nothing else shares the socket, discarding abandons the server
+ * session until it times out on its own (+wait_timeout+); use +close+
+ * for connections this process owns.
+ *
+ * @return [nil]
+ */
+static VALUE rb_mysql_client_discard(VALUE self) {
+  GET_CLIENT(self);
+
+  if (wrapper->initialized && !wrapper->closed) {
+#ifndef _WIN32
+    invalidate_socket(wrapper);
+#else
+    /* No fd redirection on Windows (see invalidate_fd); processes don't
+     * share sockets across fork() here anyway. Close the socket outright
+     * without a QUIT, same as disconnect_and_mark_inactive. */
+    if (CONNECTED(wrapper)) {
+      close(wrapper->client->net.fd);
+      wrapper->client->net.fd = -1;
+    }
+#endif
+
+    /* Same teardown sequence as Client#close, but aimed at the now-dead
+     * fd: the force-free's drain of an abandoned stream reads instant EOF
+     * instead of stealing bytes from the shared socket, and the QUIT (and
+     * TLS shutdown) that mysql_close() writes is absorbed harmlessly. The
+     * deferred result frees are dropped as bookkeeping only -- the reap
+     * skips the real mysql_free_result() calls once the wrapper is no
+     * longer CONNECTED, leaking those client-side copies, the same
+     * tradeoff decr_mysql2_client accepts. */
+    mysql2_abandon_active_stream(wrapper);
+    mysql2_reap_pending_result_frees(wrapper);
+    mysql2_drop_pending_stmt_closes(wrapper);
+    rb_thread_call_without_gvl(nogvl_close, wrapper, RUBY_UBF_IO, 0);
+  }
+
+  return Qnil;
+}
+
 /*
  * mysql_send_query is unlikely to block since most queries are small
  * enough to fit in a socket buffer, but sometimes large UPDATE and
@@ -999,13 +1066,7 @@ static void invalidate_after_interrupted_query(mysql_client_wrapper *wrapper) {
   /* Invalidate the MySQL socket to prevent further communication.
    * The GC will come along later and call mysql_close to free it.
    */
-  if (CONNECTED(wrapper)) {
-    if (invalidate_fd(wrapper->client->net.fd) == Qfalse) {
-      fprintf(stderr, "[WARN] mysql2 failed to invalidate FD safely, closing unsafely\n");
-      close(wrapper->client->net.fd);
-    }
-    wrapper->client->net.fd = -1;
-  }
+  invalidate_socket(wrapper);
 }
 
 /* rb_rescue2 companion (do_ping): re-raises after cleanup. do_ping is a
@@ -2111,6 +2172,7 @@ void init_mysql2_client(void) {
 
   rb_define_method(cMysql2Client, "close", rb_mysql_client_close, 0);
   rb_define_method(cMysql2Client, "closed?", rb_mysql_client_closed, 0);
+  rb_define_method(cMysql2Client, "discard!", rb_mysql_client_discard, 0);
   rb_define_method(cMysql2Client, "abandon_results!", rb_mysql_client_abandon_results, 0);
   rb_define_method(cMysql2Client, "escape", rb_mysql_client_real_escape, 1);
   rb_define_method(cMysql2Client, "server_info", rb_mysql_client_server_info, 0);

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -582,17 +582,10 @@ void decr_mysql2_client(mysql_client_wrapper *wrapper)
      * when a fork() actually happened. */
     if (!wrapper->automatic_close || forked_without_reconnect) {
       /* The client is being garbage collected while connected. Prevent
-       * mysql_close() from sending a mysql-QUIT or from calling shutdown() on
-       * the socket by invalidating it. invalidate_fd() will drop this
-       * process's reference to the socket only, while a QUIT or shutdown()
-       * would render the underlying connection unusable, interrupting other
-       * processes which share this object across a fork().
+       * mysql_close() from sending a mysql-QUIT or from calling shutdown()
+       * on the socket -- see invalidate_socket().
        */
-      if (invalidate_fd(wrapper->client->net.fd) == Qfalse) {
-        fprintf(stderr, "[WARN] mysql2 failed to invalidate FD safely\n");
-        close(wrapper->client->net.fd);
-      }
-      wrapper->client->net.fd = -1;
+      invalidate_socket(wrapper);
     }
   }
 #endif
@@ -1202,18 +1195,16 @@ static VALUE disconnect_and_mark_inactive(VALUE self) {
      * an abnormal early exit (timeout, exception). Don't leave the
      * connection stuck BUSY. */
     wrapper->state = MYSQL2_CLIENT_IDLE;
-    if (CONNECTED(wrapper)) {
-      /* Invalidate the MySQL socket to prevent further communication. */
+    /* Invalidate the MySQL socket to prevent further communication -- see
+     * invalidate_socket(). */
 #ifndef _WIN32
-      if (invalidate_fd(wrapper->client->net.fd) == Qfalse) {
-        rb_warn("mysql2 failed to invalidate FD safely, closing unsafely\n");
-        close(wrapper->client->net.fd);
-      }
+    invalidate_socket(wrapper);
 #else
+    if (CONNECTED(wrapper)) {
       close(wrapper->client->net.fd);
-#endif
       wrapper->client->net.fd = -1;
     }
+#endif
     /* Skip mysql client check performed before command execution. */
     wrapper->client->status = MYSQL_STATUS_READY;
     wrapper->active_fiber = Qnil;

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -583,8 +583,7 @@ void decr_mysql2_client(mysql_client_wrapper *wrapper)
     if (!wrapper->automatic_close || forked_without_reconnect) {
       /* The client is being garbage collected while connected. Prevent
        * mysql_close() from sending a mysql-QUIT or from calling shutdown()
-       * on the socket -- see invalidate_socket().
-       */
+       * on the socket. */
       invalidate_socket(wrapper);
     }
   }
@@ -1195,8 +1194,7 @@ static VALUE disconnect_and_mark_inactive(VALUE self) {
      * an abnormal early exit (timeout, exception). Don't leave the
      * connection stuck BUSY. */
     wrapper->state = MYSQL2_CLIENT_IDLE;
-    /* Invalidate the MySQL socket to prevent further communication -- see
-     * invalidate_socket(). */
+    /* Invalidate the MySQL socket to prevent further communication. */
 #ifndef _WIN32
     invalidate_socket(wrapper);
 #else

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -509,6 +509,117 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     end
   end
 
+  context "#discard!" do
+    it "marks the client closed and further commands raise" do
+      client = new_client
+      expect(client.discard!).to be_nil
+      expect(client.closed?).to eql(true)
+      expect do
+        client.query "SELECT 1"
+      end.to raise_error(Mysql2::Error, /not connected/)
+    end
+
+    # Client#socket raises on Windows, so fd release isn't observable there
+    unless RUBY_PLATFORM =~ /mingw|mswin/
+      it "releases this process's socket fd" do
+        client = new_client
+        fd = client.socket
+        client.discard!
+        expect do
+          IO.for_fd(fd, autoclose: false).stat
+        end.to raise_error(Errno::EBADF)
+      end
+    end
+
+    it "is idempotent, in either order with close" do
+      client = new_client
+      client.discard!
+      expect(client.discard!).to be_nil
+      expect(client.close).to be_nil
+
+      client = new_client
+      client.close
+      expect(client.discard!).to be_nil
+    end
+
+    it "does not resurrect the connection via reconnect" do
+      client = new_client(reconnect: true)
+      client.discard!
+      expect(client.closed?).to eql(true)
+      expect do
+        client.query "SELECT 1"
+      end.to raise_error(Mysql2::Error, /not connected/)
+    end
+
+    it "can discard mid-stream" do
+      client = new_client
+      result = client.query("SELECT 1 AS a UNION SELECT 2", stream: true, cache_rows: false)
+      result.first
+      client.discard!
+      expect(client.closed?).to eql(true)
+    end
+
+    unless RUBY_PLATFORM =~ /mingw|mswin/
+      it "leaves the parent's session intact when a forked child discards" do
+        client = Mysql2::Client.new(DatabaseCredentials['root'])
+        thread_id = client.thread_id
+
+        child = fork do
+          client.discard!
+          status = client.closed? ? 0 : 1
+          client = nil
+          run_gc
+          exit! status
+        end
+
+        _, status = Process.waitpid2(child)
+        expect(status.exitstatus).to eq(0)
+
+        # both would raise if the child's discard!, or the GC run after it,
+        # had sent a QUIT or shutdown() down the shared socket
+        expect(client.query('SELECT 1 AS one').first).to eq('one' => 1)
+        expect(client.thread_id).to eq(thread_id)
+        client.close
+      end
+
+      it "leaves the parent's prepared statements intact when a forked child discards" do
+        client = new_client
+        stmt = client.prepare('SELECT ? AS n')
+
+        child = fork do
+          client.discard!
+          exit!
+        end
+        Process.wait(child)
+
+        expect(stmt.execute(42).first).to eq('n' => 42)
+        stmt.close
+      end
+
+      it "leaves the child's session intact when the parent discards" do
+        signal_r, signal_w = IO.pipe
+        result_r, result_w = IO.pipe
+
+        client = new_client
+        child = fork do
+          signal_w.close
+          result_r.close
+          signal_r.read(1) # wait for the parent's discard!
+          row = client.query("SELECT 'child session intact' AS proof").first
+          result_w.write(row.fetch('proof'))
+          exit!
+        end
+
+        signal_r.close
+        result_w.close
+        client.discard!
+        signal_w.write('!')
+        expect(result_r.read).to eq('child session intact')
+        Process.wait(child)
+      end
+    end
+  end
+
   it "should not try to query closed mysql connection" do
     client = new_client(reconnect: true)
     expect(client.close).to be_nil


### PR DESCRIPTION
Proposed in #1535.

A forked child that inherits a mysql2 connection has no safe way to let go of it. `Client#close` drives `mysql_close()`, which sends a QUIT command -- and, under TLS, an SSL shutdown -- down the socket it shares with the parent, corrupting or killing the parent's session. The safe mechanism has been in tree for years: `invalidate_fd()` dup2's `/dev/null` over the socket fd so this process's teardown lands harmlessly. But it is reachable only from the GC finalizer (and only with `automatic_close` disabled) and from interrupted-command cleanup -- there is no way to invoke disposal on purpose.

So Rails' Mysql2Adapter hand-rolls it (`mysql2_adapter.rb#discard!`):

```ruby
IO.for_fd(@raw_connection.socket, autoclose: false).reopen(IO::NULL)
@raw_connection&.automatic_close = false
```

a blanket-rescued fd hack layered on the GC-silencing flag, which still leaves a live `/dev/null` fd behind and a client that answers `closed?` false. trilogy ships `discard!` natively, which is why Rails' TrilogyAdapter version of the same method is one clean line. This is the disposal verb that the fork *detection* work in #1493 wants to point its warnings at.

`Client#discard!` makes the in-tree mechanism deliberate:

* Factor the fd neutralization that the GC path and interrupted-command cleanup already share into `invalidate_socket()`: `invalidate_fd()` the socket, fall back to a plain `close()` if `/dev/null` can't be opened, forget the fd. `invalidate_after_interrupted_query` now calls it; its behavior is unchanged.

* `discard!` calls it too, then runs `Client#close`'s teardown aimed at the now-dead fd: force-free an abandoned stream (its drain reads instant EOF instead of stealing bytes from the shared socket), drop the deferred statement-close/result-free bookkeeping without the network round trips, and finish with `mysql_close()`, whose QUIT and TLS shutdown are absorbed by `/dev/null` and which releases the fd. The client-side `MYSQL_RES` copies behind any queued deferred frees are dropped unfreed, the same tradeoff the GC path documents.

* Terminal state is identical to close: `closed?` answers true, further commands raise `Mysql2::Error`, reconnect stays off, and the GC finalizer has nothing left to send. `discard!` twice, or `discard!` and `close` in either order, is a no-op. Unlike close, `discard!` performs no fiber-ownership check: disposal from a forked child must not refuse because the connection was mid-query in the parent at fork time.

The deliberate non-behaviors are the point: no QUIT, no `shutdown()`, no statement closes -- the server-side session and its prepared statements belong to whoever still owns the real socket. Discarding a connection nothing else shares abandons the server session until `wait_timeout`; that is the documented contract, same as the Rails hack today, and the README section says when to reach for `close` instead.

Adjacency: PR #1563 (reentrancy guards) works in the same region of client.c around these helpers. This change does not depend on it -- the primitive it reuses predates both -- but the two will conflict textually; whichever lands second rebases onto the first, as planned in #1535.

Coverage: specs cover child-discards/parent-keeps-working (including a GC pass in the child), parent-discards/child-keeps-working, prepared statements surviving a sibling process's discard, mid-stream discard, idempotence in both orders with close, no resurrection via `reconnect: true`, and release of the process's socket fd. Each was verified to fail against deliberately broken builds: one that skips the neutralization (sends a real QUIT -- all three cross-process specs fail), one that skips the closed transition (the reconnect-resurrection and fd-release specs fail). Windows has no `fork()` and no `invalidate_fd()`: there `discard!` closes the socket outright without sending QUIT, matching the existing interrupted-query fallback, and the cross-process specs do not run.
