### PR TITLE
Assert unconditionally in the interrupted-connection recovery specs

### DIFF
--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -1300,14 +1300,19 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
         end.to raise_error(Timeout::Error)
 
         # The interrupted exchange invalidates the connection, same as an
-        # interrupted query's read -- a normal, actionable connection error
-        # is fine, but a permanently leaked claim is not, whether reported
-        # to another fiber ("in use by") or to this one ("still waiting").
-        begin
+        # interrupted query's read -- so the follow-up query may raise a
+        # normal, actionable connection error, or may succeed outright.
+        # Either is fine; the one forbidden outcome is a permanently leaked
+        # claim, whether reported to another fiber ("in use by") or to this
+        # one ("still waiting"). Capture the error, if any, so the assertion
+        # runs on every outcome rather than only inside a rescue.
+        follow_up_error = begin
           @multi_client.query("SELECT 1")
+          nil
         rescue Mysql2::Error => e
-          expect(e.message).not_to match(/This connection is in use by|still waiting for a result/)
+          e
         end
+        expect(follow_up_error.to_s).not_to match(/This connection is in use by|still waiting for a result/)
       end
 
       it "releases its claim and keeps the connection usable when #abandon_results! hits a failed statement" do
@@ -2144,13 +2149,18 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
         thread.join(2)
 
         # The interrupted query must not leave the connection permanently
-        # marked busy -- a normal, actionable connection error is fine, but
-        # "This connection is in use by" (a dead fiber, forever) is not.
-        begin
+        # marked busy -- the follow-up query may raise a normal, actionable
+        # connection error or may succeed, but must never report "This
+        # connection is in use by" (a dead fiber, forever). Capture the
+        # error, if any, so the assertion runs on every outcome rather than
+        # only inside a rescue.
+        follow_up_error = begin
           client.query("SELECT 1")
+          nil
         rescue Mysql2::Error => e
-          expect(e.message).not_to match(/This connection is in use by/)
+          e
         end
+        expect(follow_up_error.to_s).not_to match(/This connection is in use by/)
       ensure
         begin
           client.close


### PR DESCRIPTION
Follow-up to @sodabrew's post-merge review of #1563 (https://github.com/brianmario/mysql2/pull/1563#discussion_r3794243844): the new interrupted-`#next_result` spec and its older Thread#exit sibling (#1392/#1508) placed their only assertion inside a `rescue Mysql2::Error` clause, so the expectation line runs only when the follow-up query raises.

The shape was sound in substance -- every leaked-claim manifestation raises a `Mysql2::Error` matching the guarded pattern (`rb_mysql_client_set_active_fiber` raises "This connection is in use by" for another fiber's claim and "still waiting for a result" for the same fiber's), so a follow-up query that succeeds proves the connection isn't locked out. But nothing in the specs said so: they read as "this should always raise," and a reader has to re-derive why a silent success is a passing outcome rather than a skipped assertion.

Both specs now capture the follow-up query's error (or nil) and run the expectation on it unconditionally, with comments enumerating the acceptable outcomes: success or an ordinary connection error, never a claim error.

Spec-only change. Full suite: 568 examples, 0 failures (11 pre-existing pendings); rubocop clean.