### PR TITLE
Map legacy :sslverify onto :ssl_mode instead of leaving it a MariaDB no-op

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,7 +39,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 164
+  Max: 170
 
 # Offense count: 3
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -50,7 +50,7 @@ module Mysql2
       self.charset_name = opts[:encoding] || 'utf8mb4'
 
       mode = parse_ssl_mode(opts[:ssl_mode]) if opts[:ssl_mode]
-      configure_tls_verification(opts, mode)
+      mode = configure_tls_verification(opts, mode)
 
       ssl_options = opts.values_at(:sslkey, :sslcert, :sslca, :sslcapath, :sslcipher)
       ssl_set(*ssl_options) if ssl_options.any? || opts.key?(:sslverify)
@@ -120,7 +120,9 @@ module Mysql2
 
     # Enforce the coherence of the TLS verification options before any of
     # them reach the client library, so a verification the caller asked for
-    # can never be silently skipped (the #879 failure mode).
+    # can never be silently skipped (the #879 failure mode). Also maps the
+    # legacy :sslverify boolean onto :ssl_mode, and returns the effective
+    # mode -- possibly filled in from :sslverify -- for the caller to apply.
     #
     # :sslca/:sslcapath left unset means the TLS backend resolves its default
     # trust store natively (OpenSSL's default verify paths,
@@ -133,7 +135,28 @@ module Mysql2
       # SSL_MODE_* constant collapses to 0) out of the verify-tier handling.
       verify_mode = (mode == SSL_MODE_VERIFY_CA || mode == SSL_MODE_VERIFY_IDENTITY) && mode != 0
 
-      return unless opts[:tls_peer_fingerprint] || opts[:tls_peer_fingerprint_list]
+      if opts.key?(:sslverify)
+        if opts[:sslverify]
+          # :sslverify => true is the legacy spelling of ssl_mode: :verify_identity
+          # -- MYSQL_OPT_SSL_MODE's own VERIFY_IDENTITY handler sets the same
+          # CLIENT_SSL_VERIFY_SERVER_CERT connect-flag :sslverify sets directly
+          # (still below, unconditionally). An explicit :ssl_mode always wins;
+          # this only fills in a mode the caller didn't otherwise ask for, and
+          # only where SSL_MODE_VERIFY_IDENTITY is a real, enforceable value.
+          if (mode.nil? || mode.zero?) && !SSL_MODE_VERIFY_IDENTITY.zero?
+            mode = SSL_MODE_VERIFY_IDENTITY
+            verify_mode = true
+          end
+        elsif verify_mode
+          # :sslverify => false and a verifying ssl_mode contradict each
+          # other: one says the connection doesn't need to be verified, the
+          # other asks mysql2 to refuse it unless it is. Refuse the ambiguity
+          # instead of silently picking a side.
+          raise Mysql2::Error::ConnectionError, "sslverify: false conflicts with ssl_mode: #{opts[:ssl_mode]}, which requires verification; pick one"
+        end
+      end
+
+      return mode unless opts[:tls_peer_fingerprint] || opts[:tls_peer_fingerprint_list]
 
       # Fingerprint pinning and CA/hostname verification are alternative
       # trust models in MariaDB Connector/C: a pinned connection runs the
@@ -144,6 +167,8 @@ module Mysql2
 
       self.tls_peer_fingerprint = opts[:tls_peer_fingerprint].to_s if opts[:tls_peer_fingerprint]
       self.tls_peer_fingerprint_list = opts[:tls_peer_fingerprint_list].to_s if opts[:tls_peer_fingerprint_list]
+
+      mode
     end
 
     # Find any default system CA paths to handle system roots

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -474,6 +474,37 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
         new_client(ssl_mode: :verify_identity, sslca: '/nonexistent/ca.pem')
       end.to raise_error(Mysql2::Error::ConnectionError, /cannot be enforced/)
     end
+
+    it "refuses sslverify: false combined with a verifying ssl_mode" do
+      skip "this build has no verifying ssl_mode" if Mysql2::Client::SSL_MODE_VERIFY_IDENTITY.zero?
+
+      # sslverify: false says the connection doesn't need to be verified;
+      # ssl_mode: :verify_identity/:verify_ca says mysql2 must refuse it
+      # unless it is. Pick one instead of silently choosing between them.
+      expect do
+        new_client(sslverify: false, ssl_mode: :verify_identity)
+      end.to raise_error(Mysql2::Error::ConnectionError, /sslverify: false conflicts/)
+
+      expect do
+        new_client(sslverify: false, ssl_mode: :verify_ca)
+      end.to raise_error(Mysql2::Error::ConnectionError, /sslverify: false conflicts/)
+    end
+
+    it "does not refuse sslverify: false combined with a non-verifying ssl_mode" do
+      expect { Klient.new(sslverify: false, ssl_mode: :required) }.not_to raise_error
+      expect { Klient.new(sslverify: false) }.not_to raise_error
+    end
+
+    it "maps sslverify: true onto ssl_mode: :verify_identity when no ssl_mode is given" do
+      skip "this build has no verifying ssl_mode" if Mysql2::Client::SSL_MODE_VERIFY_IDENTITY.zero?
+
+      client = Klient.new(sslverify: true)
+      expect(client.connect_args.last[6] & Mysql2::Client::SSL_VERIFY_SERVER_CERT).not_to eql(0)
+    end
+
+    it "lets an explicit ssl_mode win over sslverify: true" do
+      expect { Klient.new(sslverify: true, ssl_mode: :required) }.not_to raise_error
+    end
   end
 
   def run_gc


### PR DESCRIPTION
## The problem

`:sslverify => true` sets `CLIENT_SSL_VERIFY_SERVER_CERT` directly as a `mysql_real_connect()` connect-flag. MySQL's client library reads that flag during the handshake -- it's literally what `ssl_mode: :verify_identity` sets internally on MySQL, so `:sslverify` works there. MariaDB Connector/C never reads that flag anywhere in its connect path (confirmed by grepping `mariadb_lib.c` end to end): `:sslverify => true` is a complete, silent no-op on MariaDB, with none of the enforcement #1570 built for `ssl_mode: :verify_identity`.

## The fix

`configure_tls_verification` now fills in `ssl_mode: :verify_identity` from `:sslverify => true` when the caller didn't give an explicit `:ssl_mode` -- so the legacy option gets the same enforcement (and the same fail-closed guarantees, including refusing to connect on builds that can't enforce it) `ssl_mode: :verify_identity` already has. An explicit `:ssl_mode` always wins over `:sslverify`.

Conversely, `:sslverify => false` alongside a verifying `ssl_mode` (`:verify_ca` or `:verify_identity`) is a direct contradiction -- one says the connection doesn't need verification, the other requires it -- so that combination now raises `Mysql2::Error::ConnectionError` before any connection attempt, rather than silently picking a side. This follows the option-coherence precedent #1555 established, though #1555's own checks are warn-only; this one raises since it's a hard contradiction of stated intent, not a silent-degradation case.

## Verification

Logic-level: six `:sslverify`/`:ssl_mode` combinations exercised against a `Klient` subclass (already in the spec file) that records connect args without dialing out -- covers the synthesize-on-true-and-unset case, explicit-mode-wins in both directions, and both raise/no-raise sides of the false+conflicting-mode case.

Live end-to-end against MySQL 8.0.34: `sslverify: true` now genuinely fails closed against a self-signed local server (`CA certificate is required if ssl-mode is VERIFY_CA or VERIFY_IDENTITY`), matching `ssl_mode: :verify_identity`'s own behavior exactly; `sslverify: false` + a verifying `ssl_mode` raises before any connection attempt.

**Could not do live end-to-end verification against MariaDB** -- blocked by a pre-existing, unrelated crash I found while testing this and filed separately as #1575 (dual-OpenSSL-linking segfault in `MYSQL2_VERIFY_IDENTITY_SHIM`). Confirmed that crash reproduces identically with plain `ssl_mode: :verify_identity` and zero `:sslverify` involved, so it isn't specific to this change -- it's a pre-existing hazard in already-merged #1570 code, just newly surfaced by exercising the callback path on a machine with two different OpenSSL builds loaded (Ruby's own bundled OpenSSL + MacPorts' separate OpenSSL, in this case). Logic-level MariaDB coverage (the `Klient`-based specs) doesn't touch the crashing code path at all, since it never actually connects.

Full suite (`bundle exec rspec`, `bundle exec rubocop`): 603 examples, 0 failures, 21 pending (all pre-existing environment skips). `.rubocop_todo.yml`'s `Metrics/ClassLength` bumped 164 -> 170 by hand for the new lines, matching the precedent in #1482/#1555.
