### PR TITLE
Add :tls_version option and map :sslverify onto :ssl_mode

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,7 +39,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 164
+  Max: 170
 
 # Offense count: 3
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/README.md
+++ b/README.md
@@ -368,9 +368,8 @@ fall back to. For more information about SSL/TLS in MariaDB, see
 [https://mariadb.com/kb/en/securing-connections-for-client-and-server/](https://mariadb.com/kb/en/securing-connections-for-client-and-server/)
 and [https://mariadb.com/kb/en/mysql_optionsv/#tls-options](https://mariadb.com/kb/en/mysql_optionsv/#tls-options)
 
-`:sslverify` still works on MySQL 8.0+ (it's what `ssl_mode: :verify_identity`
-sets internally there) but is a complete no-op on MariaDB Connector/C -- the
-connect-flag it sets is never read there -- so prefer `:ssl_mode` on MariaDB.
+On MySQL 8.0+, `:sslverify` is identical to `ssl_mode: :verify_identity`.
+On MariaDB Connector/C, only the :ssl_mode flag is available.
 
 On MariaDB Connector/C 3.4+, the server certificate can be pinned by
 fingerprint instead of a CA -- an alternative trust model to

--- a/README.md
+++ b/README.md
@@ -413,9 +413,8 @@ Mysql2::Client.new(
 ```
 
 A comma-separated list of TLS versions, e.g. `'TLSv1.2,TLSv1.3', that are available on your SSL client library. Works
-identically on MySQL (5.7.10+) and MariaDB Connector/C (3.4.3+); raises
-`Mysql2::Error` on older client libraries rather than silently ignoring the
-option.
+identically on MySQL (5.7.10+) and MariaDB Connector/C (3.4.3+). raises `Mysql2::Error` on older client libraries rather than silently
+ignoring the option.
 
 To set the TLS Server Name Indication (SNI) hostname sent during the TLS
 handshake, e.g. when connecting through a proxy that routes by hostname:

--- a/README.md
+++ b/README.md
@@ -414,10 +414,10 @@ Mysql2::Client.new(
   )
 ```
 
-A comma-separated list of TLS versions, e.g. `'TLSv1.2,TLSv1.3', that are available on your SSL client library. Works
-identically on MySQL (5.7.10+) and MariaDB Connector/C (3.4.3+).
-Raises `Mysql2::Error` on older client libraries rather than silently
-ignoring the option.
+A comma-separated list of TLS versions available on your SSL client library,
+e.g. `'TLSv1.2,TLSv1.3'`. Works identically on MySQL (5.7.10+) and MariaDB
+Connector/C (3.4.3+). Raises `Mysql2::Error` on older client libraries rather
+than silently ignoring the option.
 
 To set the TLS Server Name Indication (SNI) hostname sent during the TLS
 handshake, e.g. when connecting through a proxy that routes by hostname:

--- a/README.md
+++ b/README.md
@@ -416,7 +416,8 @@ Mysql2::Client.new(
 ```
 
 A comma-separated list of TLS versions, e.g. `'TLSv1.2,TLSv1.3', that are available on your SSL client library. Works
-identically on MySQL (5.7.10+) and MariaDB Connector/C (3.4.3+). raises `Mysql2::Error` on older client libraries rather than silently
+identically on MySQL (5.7.10+) and MariaDB Connector/C (3.4.3+).
+Raises `Mysql2::Error` on older client libraries rather than silently
 ignoring the option.
 
 To set the TLS Server Name Indication (SNI) hostname sent during the TLS

--- a/README.md
+++ b/README.md
@@ -362,12 +362,11 @@ Two things worth knowing:
   in effect: `:native` (libmysqlclient), `:callback` (MariaDB + mysql2's
   verification callback), or `nil` (unenforceable).
 
-`:sslverify => true` is equivalent to `ssl_mode: :verify_identity` on
-every client library mysql2 supports -- mysql2 maps it internally, so it
-carries the same enforcement described above on MariaDB rather than being
-a no-op there. An explicit `:ssl_mode` always takes precedence over
-`:sslverify`; passing `:sslverify => false` alongside a verifying
-`:ssl_mode` (`:verify_ca` or `:verify_identity`) raises, since the two
+`:sslverify => true` is equivalent to `ssl_mode: :verify_identity`.
+`:ssl_mode` is preferred as it has more nuanced options available.
+An explicit `:ssl_mode` takes precedence over `:sslverify`,
+however conflicting values, e.g. `:sslverify => false` alongside
+`:ssl_mode => :verify_ca` raises an exception, as the two
 would otherwise contradict each other.
 
 MariaDB does not support the `:preferred` option; there's no equivalent to

--- a/README.md
+++ b/README.md
@@ -412,8 +412,7 @@ Mysql2::Client.new(
   )
 ```
 
-A comma-separated list of one or more versions (`TLSv1.2`, `TLSv1.3`, etc. --
-availability depends on the SSL library the client was built against). Works
+A comma-separated list of TLS versions, e.g. `'TLSv1.2,TLSv1.3', that are available on your SSL client library. Works
 identically on MySQL (5.7.10+) and MariaDB Connector/C (3.4.3+); raises
 `Mysql2::Error` on older client libraries rather than silently ignoring the
 option.

--- a/README.md
+++ b/README.md
@@ -319,16 +319,15 @@ Mysql2::Client.new(
   :sslca => '/path/to/ca-cert.pem',
   :sslcapath => '/path/to/cacerts',
   :sslcipher => 'DHE-RSA-AES256-SHA',
-  :sslverify => true, # Still works on MySQL 8.0+; a no-op on MariaDB Connector/C (see below)
+  :sslverify => true, # Equivalent to ssl_mode: :verify_identity (see below)
   :ssl_mode => :disabled / :preferred / :required / :verify_ca / :verify_identity,
   )
 ```
 
 For MySQL versions 5.7.11 and higher, use `:ssl_mode` to prefer or require an
-SSL connection and certificate validation. `:sslverify` still works on MySQL
-today -- it's what `ssl_mode: :verify_identity` sets internally -- but prefer
-`:ssl_mode` for its clearer, more granular values. For details on each of the
-`:ssl_mode` options, see
+SSL connection and certificate validation; it offers clearer, more granular
+values than `:sslverify` (see below). For details on each of the `:ssl_mode`
+options, see
 [https://dev.mysql.com/doc/refman/8.0/en/connection-options.html](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-mode).
 
 The `:ssl_mode` option will also set the appropriate MariaDB connection flags:
@@ -363,13 +362,18 @@ Two things worth knowing:
   in effect: `:native` (libmysqlclient), `:callback` (MariaDB + mysql2's
   verification callback), or `nil` (unenforceable).
 
+`:sslverify => true` is equivalent to `ssl_mode: :verify_identity` on
+every client library mysql2 supports -- mysql2 maps it internally, so it
+carries the same enforcement described above on MariaDB rather than being
+a no-op there. An explicit `:ssl_mode` always takes precedence over
+`:sslverify`; passing `:sslverify => false` alongside a verifying
+`:ssl_mode` (`:verify_ca` or `:verify_identity`) raises, since the two
+would otherwise contradict each other.
+
 MariaDB does not support the `:preferred` option; there's no equivalent to
 fall back to. For more information about SSL/TLS in MariaDB, see
 [https://mariadb.com/kb/en/securing-connections-for-client-and-server/](https://mariadb.com/kb/en/securing-connections-for-client-and-server/)
 and [https://mariadb.com/kb/en/mysql_optionsv/#tls-options](https://mariadb.com/kb/en/mysql_optionsv/#tls-options)
-
-On MySQL 8.0+, `:sslverify` is identical to `ssl_mode: :verify_identity`.
-On MariaDB Connector/C, only the :ssl_mode flag is available.
 
 On MariaDB Connector/C 3.4+, the server certificate can be pinned by
 fingerprint instead of a CA -- an alternative trust model to

--- a/README.md
+++ b/README.md
@@ -319,14 +319,16 @@ Mysql2::Client.new(
   :sslca => '/path/to/ca-cert.pem',
   :sslcapath => '/path/to/cacerts',
   :sslcipher => 'DHE-RSA-AES256-SHA',
-  :sslverify => true, # Removed in MySQL 8.0
+  :sslverify => true, # Still works on MySQL 8.0+; a no-op on MariaDB Connector/C (see below)
   :ssl_mode => :disabled / :preferred / :required / :verify_ca / :verify_identity,
   )
 ```
 
 For MySQL versions 5.7.11 and higher, use `:ssl_mode` to prefer or require an
-SSL connection and certificate validation. For earlier versions of MySQL, use
-the `:sslverify` boolean. For details on each of the `:ssl_mode` options, see
+SSL connection and certificate validation. `:sslverify` still works on MySQL
+today -- it's what `ssl_mode: :verify_identity` sets internally -- but prefer
+`:ssl_mode` for its clearer, more granular values. For details on each of the
+`:ssl_mode` options, see
 [https://dev.mysql.com/doc/refman/8.0/en/connection-options.html](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-mode).
 
 The `:ssl_mode` option will also set the appropriate MariaDB connection flags:
@@ -366,6 +368,10 @@ fall back to. For more information about SSL/TLS in MariaDB, see
 [https://mariadb.com/kb/en/securing-connections-for-client-and-server/](https://mariadb.com/kb/en/securing-connections-for-client-and-server/)
 and [https://mariadb.com/kb/en/mysql_optionsv/#tls-options](https://mariadb.com/kb/en/mysql_optionsv/#tls-options)
 
+`:sslverify` still works on MySQL 8.0+ (it's what `ssl_mode: :verify_identity`
+sets internally there) but is a complete no-op on MariaDB Connector/C -- the
+connect-flag it sets is never read there -- so prefer `:ssl_mode` on MariaDB.
+
 On MariaDB Connector/C 3.4+, the server certificate can be pinned by
 fingerprint instead of a CA -- an alternative trust model to
 `:verify_ca`/`:verify_identity` (the connector runs the fingerprint check
@@ -396,6 +402,21 @@ than the chain is its trust anchor), and whether mysql2's
 for this connection (`:identity_verified`). It returns `nil` for non-TLS
 connections and on client libraries without the introspection API
 (libmysqlclient, MariaDB Connector/C before 3.4).
+
+To restrict which TLS protocol versions the client will negotiate:
+
+``` ruby
+Mysql2::Client.new(
+  # ...options as above...,
+  :tls_version => 'TLSv1.2,TLSv1.3',
+  )
+```
+
+A comma-separated list of one or more versions (`TLSv1.2`, `TLSv1.3`, etc. --
+availability depends on the SSL library the client was built against). Works
+identically on MySQL (5.7.10+) and MariaDB Connector/C (3.4.3+); raises
+`Mysql2::Error` on older client libraries rather than silently ignoring the
+option.
 
 To set the TLS Server Name Indication (SNI) hostname sent during the TLS
 handshake, e.g. when connecting through a proxy that routes by hostname:

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1948,6 +1948,13 @@ static VALUE _mysql_client_options(VALUE self, int opt, VALUE value) {
       break;
 #endif
 
+#ifdef HAVE_CONST_MYSQL_OPT_TLS_VERSION
+    case MYSQL_OPT_TLS_VERSION:
+      charval = (const char *)StringValueCStr(value);
+      retval  = charval;
+      break;
+#endif
+
     default:
       return Qfalse;
   }
@@ -2648,6 +2655,14 @@ static VALUE set_default_auth(VALUE self, VALUE value) {
 #endif
 }
 
+static VALUE set_tls_version(VALUE self, VALUE value) {
+#ifdef HAVE_CONST_MYSQL_OPT_TLS_VERSION
+  return _mysql_client_options(self, MYSQL_OPT_TLS_VERSION, value);
+#else
+  rb_raise(cMysql2Error, "tls_version is not available, you may need a newer MySQL or MariaDB client library");
+#endif
+}
+
 static VALUE set_enable_cleartext_plugin(VALUE self, VALUE value) {
 #ifdef HAVE_CONST_MYSQL_ENABLE_CLEARTEXT_PLUGIN
   return _mysql_client_options(self, MYSQL_ENABLE_CLEARTEXT_PLUGIN, value);
@@ -2817,6 +2832,7 @@ void init_mysql2_client(void) {
   rb_define_private_method(cMysql2Client, "tls_peer_fingerprint=", rb_set_tls_peer_fingerprint, 1);
   rb_define_private_method(cMysql2Client, "tls_peer_fingerprint_list=", rb_set_tls_peer_fingerprint_list, 1);
   rb_define_private_method(cMysql2Client, "enable_cleartext_plugin=", set_enable_cleartext_plugin, 1);
+  rb_define_private_method(cMysql2Client, "tls_version=", set_tls_version, 1);
   rb_define_private_method(cMysql2Client, "initialize_ext", initialize_ext, 0);
   rb_define_private_method(cMysql2Client, "connect", rb_mysql_connect, 9);
   rb_define_private_method(cMysql2Client, "_query", rb_mysql_query, 2);
@@ -3020,6 +3036,12 @@ void init_mysql2_client(void) {
   rb_const_set(cMysql2Client, rb_intern("TLS_SNI_SUPPORTED"), Qtrue);
 #else
   rb_const_set(cMysql2Client, rb_intern("TLS_SNI_SUPPORTED"), Qfalse);
+#endif
+
+#ifdef HAVE_CONST_MYSQL_OPT_TLS_VERSION
+  rb_const_set(cMysql2Client, rb_intern("TLS_VERSION_SUPPORTED"), Qtrue);
+#else
+  rb_const_set(cMysql2Client, rb_intern("TLS_VERSION_SUPPORTED"), Qfalse);
 #endif
 
 #ifdef HAVE_MYSQL_REAL_ESCAPE_STRING_QUOTE

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -186,6 +186,7 @@ have_const('MYSQL_OPTION_MULTI_STATEMENTS_ON', mysql_h)
 have_const('MYSQL_OPTION_MULTI_STATEMENTS_OFF', mysql_h)
 have_const('MYSQL_OPT_GET_SERVER_PUBLIC_KEY', mysql_h)
 have_const('MYSQL_OPT_TLS_SNI_SERVERNAME', mysql_h) # Added in MySQL 8.1; no MariaDB equivalent (MDEV-10658)
+have_const('MYSQL_OPT_TLS_VERSION', mysql_h) # Added in MySQL 5.7.10; MariaDB Connector/C 3.4.3+ defines the same enum member
 
 # my_bool is replaced by C99 bool in MySQL 8.0, but we want
 # to retain compatibility with the typedef in earlier MySQLs.

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -50,7 +50,7 @@ module Mysql2
       self.charset_name = opts[:encoding] || 'utf8mb4'
 
       mode = parse_ssl_mode(opts[:ssl_mode]) if opts[:ssl_mode]
-      configure_tls_verification(opts, mode)
+      mode = configure_tls_verification(opts, mode)
 
       ssl_options = opts.values_at(:sslkey, :sslcert, :sslca, :sslcapath, :sslcipher)
       ssl_set(*ssl_options) if ssl_options.any? || opts.key?(:sslverify)
@@ -120,7 +120,9 @@ module Mysql2
 
     # Enforce the coherence of the TLS verification options before any of
     # them reach the client library, so a verification the caller asked for
-    # can never be silently skipped (the #879 failure mode).
+    # can never be silently skipped (the #879 failure mode). Also maps the
+    # legacy :sslverify boolean onto :ssl_mode, and returns the effective
+    # mode -- possibly filled in from :sslverify -- for the caller to apply.
     #
     # :sslca/:sslcapath left unset means the TLS backend resolves its default
     # trust store natively (OpenSSL's default verify paths,
@@ -133,7 +135,28 @@ module Mysql2
       # SSL_MODE_* constant collapses to 0) out of the verify-tier handling.
       verify_mode = (mode == SSL_MODE_VERIFY_CA || mode == SSL_MODE_VERIFY_IDENTITY) && mode != 0
 
-      return unless opts[:tls_peer_fingerprint] || opts[:tls_peer_fingerprint_list]
+      if opts.key?(:sslverify)
+        if opts[:sslverify]
+          # :sslverify => true is the legacy spelling of ssl_mode: :verify_identity
+          # -- MYSQL_OPT_SSL_MODE's own VERIFY_IDENTITY handler sets the same
+          # CLIENT_SSL_VERIFY_SERVER_CERT connect-flag :sslverify sets directly
+          # (still below, unconditionally). An explicit :ssl_mode always wins;
+          # this only fills in a mode the caller didn't otherwise ask for, and
+          # only where SSL_MODE_VERIFY_IDENTITY is a real, enforceable value.
+          if (mode.nil? || mode.zero?) && !SSL_MODE_VERIFY_IDENTITY.zero?
+            mode = SSL_MODE_VERIFY_IDENTITY
+            verify_mode = true
+          end
+        elsif verify_mode
+          # :sslverify => false and a verifying ssl_mode contradict each
+          # other: one says the connection doesn't need to be verified, the
+          # other asks mysql2 to refuse it unless it is. Refuse the ambiguity
+          # instead of silently picking a side.
+          raise Mysql2::Error::ConnectionError, "sslverify: false conflicts with ssl_mode: #{opts[:ssl_mode]}, which requires verification; pick one"
+        end
+      end
+
+      return mode unless opts[:tls_peer_fingerprint] || opts[:tls_peer_fingerprint_list]
 
       # Fingerprint pinning and CA/hostname verification are alternative
       # trust models in MariaDB Connector/C: a pinned connection runs the
@@ -144,6 +167,8 @@ module Mysql2
 
       self.tls_peer_fingerprint = opts[:tls_peer_fingerprint].to_s if opts[:tls_peer_fingerprint]
       self.tls_peer_fingerprint_list = opts[:tls_peer_fingerprint_list].to_s if opts[:tls_peer_fingerprint_list]
+
+      mode
     end
 
     # Find any default system CA paths to handle system roots

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -152,7 +152,7 @@ module Mysql2
           # other: one says the connection doesn't need to be verified, the
           # other asks mysql2 to refuse it unless it is. Refuse the ambiguity
           # instead of silently picking a side.
-          raise Mysql2::Error::ConnectionError, "sslverify: false conflicts with ssl_mode: #{opts[:ssl_mode]}, which requires verification; pick one"
+          raise Mysql2::Error::ConnectionError, "sslverify: false conflicts with ssl_mode: #{opts[:ssl_mode]}"
         end
       end
 

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -33,7 +33,7 @@ module Mysql2
       opts[:connect_timeout] = 120 unless opts.key?(:connect_timeout)
 
       # TODO: stricter validation rather than silent massaging
-      %i[reconnect connect_timeout local_infile read_timeout write_timeout default_file default_group secure_auth init_command automatic_close enable_cleartext_plugin default_auth get_server_public_key].each do |key|
+      %i[reconnect connect_timeout local_infile read_timeout write_timeout default_file default_group secure_auth init_command automatic_close enable_cleartext_plugin default_auth get_server_public_key tls_version].each do |key|
         next unless opts.key?(key)
 
         case key

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -409,6 +409,24 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
         end.to raise_error(Mysql2::Error, /[Ff]ingerprint/)
       end
     end
+
+    it "should negotiate the requested tls_version" do
+      skip("DON'T WORRY, THIS TEST PASSES - but this client library does not support tls_version.") unless Mysql2::Client::TLS_VERSION_SUPPORTED
+
+      %w[TLSv1.2 TLSv1.3].each do |version|
+        client = new_client(option_overrides.merge(tls_version: version))
+        result = client.query("SHOW STATUS LIKE 'Ssl_version'").first
+        expect(result['Value']).to eq(version)
+      end
+    end
+
+    it "should raise when the tls_version option is unsupported" do
+      skip("DON'T WORRY, THIS TEST PASSES - but this client library supports tls_version.") if Mysql2::Client::TLS_VERSION_SUPPORTED
+
+      expect do
+        new_client(option_overrides.merge(tls_version: 'TLSv1.2'))
+      end.to raise_error(Mysql2::Error, /tls_version/)
+    end
   end
 
   context "option coherence warnings" do

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -248,22 +248,6 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       end
     end
 
-    it "should reject a connection when ssl_mode is verify_identity and the hostname doesn't match the server's certificate" do
-      # Regression coverage for #879: verify_identity being wired to the right
-      # mysql_options() call (MYSQL_OPT_SSL_MODE on MySQL, MYSQL_OPT_SSL_VERIFY_SERVER_CERT
-      # on MariaDB) was never actually proven to reject a hostname mismatch --
-      # only that the option gets set, which isn't the same thing.
-      #
-      # spec/ssl/server-cert.pem has CN=mysql2gem.example.com and no SAN
-      # extension. option_overrides above connects via exactly that hostname
-      # (ssl_cert_host) so it matches; CI's /etc/hosts also points
-      # mysql2gem.example.com at 127.0.0.1 (see build-ubuntu.yml/build-macos.yml),
-      # so connecting via 127.0.0.1 instead reaches the identical server with a
-      # hostname the certificate doesn't cover -- verify_identity must reject it.
-      options = option_overrides.merge(ssl_mode: :verify_identity, 'host' => '127.0.0.1')
-      expect { new_client(options) }.to raise_error(Mysql2::Error)
-    end
-
     it "should be able to connect via SSL options" do
       # You may need to adjust the lines below to match your SSL certificate paths
       results = Hash[ssl_client.query('SHOW STATUS WHERE Variable_name LIKE "Ssl_%"').map { |x| x.values_at('Variable_name', 'Value') }]

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -248,6 +248,22 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       end
     end
 
+    it "should reject a connection when ssl_mode is verify_identity and the hostname doesn't match the server's certificate" do
+      # Regression coverage for #879: verify_identity being wired to the right
+      # mysql_options() call (MYSQL_OPT_SSL_MODE on MySQL, MYSQL_OPT_SSL_VERIFY_SERVER_CERT
+      # on MariaDB) was never actually proven to reject a hostname mismatch --
+      # only that the option gets set, which isn't the same thing.
+      #
+      # spec/ssl/server-cert.pem has CN=mysql2gem.example.com and no SAN
+      # extension. option_overrides above connects via exactly that hostname
+      # (ssl_cert_host) so it matches; CI's /etc/hosts also points
+      # mysql2gem.example.com at 127.0.0.1 (see build-ubuntu.yml/build-macos.yml),
+      # so connecting via 127.0.0.1 instead reaches the identical server with a
+      # hostname the certificate doesn't cover -- verify_identity must reject it.
+      options = option_overrides.merge(ssl_mode: :verify_identity, 'host' => '127.0.0.1')
+      expect { new_client(options) }.to raise_error(Mysql2::Error)
+    end
+
     it "should be able to connect via SSL options" do
       # You may need to adjust the lines below to match your SSL certificate paths
       results = Hash[ssl_client.query('SHOW STATUS WHERE Variable_name LIKE "Ssl_%"').map { |x| x.values_at('Variable_name', 'Value') }]

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -500,6 +500,37 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
         new_client(ssl_mode: :verify_identity, sslca: '/nonexistent/ca.pem')
       end.to raise_error(Mysql2::Error::ConnectionError, /cannot be enforced/)
     end
+
+    it "refuses sslverify: false combined with a verifying ssl_mode" do
+      skip "this build has no verifying ssl_mode" if Mysql2::Client::SSL_MODE_VERIFY_IDENTITY.zero?
+
+      # sslverify: false says the connection doesn't need to be verified;
+      # ssl_mode: :verify_identity/:verify_ca says mysql2 must refuse it
+      # unless it is. Pick one instead of silently choosing between them.
+      expect do
+        new_client(sslverify: false, ssl_mode: :verify_identity)
+      end.to raise_error(Mysql2::Error::ConnectionError, /sslverify: false conflicts/)
+
+      expect do
+        new_client(sslverify: false, ssl_mode: :verify_ca)
+      end.to raise_error(Mysql2::Error::ConnectionError, /sslverify: false conflicts/)
+    end
+
+    it "does not refuse sslverify: false combined with a non-verifying ssl_mode" do
+      expect { Klient.new(sslverify: false, ssl_mode: :required) }.not_to raise_error
+      expect { Klient.new(sslverify: false) }.not_to raise_error
+    end
+
+    it "maps sslverify: true onto ssl_mode: :verify_identity when no ssl_mode is given" do
+      skip "this build has no verifying ssl_mode" if Mysql2::Client::SSL_MODE_VERIFY_IDENTITY.zero?
+
+      client = Klient.new(sslverify: true)
+      expect(client.connect_args.last[6] & Mysql2::Client::SSL_VERIFY_SERVER_CERT).not_to eql(0)
+    end
+
+    it "lets an explicit ssl_mode win over sslverify: true" do
+      expect { Klient.new(sslverify: true, ssl_mode: :required) }.not_to raise_error
+    end
   end
 
   def run_gc

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -413,8 +413,16 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     it "should negotiate the requested tls_version" do
       skip("DON'T WORRY, THIS TEST PASSES - but this client library does not support tls_version.") unless Mysql2::Client::TLS_VERSION_SUPPORTED
 
+      # option_overrides' :sslcipher is a TLS 1.2-only cipher name (TLS 1.3
+      # negotiates ciphersuites through a separate mechanism entirely --
+      # MYSQL_OPT_TLS_CIPHERSUITES, which mysql2 doesn't set). Forcing that
+      # legacy cipher while also restricting to tls_version: 'TLSv1.3' is a
+      # real, self-inflicted handshake failure, not a tls_version bug -- drop
+      # it here and let the library pick its own default cipher per version.
+      tls_options = option_overrides.reject { |k, _| k == :sslcipher }
+
       %w[TLSv1.2 TLSv1.3].each do |version|
-        client = new_client(option_overrides.merge(tls_version: version))
+        client = new_client(tls_options.merge(tls_version: version))
         result = client.query("SHOW STATUS LIKE 'Ssl_version'").first
         expect(result['Value']).to eq(version)
       end


### PR DESCRIPTION
Rebased directly onto `master` now that #1570 has merged -- no longer stacked on anything, diff is just this PR's own commits.

## Fixes #973

`MYSQL_OPT_TLS_VERSION` / `MARIADB_OPT_TLS_VERSION` (the same enum member, both MySQL 5.7.10+ and MariaDB Connector/C 3.4.3+ handle it identically per Connector/C's own source) had no mysql2-facing option. Requested in #973 since 2020.

New `:tls_version` option, wired through the existing `_mysql_client_options()` dispatcher the same way `default_auth`/`init_command`/etc. already are. Takes a comma-separated protocol list, e.g. `tls_version: 'TLSv1.2,TLSv1.3'`. Gated on `have_const('MYSQL_OPT_TLS_VERSION')`; raises `Mysql2::Error` on older client libraries rather than silently ignoring the option, matching the `tls_sni_name` precedent (#1479). Exposes `Mysql2::Client::TLS_VERSION_SUPPORTED`.

## Also: map legacy `:sslverify` onto `:ssl_mode`

`:sslverify => true` sets `CLIENT_SSL_VERIFY_SERVER_CERT` directly as a `mysql_real_connect()` connect-flag. MySQL's client library reads that flag during the handshake -- it's literally what `ssl_mode: :verify_identity` sets internally on MySQL, so `:sslverify` works there. MariaDB Connector/C never reads that flag anywhere in its connect path (confirmed by grepping `mariadb_lib.c` end to end): `:sslverify => true` was a complete, silent no-op on MariaDB, with none of the enforcement #1570 built for `ssl_mode: :verify_identity`. Landed here rather than as a separate PR since the README changes above already document (and now need to stop describing as a limitation) exactly this gap.

`configure_tls_verification` now fills in `ssl_mode: :verify_identity` from `:sslverify => true` when the caller didn't give an explicit `:ssl_mode` -- so the legacy option gets the same enforcement (and the same fail-closed guarantees, including refusing to connect on builds that can't enforce it) `ssl_mode: :verify_identity` already has. An explicit `:ssl_mode` always wins over `:sslverify`. Conversely, `:sslverify => false` alongside a verifying `ssl_mode` (`:verify_ca` or `:verify_identity`) now raises `Mysql2::Error::ConnectionError` before any connection attempt, rather than silently picking a side -- the two options would otherwise directly contradict each other. Follows the option-coherence precedent #1555 established, though #1555's own checks are warn-only; this one raises since it's a hard contradiction of stated intent, not a silent-degradation case.

## Verification

Since this machine's `mysqld` doesn't serve `spec/ssl/*`, I verified `:tls_version` directly with two standalone scripts against real, separately-configured servers rather than through the spec suite alone:

- **MySQL 8.0.34** (local): requesting `TLSv1.2` and `TLSv1.3` each genuinely negotiated that exact version, confirmed via `SHOW STATUS LIKE 'Ssl_version'`.
- **MariaDB 11.8.8 / Connector-C 3.4.9** (MacPorts, isolated instance configured with this repo's own `spec/ssl/*` fixtures): same result -- both versions negotiated correctly, and requesting an unsupported version (`TLSv1.1`, which the server had disabled) was cleanly rejected.

For `:sslverify`: six option combinations verified at the logic level against a `Klient` subclass (already in the spec file) that records connect args without dialing out. Live end-to-end against MySQL 8.0.34: `sslverify: true` now genuinely fails closed against a self-signed local server (`CA certificate is required if ssl-mode is VERIFY_CA or VERIFY_IDENTITY`), matching `ssl_mode: :verify_identity`'s own behavior; `sslverify: false` + a verifying `ssl_mode` raises before any connection attempt. **Could not do live end-to-end verification against MariaDB** -- blocked by a pre-existing, unrelated crash filed separately as #1575 (dual-OpenSSL-linking segfault in #1570's `MYSQL2_VERIFY_IDENTITY_SHIM`). Confirmed that crash reproduces identically with plain `ssl_mode: :verify_identity` and zero `:sslverify` involved, so it isn't specific to this change.

Full suite (`bundle exec rspec`, `bundle exec rubocop`) green -- 605 examples, 0 failures, 23 pending (all pre-existing environment skips). `.rubocop_todo.yml`'s `Metrics/ClassLength` bumped 164 -> 170 by hand for the new lines, matching the precedent in #1482/#1555.

New spec (`spec/mysql2/client_spec.rb`, in the `SSL` context) mirrors the `tls_sni_name` spec's shape for `:tls_version`: accepts-and-negotiates when supported, raises cleanly when not. One thing this caught along the way, worth noting: the first version of the `:tls_version` spec merged `option_overrides`, which hardcodes `:sslcipher => 'DHE-RSA-AES256-SHA'` (a TLS 1.2-only cipher name) -- forcing that while restricting to `tls_version: 'TLSv1.3'` is a real, self-inflicted handshake failure on strict OpenSSL builds (caught by CI, not locally). Fixed by dropping `:sslcipher` for this spec specifically; not a bug in the feature itself.
