### PR TITLE
Add :tls_passphrase and alias legacy :ssl* options as :tls_*

### DIFF
--- a/.github/workflows/build-cross-version.yml
+++ b/.github/workflows/build-cross-version.yml
@@ -22,6 +22,15 @@ jobs:
           - {os: ubuntu-24.04, ruby: '3.4', db: 'mariadb12.3-client_mariadb11.8-server', client_only: mariadb12.3, services: {mariadb: {image: 'mariadb:11.8', env: {MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'yes', MARIADB_DATABASE: test}, ports: ['3306:3306'], options: '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=3s --health-retries=10'}}}
           - {os: ubuntu-24.04, ruby: '3.4', db: 'mysql84-client_mysql97-server', client_only: mysql84, services: {mysql: {image: 'mysql:9.7', env: {MYSQL_ALLOW_EMPTY_PASSWORD: 'yes', MYSQL_DATABASE: test}, ports: ['3306:3306'], options: '--health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=3s --health-retries=10'}}}
           - {os: ubuntu-24.04, ruby: '3.4', db: 'mysql97-client_mysql84-server', client_only: mysql97, services: {mysql: {image: 'mysql:8.4', env: {MYSQL_ALLOW_EMPTY_PASSWORD: 'yes', MYSQL_DATABASE: test}, ports: ['3306:3306'], options: '--health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=3s --health-retries=10'}}}
+          # Cross-vendor: a MariaDB Connector/C client against a MySQL server,
+          # e.g. an app whose base image ships libmariadb-dev talking to a
+          # managed MySQL server (RDS and similar). A plain mysql: image
+          # approximates the server's TLS/protocol behavior but isn't RDS
+          # itself -- it doesn't reproduce RDS's own certificate chain.
+          - {os: ubuntu-24.04, ruby: '3.4', db: 'mariadb11.8-client_mysql84-server', client_only: mariadb11.8, services: {mysql: {image: 'mysql:8.4', env: {MYSQL_ALLOW_EMPTY_PASSWORD: 'yes', MYSQL_DATABASE: test}, ports: ['3306:3306'], options: '--health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=3s --health-retries=10'}}}
+          - {os: ubuntu-24.04, ruby: '3.4', db: 'mariadb11.8-client_mysql97-server', client_only: mariadb11.8, services: {mysql: {image: 'mysql:9.7', env: {MYSQL_ALLOW_EMPTY_PASSWORD: 'yes', MYSQL_DATABASE: test}, ports: ['3306:3306'], options: '--health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=3s --health-retries=10'}}}
+          - {os: ubuntu-24.04, ruby: '3.4', db: 'mariadb12.3-client_mysql84-server', client_only: mariadb12.3, services: {mysql: {image: 'mysql:8.4', env: {MYSQL_ALLOW_EMPTY_PASSWORD: 'yes', MYSQL_DATABASE: test}, ports: ['3306:3306'], options: '--health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=3s --health-retries=10'}}}
+          - {os: ubuntu-24.04, ruby: '3.4', db: 'mariadb12.3-client_mysql97-server', client_only: mariadb12.3, services: {mysql: {image: 'mysql:9.7', env: {MYSQL_ALLOW_EMPTY_PASSWORD: 'yes', MYSQL_DATABASE: test}, ports: ['3306:3306'], options: '--health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=3s --health-retries=10'}}}
       fail-fast: false
     env:
       BUNDLE_WITHOUT: development

--- a/.github/workflows/build-cross-version.yml
+++ b/.github/workflows/build-cross-version.yml
@@ -20,13 +20,6 @@ jobs:
         include:
           - {os: ubuntu-24.04, ruby: '3.4', db: 'mariadb11.8-client_mariadb12.3-server', client_only: mariadb11.8, services: {mariadb: {image: 'mariadb:12.3', env: {MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'yes', MARIADB_DATABASE: test}, ports: ['3306:3306'], options: '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=3s --health-retries=10'}}}
           - {os: ubuntu-24.04, ruby: '3.4', db: 'mariadb12.3-client_mariadb11.8-server', client_only: mariadb12.3, services: {mariadb: {image: 'mariadb:11.8', env: {MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'yes', MARIADB_DATABASE: test}, ports: ['3306:3306'], options: '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=3s --health-retries=10'}}}
-          # A Connector/C 3.4+ client against 10.6/10.11 servers: the ubuntu/mariadb10.6
-          # and mariadb10.11 legs in Build (Ubuntu) install a client library bundled
-          # with those older server releases (pre-3.4, ssl_mode: :verify_identity
-          # unenforceable, see #879), so they never exercise mysql2's verification
-          # callback. These rows pair a modern client with those same servers instead.
-          - {os: ubuntu-24.04, ruby: '3.4', db: 'mariadb11.8-client_mariadb10.6-server', client_only: mariadb11.8, services: {mariadb: {image: 'mariadb:10.6', env: {MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'yes', MARIADB_DATABASE: test}, ports: ['3306:3306'], options: '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=3s --health-retries=10'}}}
-          - {os: ubuntu-24.04, ruby: '3.4', db: 'mariadb12.3-client_mariadb10.11-server', client_only: mariadb12.3, services: {mariadb: {image: 'mariadb:10.11', env: {MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'yes', MARIADB_DATABASE: test}, ports: ['3306:3306'], options: '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=3s --health-retries=10'}}}
           - {os: ubuntu-24.04, ruby: '3.4', db: 'mysql84-client_mysql97-server', client_only: mysql84, services: {mysql: {image: 'mysql:9.7', env: {MYSQL_ALLOW_EMPTY_PASSWORD: 'yes', MYSQL_DATABASE: test}, ports: ['3306:3306'], options: '--health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=3s --health-retries=10'}}}
           - {os: ubuntu-24.04, ruby: '3.4', db: 'mysql97-client_mysql84-server', client_only: mysql97, services: {mysql: {image: 'mysql:8.4', env: {MYSQL_ALLOW_EMPTY_PASSWORD: 'yes', MYSQL_DATABASE: test}, ports: ['3306:3306'], options: '--health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=3s --health-retries=10'}}}
       fail-fast: false

--- a/.github/workflows/build-cross-version.yml
+++ b/.github/workflows/build-cross-version.yml
@@ -20,6 +20,13 @@ jobs:
         include:
           - {os: ubuntu-24.04, ruby: '3.4', db: 'mariadb11.8-client_mariadb12.3-server', client_only: mariadb11.8, services: {mariadb: {image: 'mariadb:12.3', env: {MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'yes', MARIADB_DATABASE: test}, ports: ['3306:3306'], options: '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=3s --health-retries=10'}}}
           - {os: ubuntu-24.04, ruby: '3.4', db: 'mariadb12.3-client_mariadb11.8-server', client_only: mariadb12.3, services: {mariadb: {image: 'mariadb:11.8', env: {MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'yes', MARIADB_DATABASE: test}, ports: ['3306:3306'], options: '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=3s --health-retries=10'}}}
+          # A Connector/C 3.4+ client against 10.6/10.11 servers: the ubuntu/mariadb10.6
+          # and mariadb10.11 legs in Build (Ubuntu) install a client library bundled
+          # with those older server releases (pre-3.4, ssl_mode: :verify_identity
+          # unenforceable, see #879), so they never exercise mysql2's verification
+          # callback. These rows pair a modern client with those same servers instead.
+          - {os: ubuntu-24.04, ruby: '3.4', db: 'mariadb11.8-client_mariadb10.6-server', client_only: mariadb11.8, services: {mariadb: {image: 'mariadb:10.6', env: {MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'yes', MARIADB_DATABASE: test}, ports: ['3306:3306'], options: '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=3s --health-retries=10'}}}
+          - {os: ubuntu-24.04, ruby: '3.4', db: 'mariadb12.3-client_mariadb10.11-server', client_only: mariadb12.3, services: {mariadb: {image: 'mariadb:10.11', env: {MARIADB_ALLOW_EMPTY_ROOT_PASSWORD: 'yes', MARIADB_DATABASE: test}, ports: ['3306:3306'], options: '--health-cmd="healthcheck.sh --connect --innodb_initialized" --health-interval=5s --health-timeout=3s --health-retries=10'}}}
           - {os: ubuntu-24.04, ruby: '3.4', db: 'mysql84-client_mysql97-server', client_only: mysql84, services: {mysql: {image: 'mysql:9.7', env: {MYSQL_ALLOW_EMPTY_PASSWORD: 'yes', MYSQL_DATABASE: test}, ports: ['3306:3306'], options: '--health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=3s --health-retries=10'}}}
           - {os: ubuntu-24.04, ruby: '3.4', db: 'mysql97-client_mysql84-server', client_only: mysql97, services: {mysql: {image: 'mysql:8.4', env: {MYSQL_ALLOW_EMPTY_PASSWORD: 'yes', MYSQL_DATABASE: test}, ports: ['3306:3306'], options: '--health-cmd="mysqladmin ping" --health-interval=5s --health-timeout=3s --health-retries=10'}}}
       fail-fast: false

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,7 +39,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 170
+  Max: 190
 
 # Offense count: 3
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,7 +39,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 190
+  Max: 195
 
 # Offense count: 3
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/README.md
+++ b/README.md
@@ -374,10 +374,8 @@ being silently ignored.
 | MariaDB Connector/C 3.3.x | 3 of 5 (`:disabled`/`:required`/`:verify_ca`) | ❌ | ❌ | ❌ | ✅ | ❌ |
 | MariaDB Connector/C 3.4.3+ | 4 of 5, no `:preferred` | ✅ via mysql2's callback | ✅ | ✅ | ✅ | ❌ |
 
-`:preferred` is missing from every MariaDB row above because MariaDB
-Connector/C never defines `MYSQL_OPT_SSL_MODE` at all -- mysql2 maps
-`:ssl_mode`'s other four values onto `MYSQL_OPT_SSL_ENFORCE` /
-`MYSQL_OPT_SSL_VERIFY_SERVER_CERT` instead (see the table further below).
+`:preferred` is missing from every MariaDB row above -- see the `:ssl_mode`
+mapping table further below for why.
 
 ``` ruby
 Mysql2::Client.new(
@@ -427,17 +425,14 @@ Mysql2::Client.new(
   )
 ```
 
-For MySQL versions 5.7.11 and higher, use `:ssl_mode` to prefer or require an
-SSL connection and certificate validation; it offers clearer, more granular
-values than `:sslverify` (see below). For details on each of the `:ssl_mode`
-options, see
-[https://dev.mysql.com/doc/refman/8.0/en/connection-options.html](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-mode).
-
-The `:ssl_mode` option will also set the appropriate MariaDB connection flags:
+`:ssl_mode` is native on MySQL 5.7.11+
+([full option reference](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-mode));
+on MariaDB it maps onto these options instead:
 
 | `:ssl_mode`        | MariaDB option value                                |
 | ---                | ---                                                 |
 | `:disabled`        | MYSQL_OPT_SSL_ENFORCE = 0                           |
+| `:preferred`       | not available -- MariaDB Connector/C never defines MYSQL_OPT_SSL_MODE |
 | `:required`        | MYSQL_OPT_SSL_ENFORCE = 1                           |
 | `:verify_ca`       | MYSQL_OPT_SSL_VERIFY_SERVER_CERT = 1                |
 | `:verify_identity` | MYSQL_OPT_SSL_VERIFY_SERVER_CERT = 1 + mysql2's own hostname verification |

--- a/README.md
+++ b/README.md
@@ -371,7 +371,7 @@ being silently ignored.
 | --- | --- | --- | --- | --- | --- | --- |
 | MySQL 5.7.11 -- 8.0.x | all 5, incl. `:preferred` | ✅ native | ✅ | ❌ | ❌ | ❌ |
 | MySQL 8.1+ / 8.4 LTS / 9.x | all 5, incl. `:preferred` | ✅ native | ✅ | ❌ | ❌ | ✅ |
-| MariaDB Connector/C 3.3.x | 4 of 5, no `:preferred` | ❌ | ❌ | ❌ | ✅ | ❌ |
+| MariaDB Connector/C 3.3.x | 3 of 5 (`:disabled`/`:required`/`:verify_ca`) | ❌ | ❌ | ❌ | ✅ | ❌ |
 | MariaDB Connector/C 3.4.3+ | 4 of 5, no `:preferred` | ✅ via mysql2's callback | ✅ | ✅ | ✅ | ❌ |
 
 `:preferred` is missing from every MariaDB row above because MariaDB

--- a/README.md
+++ b/README.md
@@ -339,9 +339,9 @@ Modern recommended MySQL/MariaDB versions are:
 * **MariaDB Connector/C 3.4.3+** bundled with MariaDB 11.4.5+ LTS / 11.8+ LTS / 12.3+ LTS: use the
   [MariaDB repository](https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage).
 
-Clients and servers can mix vendors, since both speak the same MySQL wire
-protocol and TLS wire protocol. Several common combinations are in the
-project CI matrix.
+Clients and servers can be mixed vendors and versions, since both speak the
+same MySQL wire protocol and TLS wire protocol. Several common combinations are
+in the project CI matrix.
 
 #### SSL/TLS options
 
@@ -351,8 +351,8 @@ project CI matrix.
 | `:tls_capath`           | `:sslcapath`     | System dependent | /path/to/cacerts
 | `:tls_cert`             | `:sslcert`       | None    | /path/to/client-cert.pem
 | `:tls_key`              | `:sslkey`        | None    | /path/to/client-key.pem
-| `:tls_version`          |                  | Varies  | Set the allowed TLS versions, comma separated: TLSv1.1, TLSv1.2, TLSv1.3, etc. All versions of SSL were deprecated by [RFC 7568](https://www.rfc-editor.org/rfc/rfc7568) (2015); TLSv1.0/TLSv1.1 by [RFC 8996](https://www.rfc-editor.org/rfc/rfc8996) (2021), and are increasingly unavailable.
-| `:tls_cipher`           |                  | Typically any TLS-compatible cipher suite | Set the allowed TLS ciphers in priority order, colon separated: 'DHE-RSA-AES256-SHA:DHE-RSA-AES256-CCM:!AES128-SHA', etc. Note some ciphers are only availble in some TLS versions. Impossible combinations will result in connection failures. See https://dev.mysql.com/doc/refman/en/encrypted-connection-protocols-ciphers.html and https://github.com/openssl/openssl/wiki/TLS1.3#ciphersuites
+| `:tls_version`          |                  | Varies  | Set the allowed TLS versions, comma separated: TLSv1.1, TLSv1.2, TLSv1.3, etc. All versions of SSL were deprecated by [RFC 7568](https://www.rfc-editor.org/rfc/rfc7568) in 2015, and TLSv1.0/TLSv1.1 by [RFC 8996](https://www.rfc-editor.org/rfc/rfc8996) in 2021. Vendor removal of TLSv1.1 and support addition of TLSv1.3 varies. Within TLSv1.2 and TLSv1.3, newer ECDSA certificates enable faster more secure cipher suites.
+| `:tls_cipher`           |                  | Typically any TLS-compatible cipher suite | Set the allowed TLS ciphers in priority order, colon separated: 'DHE-RSA-AES256-SHA:DHE-RSA-AES256-CCM:!AES128-SHA', etc. Note some ciphers are only available in some TLS versions. Impossible combinations will result in connection failures. See [MySQL: TLS Protocols and Ciphers](https://dev.mysql.com/doc/refman/en/encrypted-connection-protocols-ciphers.html) and [OpenSSL: TLS 1.3 Ciphersuites](https://github.com/openssl/openssl/wiki/TLS1.3#ciphersuites)
 |                         | `:sslverify`     | `false`     | _Deprecated._ Boolean. `true` is equivalent to `:ssl_mode => :verify_identity`.
 | `:tls_mode`             | `:ssl_mode`      | `:preferred` | _Replacement for `:sslverify`._ One of `:disabled`, `:preferred`, `:required`, `:verify_ca`, `:verify_identity`. `:preferred` performs no enforcement and silently falls back to a plaintext connection.
 | `:tls_sni_name`         |                  | None        | Hostname sent during TLS handshake, e.g. `'db.example.com'`. Supported by some proxies that route by hostname. Requires MySQL client library 8.1+; unsupported by MariaDB Connector/C.
@@ -362,7 +362,7 @@ project CI matrix.
 
 Notes:
 - Options will be referred to by the modern `:tls_` prefixes going forward.
-- If both a `:tls_*` option and its deprecated alias are given with different values, `:tls_*` wins (a warning is printed).
+- If both a `:tls_*` option and its deprecated alias are given with different values, `:tls_*` wins and a warning is printed.
 - Relative paths are allowed, and may be required by managed hosting providers such as Heroku.
 - Defaults are typical, but may be different based on MySQL/MariaDB client library or SSL/TLS library build options.
 
@@ -380,23 +380,23 @@ Notes:
 ❌ means the option will raise `Mysql2::Error` with this client library.
 
 Runtime client library and TLS feature introspection:
-
-``` ruby
-Mysql2::Client.info[:version]                   # linked client library version
-Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION  # :native (MySQL), :callback (MariaDB 3.4.3+), or nil (unenforceable)
-Mysql2::Client::TLS_VERSION_SUPPORTED           # true/false
-Mysql2::Client::TLS_SNI_SUPPORTED               # true/false
-```
+| Variable                                        | Contents
+| ---                                             | --- |
+|`Mysql2::Client.info[:version]`                  | linked client library version
+|`Mysql2::Client.tls_info`                        | TLS connection information (MariaDB Connector/C 3.4.3+), or nil (MySQL, earlier MariaDB)
+|`Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION` | :native (MySQL), :callback (MariaDB Connector/C 3.4.3+), or nil (unenforceable)
+|`Mysql2::Client::TLS_VERSION_SUPPORTED`          | true/false
+|`Mysql2::Client::TLS_SNI_SUPPORTED`              | true/false
 
 #### TLS verification modes
 
-| `:tls_mode`        | MySQL client behavior               | MariaDB client behavior             |
-| ---                | ---                                 | ---                                 |
-| `:disabled`        | no TLS                              | no TLS                              |
-| `:preferred`       | TLS if available, else quiet fallback to plaintext    | not supported                       |
-| `:required`        | TLS required, no certificate verification | TLS required, no certificate verification    |
-| `:verify_ca`       | TLS required, CA chain verified           | TLS required, CA chain verified -- hostname is NOT checked, even for local peers |
-| `:verify_identity` | TLS required, CA chain + hostname verified natively | TLS required, CA chain + hostname verified via mysql2's own verification callback (Connector/C 3.4+) |
+| `:tls_mode`        | MySQL client behavior                               | MariaDB client behavior
+| ---                | ---                                                 | ---
+| `:disabled`        | no TLS                                              | no TLS
+| `:preferred`       | TLS if available, else quiet fallback to plaintext  | not supported
+| `:required`        | TLS required, no certificate verification           | TLS required, no certificate verification
+| `:verify_ca`       | TLS required, CA chain verified                     | TLS required, CA chain verified -- hostname is NOT checked, even for local peers
+| `:verify_identity` | TLS required, CA chain + hostname verified natively | TLS required, CA chain + hostname verified via mysql2's own verification callback (Connector/C 3.4+)
 
 Notes:
 - With `:tls_ca`/`:tls_capath` unset, the TLS backend resolves its
@@ -416,9 +416,10 @@ Notes:
 #### Certificate fingerprint pinning
 
 On MariaDB Connector/C 3.4+, the server certificate can be pinned by
-fingerprint instead of a CA -- an alternative trust model to
-`:verify_ca`/`:verify_identity` (the connector runs the fingerprint check
-*instead of* the CA/hostname checks, so combining them raises):
+fingerprint instead of a CA. This is alternative trust model to
+`:verify_ca`/`:verify_identity`, ensuring that the specific certificate
+presented by the server matches one that the client trusts. An exception
+is raised if both CA verification and fingerprint verification are configured.
 
 ``` ruby
 Mysql2::Client.new(
@@ -436,13 +437,22 @@ client library observed it: negotiated protocol and cipher, the peer
 certificate the server actually presented (subject, issuer, validity,
 SHA-256 fingerprint), the bitmask of verification checks the connector
 recorded as failed (`:verify_status`, decodable with the
-`Mysql2::Client::TLS_VERIFY_*` constants -- note a CA-less pinned
-connection legitimately carries `TLS_VERIFY_TRUST`, since the pin rather
-than the chain is its trust anchor), and whether mysql2's
+`Mysql2::Client::TLS_VERIFY_*` constants, and whether mysql2's
 `:verify_identity` enforcement confirmed chain and hostname verification
 for this connection (`:identity_verified`). It returns `nil` for non-TLS
 connections and on client libraries without the introspection API
 (libmysqlclient, MariaDB Connector/C before 3.4).
+
+| Constant                  | Purpose |
+| ---                       | ---     |
+| `TLS_VERIFY_OK`           | No verification failure -- the chain and hostname checks that ran passed.
+| `TLS_VERIFY_TRUST`        | Certificate chain isn't trusted against the configured CA (or, for a CA-less pinned connection, no CA was configured at all -- see [Certificate fingerprint pinning](#certificate-fingerprint-pinning)).
+| `TLS_VERIFY_HOST`         | Hostname doesn't match the certificate's SAN/CN, or no hostname was available to check against.
+| `TLS_VERIFY_FINGERPRINT`  | Server certificate doesn't match a pinned `:tls_peer_fingerprint`.
+| `TLS_VERIFY_PERIOD`       | Certificate is outside its validity period (expired or not yet valid).
+| `TLS_VERIFY_REVOKED`      | Certificate has been revoked.
+| `TLS_VERIFY_UNKNOWN`      | Verification failed for an unspecified reason.
+| `TLS_VERIFY_ERROR`        | mysql2's own hostname-verification refusal -- forced so the connector's local-peer leniency (which would otherwise accept a self-signed certificate with no CA configured) can't complete the connection anyway.
 
 ### Secure auth
 

--- a/README.md
+++ b/README.md
@@ -364,14 +364,15 @@ relying on a distro package, the modern floors are:
 
 Only current, supported versions are listed. Older combinations still work
 in the code and specs but aren't documented here -- upgrade rather than
-work around them.
+work around them. ❌ means the option raises `Mysql2::Error` rather than
+being silently ignored.
 
 | Client library | `ssl_mode` values | `verify_identity` | `tls_version` | `tls_peer_fingerprint` | `tls_passphrase` | `tls_sni_name` |
 | --- | --- | --- | --- | --- | --- | --- |
 | MySQL 5.7.11 -- 8.0.x | all 5, incl. `:preferred` | ✅ native | ✅ | ❌ | ❌ | ❌ |
 | MySQL 8.1+ / 8.4 LTS / 9.x | all 5, incl. `:preferred` | ✅ native | ✅ | ❌ | ❌ | ✅ |
-| MariaDB Connector/C 3.3.x | 4 of 5, no `:preferred` | ❌ raises | ❌ raises | ❌ raises | ✅ | ❌ never |
-| MariaDB Connector/C 3.4.3+ | 4 of 5, no `:preferred` | ✅ via mysql2's callback | ✅ | ✅ | ✅ | ❌ never |
+| MariaDB Connector/C 3.3.x | 4 of 5, no `:preferred` | ❌ | ❌ | ❌ | ✅ | ❌ |
+| MariaDB Connector/C 3.4.3+ | 4 of 5, no `:preferred` | ✅ via mysql2's callback | ✅ | ✅ | ✅ | ❌ |
 
 `:preferred` is missing from every MariaDB row above because MariaDB
 Connector/C never defines `MYSQL_OPT_SSL_MODE` at all -- mysql2 maps

--- a/README.md
+++ b/README.md
@@ -380,6 +380,7 @@ Notes:
 | MariaDB Connector/C 3.4.3+ | 4 of 5, no `:preferred` | ✅ via mysql2's callback | ✅ | ✅ | ✅ | ❌ |
 
 ✅ means the option is supported with this client library.
+
 ❌ means the option will raise `Mysql2::Error` with this client library.
 
 Runtime client library and TLS feature introspection:

--- a/README.md
+++ b/README.md
@@ -314,13 +314,47 @@ managed hosting providers such as Heroku.
 ``` ruby
 Mysql2::Client.new(
   # ...options as above...,
-  :sslkey => '/path/to/client-key.pem',
-  :sslcert => '/path/to/client-cert.pem',
-  :sslca => '/path/to/ca-cert.pem',
-  :sslcapath => '/path/to/cacerts',
-  :sslcipher => 'DHE-RSA-AES256-SHA',
+  :tls_key => '/path/to/client-key.pem',
+  :tls_cert => '/path/to/client-cert.pem',
+  :tls_ca => '/path/to/ca-cert.pem',
+  :tls_capath => '/path/to/cacerts',
+  :tls_cipher => 'DHE-RSA-AES256-SHA',
   :sslverify => true, # Equivalent to ssl_mode: :verify_identity (see below)
   :ssl_mode => :disabled / :preferred / :required / :verify_ca / :verify_identity,
+  )
+```
+
+`:tls_key`/`:tls_cert`/`:tls_ca`/`:tls_capath`/`:tls_cipher` are the
+recommended names; `:sslkey`/`:sslcert`/`:sslca`/`:sslcapath`/`:sslcipher`
+remain supported as aliases so existing code keeps working. If both a
+`:tls_*` option and its legacy `:ssl*` alias are given with different
+values, `:tls_*` wins. This mirrors MariaDB Connector/C itself, which
+registers both an `ssl-*` and a `tls-*` name for the equivalent
+`mysql_options()` settings in its own config-file parser (see
+[`mariadb_lib.c`](https://github.com/mariadb-corporation/mariadb-connector-c/blob/master/libmariadb/mariadb_lib.c),
+e.g. `ssl-key`/`tls-key`). MySQL's own `mysql_options()` doesn't carry the
+same `ssl-key`/`tls-key`-style rename for these particular options --
+`--tls-version` and `--tls-ciphersuites` are its only `tls-`-prefixed
+options, and both are new capabilities that never had an `ssl-` name to
+begin with (see
+[https://dev.mysql.com/doc/c-api/8.0/en/mysql-options.html](https://dev.mysql.com/doc/c-api/8.0/en/mysql-options.html))
+-- but it's the same underlying direction: `tls-` is the modern prefix
+for TLS configuration on both client libraries, and mysql2 follows it.
+
+`:sslverify` is intentionally not renamed to a `:tls_*` name -- it already
+maps onto `:ssl_mode` (see below) rather than being a plain rename of an
+existing option.
+
+If your `:sslkey`/`:tls_key` file is encrypted, supply the passphrase to
+decrypt it (MariaDB Connector/C only -- MySQL's client library has no
+equivalent option, and mysql2 raises rather than connecting with an
+unusable key):
+
+``` ruby
+Mysql2::Client.new(
+  # ...options as above...,
+  :tls_key => '/path/to/encrypted-client-key.pem',
+  :tls_passphrase => 'the passphrase the key was encrypted with',
   )
 ```
 

--- a/README.md
+++ b/README.md
@@ -311,6 +311,88 @@ support. MySQL client library defaults will be used for any parameters that are
 left out or set to nil. Relative paths are allowed, and may be required by
 managed hosting providers such as Heroku.
 
+#### Modern best practices
+
+A fully-verified connection (certificate chain **and** hostname checked) on
+exactly TLS 1.3 needs two options together:
+
+``` ruby
+Mysql2::Client.new(
+  host: 'db.example.com',
+  ssl_mode: :verify_identity,
+  tls_version: 'TLSv1.3',
+)
+```
+
+Whether this actually gets you both depends entirely on **your application's
+own client library** -- not the database server's version, and not even your
+distro's marketing version number. Server and client library versions move
+independently. Two very common base images make this concrete:
+
+* **Ubuntu 24.04 LTS** (`ubuntu:24.04`) -- `apt-get install libmariadb-dev` /
+  `mariadb-server` installs MariaDB 10.11.13, bundling **MariaDB Connector/C
+  3.3.16**. That's below the 3.4 floor mysql2 needs to enforce
+  `verify_identity`'s hostname check -- it raises rather than connect with the
+  check silently skipped (#879), and `tls_version` raises too. The strongest
+  option available out of the box is CA-only verification:
+  ``` ruby
+  Mysql2::Client.new(
+    host: 'db.example.com',
+    ssl_mode: :verify_ca,   # chain verified; hostname is NOT checked on this build
+  )
+  ```
+  To get real hostname verification and `tls_version` on Ubuntu 24.04, add
+  MariaDB's own package repository (not Ubuntu's) and install from that
+  instead -- see
+  [MariaDB's package repository setup guide](https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage).
+* **Ubuntu 26.04 LTS** (`ubuntu:26.04`) -- ships MariaDB 11.8.6, bundling
+  **MariaDB Connector/C 3.4.9**. The first `ssl_mode: :verify_identity` /
+  `tls_version: 'TLSv1.3'` example above works out of the box, no extra repo
+  needed.
+
+If you're building or installing a client library directly rather than
+relying on a distro package, the modern floors are:
+
+* **MySQL 8.0.36 or later** (any current MySQL 8.0 LTS / 8.4 LTS / 9.x point
+  release -- via the
+  [MySQL APT repository](https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/)
+  or equivalent). MySQL 5.7.11+ is functionally sufficient for everything in
+  this section too, but MySQL 5.7 itself is long past Oracle's supported
+  end-of-life -- treat 5.7.11+ as "still works," not as a recommendation.
+* **MariaDB Connector/C 3.4.3 or later**, installed from
+  [MariaDB's own package repository](https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)
+  rather than your distro's archive. This ships with recent MariaDB 11.4 LTS
+  point releases and all of 11.8+/12.3+, but *not* with 11.4's earliest point
+  releases (11.4.0-11.4.4 bundled Connector/C 3.4.2, which enforces
+  `verify_identity` but can't do `tls_version` -- see the compatibility table
+  below). Check what you actually have rather than assuming from the server's
+  marketing version:
+  ``` ruby
+  Mysql2::Client.info[:version]                        # linked client library version
+  Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION        # :native, :callback, or nil (unenforceable)
+  Mysql2::Client::TLS_VERSION_SUPPORTED                 # true/false
+  ```
+
+#### Version compatibility
+
+Only current, supported versions are listed here. If you're on something
+older than every row below, `ssl_mode`/`tls_*` behavior for it is still in
+the code and specs, but isn't covered in this README -- upgrading is the
+recommended path rather than working around it.
+
+| Client library | `ssl_mode` values | `verify_identity` | `tls_version` | `tls_peer_fingerprint` | `tls_passphrase` | `tls_sni_name` |
+| --- | --- | --- | --- | --- | --- | --- |
+| MySQL 5.7.11 -- 8.0.x | all 5, incl. `:preferred` | ✅ native | ✅ | ❌ | ❌ | ❌ |
+| MySQL 8.1+ / 8.4 LTS / 9.x | all 5, incl. `:preferred` | ✅ native | ✅ | ❌ | ❌ | ✅ (8.1+) |
+| MariaDB Connector/C 3.4.0 -- 3.4.2 | 4 of 5, no `:preferred` | ✅ via mysql2's callback | ❌ raises | ✅ | ✅ | ❌ never |
+| MariaDB Connector/C 3.4.3+ | 4 of 5, no `:preferred` | ✅ via mysql2's callback | ✅ | ✅ | ✅ | ❌ never |
+
+`:preferred` doesn't exist on MariaDB at any version -- MariaDB Connector/C
+never defines `MYSQL_OPT_SSL_MODE` at all; mysql2 maps `:ssl_mode`'s other
+four values onto MariaDB's own `MYSQL_OPT_SSL_ENFORCE` /
+`MYSQL_OPT_SSL_VERIFY_SERVER_CERT` options instead (see the table further
+below). `tls_sni_name` never works on any MariaDB Connector/C version.
+
 ``` ruby
 Mysql2::Client.new(
   # ...options as above...,
@@ -319,7 +401,7 @@ Mysql2::Client.new(
   :tls_ca => '/path/to/ca-cert.pem',
   :tls_capath => '/path/to/cacerts',
   :tls_cipher => 'DHE-RSA-AES256-SHA',
-  :sslverify => true, # Equivalent to ssl_mode: :verify_identity (see below)
+  :sslverify => true, # deprecated -- equivalent to ssl_mode: :verify_identity (see below)
   :ssl_mode => :disabled / :preferred / :required / :verify_ca / :verify_identity,
   )
 ```
@@ -341,9 +423,10 @@ begin with (see
 -- but it's the same underlying direction: `tls-` is the modern prefix
 for TLS configuration on both client libraries, and mysql2 follows it.
 
-`:sslverify` is intentionally not renamed to a `:tls_*` name -- it already
-maps onto `:ssl_mode` (see below) rather than being a plain rename of an
-existing option.
+`:sslverify` is deprecated in favor of `:ssl_mode`, which has more nuanced
+values available (see below) -- it's intentionally not renamed to a `:tls_*`
+name, since it isn't a plain rename of an existing option the way the five
+above are.
 
 If your `:sslkey`/`:tls_key` file is encrypted, supply the passphrase to
 decrypt it (MariaDB Connector/C only -- MySQL's client library has no
@@ -397,8 +480,8 @@ Two things worth knowing:
   verification callback), or `nil` (unenforceable).
 
 `:sslverify => true` is equivalent to `ssl_mode: :verify_identity`.
-`:ssl_mode` is preferred as it has more nuanced options available.
-An explicit `:ssl_mode` takes precedence over `:sslverify`,
+`:sslverify` is deprecated in favor of `:ssl_mode`, which has more nuanced
+values available. An explicit `:ssl_mode` takes precedence over `:sslverify`,
 however conflicting values, e.g. `:sslverify => false` alongside
 `:ssl_mode => :verify_ca` raises an exception, as the two
 would otherwise contradict each other.

--- a/README.md
+++ b/README.md
@@ -374,53 +374,7 @@ being silently ignored.
 | MariaDB Connector/C 3.3.x | 3 of 5 (`:disabled`/`:required`/`:verify_ca`) | ❌ | ❌ | ❌ | ✅ | ❌ |
 | MariaDB Connector/C 3.4.3+ | 4 of 5, no `:preferred` | ✅ via mysql2's callback | ✅ | ✅ | ✅ | ❌ |
 
-`:preferred` is missing from every MariaDB row above -- see the `:ssl_mode`
-mapping table further below for why.
-
-``` ruby
-Mysql2::Client.new(
-  # ...options as above...,
-  :tls_key => '/path/to/client-key.pem',
-  :tls_cert => '/path/to/client-cert.pem',
-  :tls_ca => '/path/to/ca-cert.pem',
-  :tls_capath => '/path/to/cacerts',
-  :tls_cipher => 'DHE-RSA-AES256-SHA',
-  :sslverify => true, # deprecated -- equivalent to ssl_mode: :verify_identity (see below)
-  :ssl_mode => :disabled / :preferred / :required / :verify_ca / :verify_identity,
-  )
-```
-
-`:tls_key`/`:tls_cert`/`:tls_ca`/`:tls_capath`/`:tls_cipher` are the
-recommended names; `:sslkey`/`:sslcert`/`:sslca`/`:sslcapath`/`:sslcipher`
-remain supported as aliases so existing code keeps working. If both a
-`:tls_*` option and its legacy `:ssl*` alias are given with different
-values, `:tls_*` wins. This mirrors MariaDB Connector/C itself, which
-registers both an `ssl-*` and a `tls-*` name for the equivalent
-`mysql_options()` settings in its own config-file parser (see
-[`mariadb_lib.c`](https://github.com/mariadb-corporation/mariadb-connector-c/blob/master/libmariadb/mariadb_lib.c),
-e.g. `ssl-key`/`tls-key`). MySQL's own `mysql_options()` doesn't carry the
-same `ssl-key`/`tls-key`-style rename for these particular options --
-`--tls-version` and `--tls-ciphersuites` are its only `tls-`-prefixed
-options, and both are new capabilities that never had an `ssl-` name to
-begin with (see
-[https://dev.mysql.com/doc/c-api/8.0/en/mysql-options.html](https://dev.mysql.com/doc/c-api/8.0/en/mysql-options.html))
--- but it's the same underlying direction: `tls-` is the modern prefix
-for TLS configuration on both client libraries, and mysql2 follows it.
-
-`:sslverify` is deprecated in favor of `:ssl_mode`.
-
-If your `:sslkey`/`:tls_key` file is encrypted, supply the passphrase to
-decrypt it (MariaDB Connector/C only -- MySQL's client library has no
-equivalent option, and mysql2 raises rather than connecting with an
-unusable key):
-
-``` ruby
-Mysql2::Client.new(
-  # ...options as above...,
-  :tls_key => '/path/to/encrypted-client-key.pem',
-  :tls_passphrase => 'the passphrase the key was encrypted with',
-  )
-```
+#### Verification levels
 
 `:ssl_mode` is native on MySQL 5.7.11+
 ([full option reference](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-mode)).
@@ -448,17 +402,60 @@ Two things worth knowing:
   in effect: `:native` (libmysqlclient), `:callback` (MariaDB + mysql2's
   verification callback), or `nil` (unenforceable).
 
-`:sslverify => true` is equivalent to `ssl_mode: :verify_identity`.
-`:sslverify` is deprecated in favor of `:ssl_mode`. An explicit `:ssl_mode`
-takes precedence over `:sslverify`,
-however conflicting values, e.g. `:sslverify => false` alongside
-`:ssl_mode => :verify_ca` raises an exception, as the two
-would otherwise contradict each other.
+`:sslverify => true` is deprecated, equivalent to `ssl_mode: :verify_identity`.
+An explicit `:ssl_mode` takes precedence over `:sslverify`; however,
+conflicting values, e.g. `:sslverify => false` alongside
+`:ssl_mode => :verify_ca`, raise an exception, as the two would otherwise
+contradict each other.
 
-MariaDB does not support the `:preferred` option; there's no equivalent to
-fall back to. For more information about SSL/TLS in MariaDB, see
+For more information about SSL/TLS in MariaDB, see
 [https://mariadb.com/kb/en/securing-connections-for-client-and-server/](https://mariadb.com/kb/en/securing-connections-for-client-and-server/)
 and [https://mariadb.com/kb/en/mysql_optionsv/#tls-options](https://mariadb.com/kb/en/mysql_optionsv/#tls-options)
+
+#### Client keys, certificates, and CAs
+
+``` ruby
+Mysql2::Client.new(
+  # ...options as above...,
+  :tls_key => '/path/to/client-key.pem',
+  :tls_cert => '/path/to/client-cert.pem',
+  :tls_ca => '/path/to/ca-cert.pem',
+  :tls_capath => '/path/to/cacerts',
+  :tls_cipher => 'DHE-RSA-AES256-SHA',
+  )
+```
+
+`:tls_key`/`:tls_cert`/`:tls_ca`/`:tls_capath`/`:tls_cipher` are the
+recommended names; `:sslkey`/`:sslcert`/`:sslca`/`:sslcapath`/`:sslcipher`
+remain supported as aliases so existing code keeps working. If both a
+`:tls_*` option and its legacy `:ssl*` alias are given with different
+values, `:tls_*` wins. This mirrors MariaDB Connector/C itself, which
+registers both an `ssl-*` and a `tls-*` name for the equivalent
+`mysql_options()` settings in its own config-file parser (see
+[`mariadb_lib.c`](https://github.com/mariadb-corporation/mariadb-connector-c/blob/master/libmariadb/mariadb_lib.c),
+e.g. `ssl-key`/`tls-key`). MySQL's own `mysql_options()` doesn't carry the
+same `ssl-key`/`tls-key`-style rename for these particular options --
+`--tls-version` and `--tls-ciphersuites` are its only `tls-`-prefixed
+options, and both are new capabilities that never had an `ssl-` name to
+begin with (see
+[https://dev.mysql.com/doc/c-api/8.0/en/mysql-options.html](https://dev.mysql.com/doc/c-api/8.0/en/mysql-options.html))
+-- but it's the same underlying direction: `tls-` is the modern prefix
+for TLS configuration on both client libraries, and mysql2 follows it.
+
+If your `:sslkey`/`:tls_key` file is encrypted, supply the passphrase to
+decrypt it (MariaDB Connector/C only -- MySQL's client library has no
+equivalent option, and mysql2 raises rather than connecting with an
+unusable key):
+
+``` ruby
+Mysql2::Client.new(
+  # ...options as above...,
+  :tls_key => '/path/to/encrypted-client-key.pem',
+  :tls_passphrase => 'the passphrase the key was encrypted with',
+  )
+```
+
+#### Certificate fingerprint pinning
 
 On MariaDB Connector/C 3.4+, the server certificate can be pinned by
 fingerprint instead of a CA -- an alternative trust model to
@@ -474,9 +471,7 @@ Mysql2::Client.new(
   )
 ```
 
-On client libraries without pinning support (libmysqlclient, MariaDB
-Connector/C before 3.4) these options raise rather than silently
-connecting unpinned.
+#### Inspecting the TLS session
 
 After connecting, `Client#tls_info` describes the TLS session as the
 client library observed it: negotiated protocol and cipher, the peer
@@ -491,6 +486,8 @@ for this connection (`:identity_verified`). It returns `nil` for non-TLS
 connections and on client libraries without the introspection API
 (libmysqlclient, MariaDB Connector/C before 3.4).
 
+#### Restricting TLS protocol versions
+
 To restrict which TLS protocol versions the client will negotiate:
 
 ``` ruby
@@ -501,9 +498,9 @@ Mysql2::Client.new(
 ```
 
 A comma-separated list of TLS versions available on your SSL client library,
-e.g. `'TLSv1.2,TLSv1.3'`. Works identically on MySQL (5.7.10+) and MariaDB
-Connector/C (3.4.3+). Raises `Mysql2::Error` on older client libraries rather
-than silently ignoring the option.
+e.g. `'TLSv1.2,TLSv1.3'`.
+
+#### TLS Server Name Indication (SNI)
 
 To set the TLS Server Name Indication (SNI) hostname sent during the TLS
 handshake, e.g. when connecting through a proxy that routes by hostname:
@@ -515,9 +512,7 @@ Mysql2::Client.new(
   )
 ```
 
-This requires MySQL client library 8.1 or higher. On older client libraries
-and all versions of MariaDB, passing this option raises `Mysql2::Error`
-rather than silently connecting without it.
+This requires MySQL client library 8.1 or higher; unsupported on MariaDB.
 
 ### Secure auth
 

--- a/README.md
+++ b/README.md
@@ -353,8 +353,7 @@ relying on a distro package, the modern floors are:
   rather than your distro's archive. This ships with recent MariaDB 11.4 LTS
   point releases and all of 11.8+/12.3+, but *not* with 11.4's earliest point
   releases (11.4.0-11.4.4 bundled Connector/C 3.4.2, which enforces
-  `verify_identity` but can't do `tls_version` -- see the compatibility table
-  below). Check what you actually have:
+  `verify_identity` but can't do `tls_version`). Check what you actually have:
   ``` ruby
   Mysql2::Client.info[:version]                        # linked client library version
   Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION        # :native, :callback, or nil (unenforceable)
@@ -371,7 +370,7 @@ work around them.
 | --- | --- | --- | --- | --- | --- | --- |
 | MySQL 5.7.11 -- 8.0.x | all 5, incl. `:preferred` | ✅ native | ✅ | ❌ | ❌ | ❌ |
 | MySQL 8.1+ / 8.4 LTS / 9.x | all 5, incl. `:preferred` | ✅ native | ✅ | ❌ | ❌ | ✅ |
-| MariaDB Connector/C 3.4.0 -- 3.4.2 | 4 of 5, no `:preferred` | ✅ via mysql2's callback | ❌ raises | ✅ | ✅ | ❌ never |
+| MariaDB Connector/C 3.3.x | 4 of 5, no `:preferred` | ❌ raises | ❌ raises | ❌ raises | ✅ | ❌ never |
 | MariaDB Connector/C 3.4.3+ | 4 of 5, no `:preferred` | ✅ via mysql2's callback | ✅ | ✅ | ✅ | ❌ never |
 
 `:preferred` is missing from every MariaDB row above because MariaDB

--- a/README.md
+++ b/README.md
@@ -324,17 +324,16 @@ Mysql2::Client.new(
 )
 ```
 
-Whether this actually gets you both depends entirely on **your application's
-own client library** -- not the database server's version, and not even your
-distro's marketing version number. Server and client library versions move
-independently. A very common base image makes this concrete:
+This depends on **your application's client library version**, not the
+server's -- they move independently. A very common base image makes this
+concrete:
 
 * **Ubuntu 24.04 LTS** (`ubuntu:24.04`) -- `apt-get install libmariadb-dev` /
   `mariadb-server` installs MariaDB 10.11.13, bundling **MariaDB Connector/C
-  3.3.16**. That's below the 3.4 floor mysql2 needs to enforce
-  `verify_identity`'s hostname check -- it raises rather than connect with the
-  check silently skipped (#879), and `tls_version` raises too. The strongest
-  option available out of the box is CA-only verification:
+  3.3.16** -- below the 3.4 floor mysql2 needs for `verify_identity`
+  (raises rather than skip the hostname check silently, #879) or
+  `tls_version` (also raises). The strongest option out of the box is
+  CA-only verification:
   ``` ruby
   Mysql2::Client.new(
     host: 'db.example.com',
@@ -355,8 +354,7 @@ relying on a distro package, the modern floors are:
   point releases and all of 11.8+/12.3+, but *not* with 11.4's earliest point
   releases (11.4.0-11.4.4 bundled Connector/C 3.4.2, which enforces
   `verify_identity` but can't do `tls_version` -- see the compatibility table
-  below). Check what you actually have rather than assuming from the server's
-  marketing version:
+  below). Check what you actually have:
   ``` ruby
   Mysql2::Client.info[:version]                        # linked client library version
   Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION        # :native, :callback, or nil (unenforceable)
@@ -365,10 +363,9 @@ relying on a distro package, the modern floors are:
 
 #### Version compatibility
 
-Only current, supported versions are listed here. If you're on something
-older than every row below, `ssl_mode`/`tls_*` behavior for it is still in
-the code and specs, but isn't covered in this README -- upgrading is the
-recommended path rather than working around it.
+Only current, supported versions are listed. Older combinations still work
+in the code and specs but aren't documented here -- upgrade rather than
+work around them.
 
 | Client library | `ssl_mode` values | `verify_identity` | `tls_version` | `tls_peer_fingerprint` | `tls_passphrase` | `tls_sni_name` |
 | --- | --- | --- | --- | --- | --- | --- |
@@ -377,11 +374,10 @@ recommended path rather than working around it.
 | MariaDB Connector/C 3.4.0 -- 3.4.2 | 4 of 5, no `:preferred` | ✅ via mysql2's callback | ❌ raises | ✅ | ✅ | ❌ never |
 | MariaDB Connector/C 3.4.3+ | 4 of 5, no `:preferred` | ✅ via mysql2's callback | ✅ | ✅ | ✅ | ❌ never |
 
-`:preferred` doesn't exist on MariaDB at any version -- MariaDB Connector/C
-never defines `MYSQL_OPT_SSL_MODE` at all; mysql2 maps `:ssl_mode`'s other
-four values onto MariaDB's own `MYSQL_OPT_SSL_ENFORCE` /
-`MYSQL_OPT_SSL_VERIFY_SERVER_CERT` options instead (see the table further
-below). `tls_sni_name` never works on any MariaDB Connector/C version.
+`:preferred` is missing from every MariaDB row above because MariaDB
+Connector/C never defines `MYSQL_OPT_SSL_MODE` at all -- mysql2 maps
+`:ssl_mode`'s other four values onto `MYSQL_OPT_SSL_ENFORCE` /
+`MYSQL_OPT_SSL_VERIFY_SERVER_CERT` instead (see the table further below).
 
 ``` ruby
 Mysql2::Client.new(

--- a/README.md
+++ b/README.md
@@ -327,7 +327,7 @@ Mysql2::Client.new(
 Whether this actually gets you both depends entirely on **your application's
 own client library** -- not the database server's version, and not even your
 distro's marketing version number. Server and client library versions move
-independently. Two very common base images make this concrete:
+independently. A very common base image makes this concrete:
 
 * **Ubuntu 24.04 LTS** (`ubuntu:24.04`) -- `apt-get install libmariadb-dev` /
   `mariadb-server` installs MariaDB 10.11.13, bundling **MariaDB Connector/C
@@ -341,14 +341,6 @@ independently. Two very common base images make this concrete:
     ssl_mode: :verify_ca,   # chain verified; hostname is NOT checked on this build
   )
   ```
-  To get real hostname verification and `tls_version` on Ubuntu 24.04, add
-  MariaDB's own package repository (not Ubuntu's) and install from that
-  instead -- see
-  [MariaDB's package repository setup guide](https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage).
-* **Ubuntu 26.04 LTS** (`ubuntu:26.04`) -- ships MariaDB 11.8.6, bundling
-  **MariaDB Connector/C 3.4.9**. The first `ssl_mode: :verify_identity` /
-  `tls_version: 'TLSv1.3'` example above works out of the box, no extra repo
-  needed.
 
 If you're building or installing a client library directly rather than
 relying on a distro package, the modern floors are:

--- a/README.md
+++ b/README.md
@@ -454,6 +454,20 @@ connections and on client libraries without the introspection API
 | `TLS_VERIFY_UNKNOWN`      | Verification failed for an unspecified reason.
 | `TLS_VERIFY_ERROR`        | mysql2's own hostname-verification refusal -- forced so the connector's local-peer leniency (which would otherwise accept a self-signed certificate with no CA configured) can't complete the connection anyway.
 
+`Client#tls_info` is `nil` on MySQL (libmysqlclient has no C-level introspection
+API), but the server's session status variables are visible to any client
+library, so a query works everywhere `tls_info` doesn't:
+
+``` ruby
+client.query("SHOW SESSION STATUS LIKE 'Ssl_%'").each { |row| p row }
+# Ssl_cipher, Ssl_version, etc. -- empty values mean the connection isn't encrypted
+```
+
+See MySQL's
+[Monitoring Current Client Session TLS Protocol and Cipher](https://dev.mysql.com/doc/refman/en/encrypted-connection-protocols-ciphers.html#encrypted-connection-protocol-monitoring)
+and MariaDB's
+[Verifying that a Connection is Using TLS](https://mariadb.com/docs/server/security/encryption/data-in-transit-encryption/securing-connections-for-client-and-server#verifying-that-a-connection-is-using-tls).
+
 ### Secure auth
 
 Starting with MySQL 5.6.5, secure_auth is enabled by default on servers (it was disabled by default prior to this).

--- a/README.md
+++ b/README.md
@@ -341,19 +341,19 @@ concrete:
 If you're building or installing a client library directly rather than
 relying on a distro package, the modern floors are:
 
-* **MySQL 5.7.11+ / MySQL 8.0+** (any current MySQL 8.0 LTS / 8.4 LTS / 9.x
-  point release -- via the
-  [MySQL APT repository](https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/)
-  or equivalent).
-* **MariaDB Connector/C 3.4.3+**, installed from
-  [MariaDB's own package repository](https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)
-  rather than your distro's archive. This ships with MariaDB 11.4.5+ /
-  11.8+ / 12.3+. Check what you actually have:
-  ``` ruby
-  Mysql2::Client.info[:version]                        # linked client library version
-  Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION        # :native, :callback, or nil (unenforceable)
-  Mysql2::Client::TLS_VERSION_SUPPORTED                 # true/false
-  ```
+* **MySQL 5.7.11+ / 8.0+** -- via the
+  [MySQL APT repository](https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/).
+* **MariaDB Connector/C 3.4.3+** -- via
+  [MariaDB's own package repository](https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage),
+  bundled with MariaDB 11.4.5+ / 11.8+ / 12.3+.
+
+Check what you actually have:
+
+``` ruby
+Mysql2::Client.info[:version]                        # linked client library version
+Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION        # :native, :callback, or nil (unenforceable)
+Mysql2::Client::TLS_VERSION_SUPPORTED                 # true/false
+```
 
 #### Version compatibility
 

--- a/README.md
+++ b/README.md
@@ -340,12 +340,8 @@ Modern recommended MySQL/MariaDB versions are:
   [MariaDB repository](https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage).
 
 Clients and servers can mix vendors, since both speak the same MySQL wire
-protocol. This project's CI verifies a MariaDB Connector/C client connecting
-over TLS to a MySQL server (e.g. an app whose base image ships
-`libmariadb-dev` talking to a managed MySQL server such as RDS); the reverse
-direction (a MySQL client against a MariaDB server) isn't separately tested
-here but is expected to behave the same way, since TLS verification happens
-entirely client-side.
+protocol and TLS wire protocol. Several common combinations are in the
+project CI matrix.
 
 #### SSL/TLS options
 

--- a/README.md
+++ b/README.md
@@ -303,152 +303,113 @@ type of connection to make, with special interpretation you should be aware of:
 * An IPv4 or IPv6 address will result in a TCP connection.
 * Any other value will be looked up as a hostname for a TCP connection.
 
-### SSL/TLS options
+### Secure connections with SSL/TLS
 
-Setting any of the following options will enable an SSL/TLS connection, but
-only if your MySQL client library and server have been compiled with SSL
-support. MySQL client library defaults will be used for any parameters that are
-left out or set to nil. Relative paths are allowed, and may be required by
-managed hosting providers such as Heroku.
+The mysql2 gem can configure the underlying MySQL/MariaDB client library to
+connect to the database server using a secure SSL/TLS connection. Setting
+any `:tls_*` option enables a secure connection, and setting a crucial
+combination of flags is needed to enforce and validate the secure connection.
+
+There are important differences in SSL/TLS support between MySQL and MariaDB
+versions, and the client library must be compiled with SSL/TLS enabled.
+Depending on your distribution or local build options, it may be linked with
+OpenSSL 1.x, OpenSSL 3.x, GnuTLS, WolfSSL, or Schannel implementations.
+
+For more information about SSL/TLS in MariaDB, see
+[https://mariadb.com/kb/en/securing-connections-for-client-and-server/](https://mariadb.com/kb/en/securing-connections-for-client-and-server/)
+and [https://mariadb.com/kb/en/mysql_optionsv/#tls-options](https://mariadb.com/kb/en/mysql_optionsv/#tls-options)
 
 #### Modern best practices
 
-A fully-verified connection (certificate chain **and** hostname checked) on
-exactly TLS 1.3 needs two options together:
+A TLS connection with fully-verified certificate chain, hostname matching the
+certificate, and modern TLS v1.2 or v1.3:
 
 ``` ruby
 Mysql2::Client.new(
   host: 'db.example.com',
-  ssl_mode: :verify_identity,
-  tls_version: 'TLSv1.3',
+  tls_mode: :verify_identity,
+  tls_version: 'TLSv1.2,TLSv1.3',
 )
 ```
 
-This depends on **your application's client library version**, not the
-server's -- they move independently. A very common base image makes this
-concrete:
+Modern recommended MySQL/MariaDB versions are:
 
-* **Ubuntu 24.04 LTS** (`ubuntu:24.04`) -- `apt-get install libmariadb-dev` /
-  `mariadb-server` installs MariaDB 10.11.13, bundling **MariaDB Connector/C
-  3.3.16**. The strongest option out of the box is CA-only verification:
-  ``` ruby
-  Mysql2::Client.new(
-    host: 'db.example.com',
-    ssl_mode: :verify_ca,   # chain verified; hostname is NOT checked on this build
-  )
-  ```
+* **MySQL 5.7.11+ / 8.0+ LTS / 8.4+ LTS / 9.7+ LTS**: use the
+  [MySQL repository](https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/).
+* **MariaDB Connector/C 3.4.3+** bundled with MariaDB 11.4.5+ LTS / 11.8+ LTS / 12.3+ LTS: use the
+  [MariaDB repository](https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage).
 
-If you're building or installing a client library directly rather than
-relying on a distro package, the modern floors are:
+In general, MariaDB clients can connect to MySQL servers and vice-versa,
+and this remains true of the SSL/TLS connections.
 
-* **MySQL 5.7.11+ / 8.0+** -- via the
-  [MySQL APT repository](https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/).
-* **MariaDB Connector/C 3.4.3+** -- via
-  [MariaDB's own package repository](https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage),
-  bundled with MariaDB 11.4.5+ / 11.8+ / 12.3+.
+#### SSL/TLS options
 
-Check what you actually have:
+| Option                  | Deprecated Alias | Default | Purpose
+| ---                     | ---              | ---     | ---
+| `:tls_ca`               | `:sslca`         | None    | /path/to/ca-cert.pem
+| `:tls_capath`           | `:sslcapath`     | System dependent | /path/to/cacerts
+| `:tls_cert`             | `:sslcert`       | None    | /path/to/client-cert.pem
+| `:tls_key`              | `:sslkey`        | None    | /path/to/client-key.pem
+| `:tls_version`          |                  | Varies  | Set the allowed TLS versions, comma separated: TLSv1.1, TLSv1.2, TLSv1.3, etc. All versions of SSL, TLSv1.0, and TLSv1.1 are deprecated globally since mid-2010s, and gradually becoming unavailable in the 2020s.
+| `:tls_cipher`           |                  | Typically any TLS-compatible cipher suite | Set the allowed TLS ciphers in priority order, colon separated: 'DHE-RSA-AES256-SHA:DHE-RSA-AES256-CCM:!AES128-SHA', etc. Note some ciphers are only availble in some TLS versions. Impossible combinations will result in connection failures. See https://dev.mysql.com/doc/refman/en/encrypted-connection-protocols-ciphers.html and https://github.com/openssl/openssl/wiki/TLS1.3#ciphersuites
+|                         | `:sslverify`     | `false`     | _Deprecated._ Boolean. `true` is equivalent to `:ssl_mode => :verify_identity`.
+| `:tls_mode`             | `:ssl_mode`      | `:preferred` | _Replacement for `:sslverify`._ One of :disabled, :preferred, etc. Note that `:preferred` performs no enforcement and will silently fall back to a plaintext connection.
+| `:tls_sni_name`         |                  | None        | Hostname sent during TLS handshake, e.g. `'db.example.com'`. Supported by some proxies that route by hostname. Requires MySQL client library 8.1+; unsupported by MariaDB Connector/C.
+| `:tls_passphrase`       |                  | None        | Passphrase if the `:tls_key` file is password-protected. Only supported by MariaDB Connector/C.
+| `:tls_peer_fingerprint` |                  | None        | Server certificate fingerprint in lieu of CA validation.
+| `:tls_peer_fingerprint_list` |             | None        | '/path/to/fingerprints'
 
-``` ruby
-Mysql2::Client.info[:version]                        # linked client library version
-Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION        # :native, :callback, or nil (unenforceable)
-Mysql2::Client::TLS_VERSION_SUPPORTED                 # true/false
-```
+Notes:
+- Options will be referred to by the modern `:tls_` prefixes going forward.
+- Relative paths are allowed, and may be required by managed hosting providers such as Heroku.
+- Defaults are typical, but may be different based on MySQL/MariaDB client library or SSL/TLS library build options.
+
 
 #### Version compatibility
 
-Only current, supported versions are listed. Older combinations still work
-in the code and specs but aren't documented here -- upgrade rather than
-work around them. ❌ means the option raises `Mysql2::Error` rather than
-being silently ignored.
-
-| Client library | `ssl_mode` values | `verify_identity` | `tls_version` | `tls_peer_fingerprint` | `tls_passphrase` | `tls_sni_name` |
+| Client library | `:tls_mode` values | `:verify_identity` | `:tls_version` | `:tls_peer_fingerprint` | `:tls_passphrase` | `:tls_sni_name` |
 | --- | --- | --- | --- | --- | --- | --- |
 | MySQL 5.7.11 -- 8.0.x | all 5, incl. `:preferred` | ✅ native | ✅ | ❌ | ❌ | ❌ |
 | MySQL 8.1+ / 8.4 LTS / 9.x | all 5, incl. `:preferred` | ✅ native | ✅ | ❌ | ❌ | ✅ |
 | MariaDB Connector/C 3.3.x | 3 of 5 (`:disabled`/`:required`/`:verify_ca`) | ❌ | ❌ | ❌ | ✅ | ❌ |
 | MariaDB Connector/C 3.4.3+ | 4 of 5, no `:preferred` | ✅ via mysql2's callback | ✅ | ✅ | ✅ | ❌ |
 
-#### Verification levels
+✅ means the option is supported with this client library.
+❌ means the option will raise `Mysql2::Error` with this client library..
 
-`:ssl_mode` is native on MySQL 5.7.11+
-([full option reference](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-mode)).
-What each value actually checks:
+Runtime client library and TLS feature introspection:
 
-| `:ssl_mode`        | MySQL client behavior              | MariaDB client behavior            |
+``` ruby
+Mysql2::Client.info[:version]                   # linked client library version
+Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION  # :native (MySQL), :callback (MariaDB 3.4.3+), or nil (unenforceable)
+Mysql2::Client::TLS_VERSION_SUPPORTED           # true/false
+Mysql2::Client::TLS_SNI_SUPPORTED               # true/false
+```
+
+#### TLS verification modes
+
+| `:tls_mode`        | MySQL client behavior               | MariaDB client behavior             |
 | ---                | ---                                 | ---                                 |
 | `:disabled`        | no TLS                              | no TLS                              |
-| `:preferred`       | TLS if available, else plaintext    | not supported                       |
-| `:required`        | TLS required, no verification       | TLS required, no verification       |
-| `:verify_ca`       | TLS required, CA chain verified     | TLS required, CA chain verified -- hostname is NOT checked, even for local peers |
+| `:preferred`       | TLS if available, else quiet fallback to plaintext    | not supported                       |
+| `:required`        | TLS required, no certificate verification | TLS required, no certificate verification    |
+| `:verify_ca`       | TLS required, CA chain verified           | TLS required, CA chain verified -- hostname is NOT checked, even for local peers |
 | `:verify_identity` | TLS required, CA chain + hostname verified natively | TLS required, CA chain + hostname verified via mysql2's own verification callback (Connector/C 3.4+) |
 
-Two things worth knowing:
-
-* With `:sslca`/`:sslcapath` left unset, the TLS backend resolves its
-  default trust store natively (OpenSSL's default verify paths,
-  `SSL_CERT_FILE`/`SSL_CERT_DIR`, or the platform certificate store) --
-  publicly-CA-signed servers verify with no CA option passed. Under
-  `:verify_identity`, an unverifiable chain is refused at connect time.
-* If the mysql2 build cannot enforce the hostname check (MariaDB
-  Connector/C older than 3.4, or no OpenSSL headers at build time),
-  `ssl_mode: :verify_identity` raises instead of connecting.
-  `Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION` reports the mechanism
-  in effect: `:native` (libmysqlclient), `:callback` (MariaDB + mysql2's
-  verification callback), or `nil` (unenforceable).
-
-`:sslverify => true` is deprecated, equivalent to `ssl_mode: :verify_identity`.
-An explicit `:ssl_mode` takes precedence over `:sslverify`; however,
-conflicting values, e.g. `:sslverify => false` alongside
-`:ssl_mode => :verify_ca`, raise an exception, as the two would otherwise
-contradict each other.
-
-For more information about SSL/TLS in MariaDB, see
-[https://mariadb.com/kb/en/securing-connections-for-client-and-server/](https://mariadb.com/kb/en/securing-connections-for-client-and-server/)
-and [https://mariadb.com/kb/en/mysql_optionsv/#tls-options](https://mariadb.com/kb/en/mysql_optionsv/#tls-options)
-
-#### Client keys, certificates, and CAs
-
-``` ruby
-Mysql2::Client.new(
-  # ...options as above...,
-  :tls_key => '/path/to/client-key.pem',
-  :tls_cert => '/path/to/client-cert.pem',
-  :tls_ca => '/path/to/ca-cert.pem',
-  :tls_capath => '/path/to/cacerts',
-  :tls_cipher => 'DHE-RSA-AES256-SHA',
-  )
-```
-
-`:tls_key`/`:tls_cert`/`:tls_ca`/`:tls_capath`/`:tls_cipher` are the
-recommended names; `:sslkey`/`:sslcert`/`:sslca`/`:sslcapath`/`:sslcipher`
-remain supported as aliases so existing code keeps working. If both a
-`:tls_*` option and its legacy `:ssl*` alias are given with different
-values, `:tls_*` wins. This mirrors MariaDB Connector/C itself, which
-registers both an `ssl-*` and a `tls-*` name for the equivalent
-`mysql_options()` settings in its own config-file parser (see
-[`mariadb_lib.c`](https://github.com/mariadb-corporation/mariadb-connector-c/blob/master/libmariadb/mariadb_lib.c),
-e.g. `ssl-key`/`tls-key`). MySQL's own `mysql_options()` doesn't carry the
-same `ssl-key`/`tls-key`-style rename for these particular options --
-`--tls-version` and `--tls-ciphersuites` are its only `tls-`-prefixed
-options, and both are new capabilities that never had an `ssl-` name to
-begin with (see
-[https://dev.mysql.com/doc/c-api/8.0/en/mysql-options.html](https://dev.mysql.com/doc/c-api/8.0/en/mysql-options.html))
--- but it's the same underlying direction: `tls-` is the modern prefix
-for TLS configuration on both client libraries, and mysql2 follows it.
-
-If your `:sslkey`/`:tls_key` file is encrypted, supply the passphrase to
-decrypt it (MariaDB Connector/C only -- MySQL's client library has no
-equivalent option, and mysql2 raises rather than connecting with an
-unusable key):
-
-``` ruby
-Mysql2::Client.new(
-  # ...options as above...,
-  :tls_key => '/path/to/encrypted-client-key.pem',
-  :tls_passphrase => 'the passphrase the key was encrypted with',
-  )
-```
+Notes:
+- With `:tls_ca`/`:tls_capath` unset, the TLS backend resolves its
+  default trust store natively, i.e. using OpenSSL's default verify paths,
+  environment variables `SSL_CERT_FILE`/`SSL_CERT_DIR`, or the platform certificate store.
+- With `:verify_ca` or `:verify_identity`, an unverifiable certificate chain is
+  refused at connect time and an exception is raised, `Mysql2::Error::ConnectionError`.
+- With `:verify_identity`, the hostname must also match the certificate subjectAltName,
+  otherwise the connection is refused and an exception is raised, `Mysql2::Error::ConnectionError`.
+- With `:verify_identity`, if the mysql2 gem is built against a client library
+  that does not support hostname verification, an exception is raised without
+  even attempting the connection. This situation will be noted in the message.
+  Either upgrade the client library, or downgrade the connection to `:verify_ca`
+  and accept some risk of hostname uncertainty. Relying on the CA certificate
+  validation only may be acceptable in your use case at your judgment.
 
 #### Certificate fingerprint pinning
 
@@ -481,17 +442,6 @@ for this connection (`:identity_verified`). It returns `nil` for non-TLS
 connections and on client libraries without the introspection API
 (libmysqlclient, MariaDB Connector/C before 3.4).
 
-#### Restricting TLS protocol versions
-
-* `:tls_version => 'TLSv1.2,TLSv1.3'` -- comma-separated list of TLS versions
-  the client will negotiate.
-
-#### TLS Server Name Indication (SNI)
-
-* `:tls_sni_name => 'db.example.com'` -- SNI hostname sent during the TLS
-  handshake, e.g. when connecting through a proxy that routes by hostname.
-  Requires MySQL client library 8.1+; unsupported on MariaDB.
-
 ### Secure auth
 
 Starting with MySQL 5.6.5, secure_auth is enabled by default on servers (it was disabled by default prior to this).
@@ -515,7 +465,7 @@ Debian and its derivatives ship a GnuTLS-linked `mariadb-connector-c` by
 default.
 
 Suggested alternatives:
-* Connect over TLS: `:ssl_mode => :required`.
+* Connect over TLS: `:tls_mode => :required`.
 * Connect over a Unix socket instead of TCP: `:socket => '/path/to/mysql.sock'`.
 * Change the server account's authentication plugin, e.g. to
   `mysql_native_password`, if TLS isn't an option. Understand the security
@@ -669,7 +619,7 @@ By default (`automatic_close` is `true`), a `Client` garbage collected in a proc
 Mysql2::Client.new(:automatic_close => false)
 ```
 
-`automatic_close = false` only keeps a **plaintext** connection alive across `fork()`. `fork()` duplicates a TLS connection's OpenSSL session state into two independent copies, and the first real query from either side desyncs the other's: `Aborted_clients` increments on the server, and the stale side sees `Mysql2::Error::ConnectionError: Lost connection to MySQL server during query`. Connect with `:ssl_mode => :disabled` if your application depends on sharing a connection across `fork()`.
+`automatic_close = false` only keeps a **plaintext** connection alive across `fork()`. `fork()` duplicates a TLS connection's OpenSSL session state into two independent copies, and the first real query from either side desyncs the other's: `Aborted_clients` increments on the server, and the stale side sees `Mysql2::Error::ConnectionError: Lost connection to MySQL server during query`. Connect with `:tls_mode => :disabled` if your application depends on sharing a connection across `fork()`.
 
 ## Cascading config
 

--- a/README.md
+++ b/README.md
@@ -407,10 +407,7 @@ begin with (see
 -- but it's the same underlying direction: `tls-` is the modern prefix
 for TLS configuration on both client libraries, and mysql2 follows it.
 
-`:sslverify` is deprecated in favor of `:ssl_mode`, which has more nuanced
-values available (see below) -- it's intentionally not renamed to a `:tls_*`
-name, since it isn't a plain rename of an existing option the way the five
-above are.
+`:sslverify` is deprecated in favor of `:ssl_mode`.
 
 If your `:sslkey`/`:tls_key` file is encrypted, supply the passphrase to
 decrypt it (MariaDB Connector/C only -- MySQL's client library has no
@@ -461,8 +458,8 @@ Two things worth knowing:
   verification callback), or `nil` (unenforceable).
 
 `:sslverify => true` is equivalent to `ssl_mode: :verify_identity`.
-`:sslverify` is deprecated in favor of `:ssl_mode`, which has more nuanced
-values available. An explicit `:ssl_mode` takes precedence over `:sslverify`,
+`:sslverify` is deprecated in favor of `:ssl_mode`. An explicit `:ssl_mode`
+takes precedence over `:sslverify`,
 however conflicting values, e.g. `:sslverify => false` alongside
 `:ssl_mode => :verify_ca` raises an exception, as the two
 would otherwise contradict each other.

--- a/README.md
+++ b/README.md
@@ -330,10 +330,7 @@ concrete:
 
 * **Ubuntu 24.04 LTS** (`ubuntu:24.04`) -- `apt-get install libmariadb-dev` /
   `mariadb-server` installs MariaDB 10.11.13, bundling **MariaDB Connector/C
-  3.3.16** -- below the 3.4 floor mysql2 needs for `verify_identity`
-  (raises rather than skip the hostname check silently, #879) or
-  `tls_version` (also raises). The strongest option out of the box is
-  CA-only verification:
+  3.3.16**. The strongest option out of the box is CA-only verification:
   ``` ruby
   Mysql2::Client.new(
     host: 'db.example.com',

--- a/README.md
+++ b/README.md
@@ -423,25 +423,16 @@ Mysql2::Client.new(
 ```
 
 `:ssl_mode` is native on MySQL 5.7.11+
-([full option reference](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-mode));
-on MariaDB it maps onto these options instead:
+([full option reference](https://dev.mysql.com/doc/refman/8.0/en/connection-options.html#option_general_ssl-mode)).
+What each value actually checks:
 
-| `:ssl_mode`        | MariaDB option value                                |
-| ---                | ---                                                 |
-| `:disabled`        | MYSQL_OPT_SSL_ENFORCE = 0                           |
-| `:preferred`       | not available -- MariaDB Connector/C never defines MYSQL_OPT_SSL_MODE |
-| `:required`        | MYSQL_OPT_SSL_ENFORCE = 1                           |
-| `:verify_ca`       | MYSQL_OPT_SSL_VERIFY_SERVER_CERT = 1                |
-| `:verify_identity` | MYSQL_OPT_SSL_VERIFY_SERVER_CERT = 1 + mysql2's own hostname verification |
-
-MYSQL_OPT_SSL_VERIFY_SERVER_CERT verifies the CA at most: despite its
-MySQL-derived name, MariaDB Connector/C decides whether to check the
-hostname from the peer address, and never checks it for peers it considers
-local (127.0.0.1, ::1, or socket connections). mysql2 enforces
-`:verify_identity` on MariaDB itself, by registering a TLS
-verification callback (MariaDB Connector/C 3.4+) that verifies the
-certificate chain and the hostname (SAN, wildcard, and IP-address matching
-via OpenSSL) on every connection, local peers included.
+| `:ssl_mode`        | MySQL client behavior              | MariaDB client behavior            |
+| ---                | ---                                 | ---                                 |
+| `:disabled`        | no TLS                              | no TLS                              |
+| `:preferred`       | TLS if available, else plaintext    | not supported                       |
+| `:required`        | TLS required, no verification       | TLS required, no verification       |
+| `:verify_ca`       | TLS required, CA chain verified     | TLS required, CA chain verified -- hostname is NOT checked, even for local peers |
+| `:verify_identity` | TLS required, CA chain + hostname verified natively | TLS required, CA chain + hostname verified via mysql2's own verification callback (Connector/C 3.4+) |
 
 Two things worth knowing:
 

--- a/README.md
+++ b/README.md
@@ -345,12 +345,10 @@ relying on a distro package, the modern floors are:
   point release -- via the
   [MySQL APT repository](https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/)
   or equivalent).
-* **MariaDB Connector/C 3.4.3 or later**, installed from
+* **MariaDB Connector/C 3.4.3+**, installed from
   [MariaDB's own package repository](https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)
-  rather than your distro's archive. This ships with recent MariaDB 11.4 LTS
-  point releases and all of 11.8+/12.3+, but *not* with 11.4's earliest point
-  releases (11.4.0-11.4.4 bundled Connector/C 3.4.2, which enforces
-  `verify_identity` but can't do `tls_version`). Check what you actually have:
+  rather than your distro's archive. This ships with MariaDB 11.4.5+ /
+  11.8+ / 12.3+. Check what you actually have:
   ``` ruby
   Mysql2::Client.info[:version]                        # linked client library version
   Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION        # :native, :callback, or nil (unenforceable)

--- a/README.md
+++ b/README.md
@@ -370,7 +370,7 @@ work around them.
 | Client library | `ssl_mode` values | `verify_identity` | `tls_version` | `tls_peer_fingerprint` | `tls_passphrase` | `tls_sni_name` |
 | --- | --- | --- | --- | --- | --- | --- |
 | MySQL 5.7.11 -- 8.0.x | all 5, incl. `:preferred` | ✅ native | ✅ | ❌ | ❌ | ❌ |
-| MySQL 8.1+ / 8.4 LTS / 9.x | all 5, incl. `:preferred` | ✅ native | ✅ | ❌ | ❌ | ✅ (8.1+) |
+| MySQL 8.1+ / 8.4 LTS / 9.x | all 5, incl. `:preferred` | ✅ native | ✅ | ❌ | ❌ | ✅ |
 | MariaDB Connector/C 3.4.0 -- 3.4.2 | 4 of 5, no `:preferred` | ✅ via mysql2's callback | ❌ raises | ✅ | ✅ | ❌ never |
 | MariaDB Connector/C 3.4.3+ | 4 of 5, no `:preferred` | ✅ via mysql2's callback | ✅ | ✅ | ✅ | ❌ never |
 

--- a/README.md
+++ b/README.md
@@ -307,8 +307,8 @@ type of connection to make, with special interpretation you should be aware of:
 
 The mysql2 gem can configure the underlying MySQL/MariaDB client library to
 connect to the database server using a secure SSL/TLS connection. Setting
-any `:tls_*` option enables a secure connection, and setting a crucial
-combination of flags is needed to enforce and validate the secure connection.
+any `:tls_*` option enables a secure connection, but `:tls_mode` is the
+option that actually controls whether it's enforced and verified.
 
 There are important differences in SSL/TLS support between MySQL and MariaDB
 versions, and the client library must be compiled with SSL/TLS enabled.
@@ -339,8 +339,13 @@ Modern recommended MySQL/MariaDB versions are:
 * **MariaDB Connector/C 3.4.3+** bundled with MariaDB 11.4.5+ LTS / 11.8+ LTS / 12.3+ LTS: use the
   [MariaDB repository](https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage).
 
-In general, MariaDB clients can connect to MySQL servers and vice-versa,
-and this remains true of the SSL/TLS connections.
+Clients and servers can mix vendors, since both speak the same MySQL wire
+protocol. This project's CI verifies a MariaDB Connector/C client connecting
+over TLS to a MySQL server (e.g. an app whose base image ships
+`libmariadb-dev` talking to a managed MySQL server such as RDS); the reverse
+direction (a MySQL client against a MariaDB server) isn't separately tested
+here but is expected to behave the same way, since TLS verification happens
+entirely client-side.
 
 #### SSL/TLS options
 
@@ -350,32 +355,32 @@ and this remains true of the SSL/TLS connections.
 | `:tls_capath`           | `:sslcapath`     | System dependent | /path/to/cacerts
 | `:tls_cert`             | `:sslcert`       | None    | /path/to/client-cert.pem
 | `:tls_key`              | `:sslkey`        | None    | /path/to/client-key.pem
-| `:tls_version`          |                  | Varies  | Set the allowed TLS versions, comma separated: TLSv1.1, TLSv1.2, TLSv1.3, etc. All versions of SSL, TLSv1.0, and TLSv1.1 are deprecated globally since mid-2010s, and gradually becoming unavailable in the 2020s.
+| `:tls_version`          |                  | Varies  | Set the allowed TLS versions, comma separated: TLSv1.1, TLSv1.2, TLSv1.3, etc. All versions of SSL were deprecated by [RFC 7568](https://www.rfc-editor.org/rfc/rfc7568) (2015); TLSv1.0/TLSv1.1 by [RFC 8996](https://www.rfc-editor.org/rfc/rfc8996) (2021), and are increasingly unavailable.
 | `:tls_cipher`           |                  | Typically any TLS-compatible cipher suite | Set the allowed TLS ciphers in priority order, colon separated: 'DHE-RSA-AES256-SHA:DHE-RSA-AES256-CCM:!AES128-SHA', etc. Note some ciphers are only availble in some TLS versions. Impossible combinations will result in connection failures. See https://dev.mysql.com/doc/refman/en/encrypted-connection-protocols-ciphers.html and https://github.com/openssl/openssl/wiki/TLS1.3#ciphersuites
 |                         | `:sslverify`     | `false`     | _Deprecated._ Boolean. `true` is equivalent to `:ssl_mode => :verify_identity`.
-| `:tls_mode`             | `:ssl_mode`      | `:preferred` | _Replacement for `:sslverify`._ One of :disabled, :preferred, etc. Note that `:preferred` performs no enforcement and will silently fall back to a plaintext connection.
+| `:tls_mode`             | `:ssl_mode`      | `:preferred` | _Replacement for `:sslverify`._ One of `:disabled`, `:preferred`, `:required`, `:verify_ca`, `:verify_identity`. `:preferred` performs no enforcement and silently falls back to a plaintext connection.
 | `:tls_sni_name`         |                  | None        | Hostname sent during TLS handshake, e.g. `'db.example.com'`. Supported by some proxies that route by hostname. Requires MySQL client library 8.1+; unsupported by MariaDB Connector/C.
 | `:tls_passphrase`       |                  | None        | Passphrase if the `:tls_key` file is password-protected. Only supported by MariaDB Connector/C.
-| `:tls_peer_fingerprint` |                  | None        | Server certificate fingerprint in lieu of CA validation.
-| `:tls_peer_fingerprint_list` |             | None        | '/path/to/fingerprints'
+| `:tls_peer_fingerprint` |                  | None        | Server certificate fingerprint in lieu of CA validation. Only supported by MariaDB Connector/C 3.4+.
+| `:tls_peer_fingerprint_list` |             | None        | /path/to/fingerprints. Only supported by MariaDB Connector/C 3.4+.
 
 Notes:
 - Options will be referred to by the modern `:tls_` prefixes going forward.
+- If both a `:tls_*` option and its deprecated alias are given with different values, `:tls_*` wins (a warning is printed).
 - Relative paths are allowed, and may be required by managed hosting providers such as Heroku.
 - Defaults are typical, but may be different based on MySQL/MariaDB client library or SSL/TLS library build options.
-
 
 #### Version compatibility
 
 | Client library | `:tls_mode` values | `:verify_identity` | `:tls_version` | `:tls_peer_fingerprint` | `:tls_passphrase` | `:tls_sni_name` |
 | --- | --- | --- | --- | --- | --- | --- |
-| MySQL 5.7.11 -- 8.0.x | all 5, incl. `:preferred` | ✅ native | ✅ | ❌ | ❌ | ❌ |
-| MySQL 8.1+ / 8.4 LTS / 9.x | all 5, incl. `:preferred` | ✅ native | ✅ | ❌ | ❌ | ✅ |
+| MySQL 5.7.11+ / 8.0.x | all 5, incl. `:preferred` | ✅ native | ✅ | ❌ | ❌ | ❌ |
+| MySQL 8.1+ / 8.4.x LTS / 9.7.x LTS | all 5, incl. `:preferred` | ✅ native | ✅ | ❌ | ❌ | ✅ |
 | MariaDB Connector/C 3.3.x | 3 of 5 (`:disabled`/`:required`/`:verify_ca`) | ❌ | ❌ | ❌ | ✅ | ❌ |
 | MariaDB Connector/C 3.4.3+ | 4 of 5, no `:preferred` | ✅ via mysql2's callback | ✅ | ✅ | ✅ | ❌ |
 
 ✅ means the option is supported with this client library.
-❌ means the option will raise `Mysql2::Error` with this client library..
+❌ means the option will raise `Mysql2::Error` with this client library.
 
 Runtime client library and TLS feature introspection:
 

--- a/README.md
+++ b/README.md
@@ -483,31 +483,14 @@ connections and on client libraries without the introspection API
 
 #### Restricting TLS protocol versions
 
-To restrict which TLS protocol versions the client will negotiate:
-
-``` ruby
-Mysql2::Client.new(
-  # ...options as above...,
-  :tls_version => 'TLSv1.2,TLSv1.3',
-  )
-```
-
-A comma-separated list of TLS versions available on your SSL client library,
-e.g. `'TLSv1.2,TLSv1.3'`.
+* `:tls_version => 'TLSv1.2,TLSv1.3'` -- comma-separated list of TLS versions
+  the client will negotiate.
 
 #### TLS Server Name Indication (SNI)
 
-To set the TLS Server Name Indication (SNI) hostname sent during the TLS
-handshake, e.g. when connecting through a proxy that routes by hostname:
-
-``` ruby
-Mysql2::Client.new(
-  # ...options as above...,
-  :tls_sni_name => 'db.example.com',
-  )
-```
-
-This requires MySQL client library 8.1 or higher; unsupported on MariaDB.
+* `:tls_sni_name => 'db.example.com'` -- SNI hostname sent during the TLS
+  handshake, e.g. when connecting through a proxy that routes by hostname.
+  Requires MySQL client library 8.1+; unsupported on MariaDB.
 
 ### Secure auth
 

--- a/README.md
+++ b/README.md
@@ -345,12 +345,10 @@ independently. A very common base image makes this concrete:
 If you're building or installing a client library directly rather than
 relying on a distro package, the modern floors are:
 
-* **MySQL 8.0.36 or later** (any current MySQL 8.0 LTS / 8.4 LTS / 9.x point
-  release -- via the
+* **MySQL 5.7.11+ / MySQL 8.0+** (any current MySQL 8.0 LTS / 8.4 LTS / 9.x
+  point release -- via the
   [MySQL APT repository](https://dev.mysql.com/doc/mysql-apt-repo-quick-guide/en/)
-  or equivalent). MySQL 5.7.11+ is functionally sufficient for everything in
-  this section too, but MySQL 5.7 itself is long past Oracle's supported
-  end-of-life -- treat 5.7.11+ as "still works," not as a recommendation.
+  or equivalent).
 * **MariaDB Connector/C 3.4.3 or later**, installed from
   [MariaDB's own package repository](https://mariadb.com/docs/server/server-management/install-and-upgrade-mariadb/mariadb-package-repository-setup-and-usage)
   rather than your distro's archive. This ships with recent MariaDB 11.4 LTS

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -1102,6 +1102,25 @@ static VALUE rb_set_tls_peer_fingerprint_list(VALUE self, VALUE path) {
 #endif
 }
 
+/* :tls_passphrase -- decrypts an encrypted :sslkey file (MariaDB
+ * Connector/C only; no MYSQL_OPT_* equivalent). Raises on unsupported
+ * builds rather than silently connecting with an unusable key: without
+ * the passphrase the encrypted key can't be loaded, and the caller would
+ * otherwise see only a low-level, unhelpful decryption error from the TLS
+ * handshake instead of a clear reason. */
+static VALUE rb_set_tls_passphrase(VALUE self, VALUE passphrase) {
+#ifdef HAVE_CONST_MARIADB_OPT_TLS_PASSPHRASE
+  GET_CLIENT(self);
+  mysql_options(wrapper->client, MARIADB_OPT_TLS_PASSPHRASE, StringValueCStr(passphrase));
+  return passphrase;
+#else
+  (void)self; (void)passphrase;
+  rb_raise(cMysql2ConnectionError,
+           ":tls_passphrase requires MariaDB Connector/C; this client library (%s) has no way "
+           "to supply a passphrase for an encrypted :sslkey file", mysql_get_client_info());
+#endif
+}
+
 #ifdef CLIENT_CONNECT_ATTRS
 static int opt_connect_attr_add_i(VALUE key, VALUE value, VALUE arg)
 {
@@ -2839,6 +2858,7 @@ void init_mysql2_client(void) {
   rb_define_private_method(cMysql2Client, "ssl_mode=", rb_set_ssl_mode_option, 1);
   rb_define_private_method(cMysql2Client, "tls_peer_fingerprint=", rb_set_tls_peer_fingerprint, 1);
   rb_define_private_method(cMysql2Client, "tls_peer_fingerprint_list=", rb_set_tls_peer_fingerprint_list, 1);
+  rb_define_private_method(cMysql2Client, "tls_passphrase=", rb_set_tls_passphrase, 1);
   rb_define_private_method(cMysql2Client, "enable_cleartext_plugin=", set_enable_cleartext_plugin, 1);
   rb_define_private_method(cMysql2Client, "tls_version=", set_tls_version, 1);
   rb_define_private_method(cMysql2Client, "initialize_ext", initialize_ext, 0);
@@ -3075,6 +3095,12 @@ void init_mysql2_client(void) {
   rb_const_set(cMysql2Client, rb_intern("TLS_PEER_FINGERPRINT_SUPPORTED"), Qtrue);
 #else
   rb_const_set(cMysql2Client, rb_intern("TLS_PEER_FINGERPRINT_SUPPORTED"), Qfalse);
+#endif
+
+#ifdef HAVE_CONST_MARIADB_OPT_TLS_PASSPHRASE
+  rb_const_set(cMysql2Client, rb_intern("TLS_PASSPHRASE_SUPPORTED"), Qtrue);
+#else
+  rb_const_set(cMysql2Client, rb_intern("TLS_PASSPHRASE_SUPPORTED"), Qfalse);
 #endif
 
   /* The MARIADB_TLS_VERIFY_* bits reported by Client#tls_info's

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -225,6 +225,11 @@ if have_sha2_fingerprint_verification
   have_const('MARIADB_OPT_TLS_PEER_FP_LIST', mysql_h)
 end
 
+# Passphrase for an encrypted :sslkey file (:tls_passphrase). Present in
+# MariaDB Connector/C since at least 3.1 -- unlike fingerprint pinning
+# above, no version-dependent behavior change to gate on.
+have_const('MARIADB_OPT_TLS_PASSPHRASE', mysql_h)
+
 # The ssl_mode: :verify_identity enforcement callback (#879). Everything it
 # needs, or :verify_identity refuses to connect on MariaDB rather than
 # silently skipping hostname verification:

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -19,6 +19,22 @@ module Mysql2
       }
     end
 
+    # :tls_key/:tls_cert/:tls_ca/:tls_capath/:tls_cipher are the modern names
+    # for :sslkey/:sslcert/:sslca/:sslcapath/:sslcipher. MariaDB Connector/C
+    # registers both spellings for its own equivalent option-file settings
+    # (ssl-key and tls-key, ssl-passphrase and tls-passphrase, etc.); mysql2
+    # follows the same pattern here. If both spellings are given, the newer
+    # :tls_* name wins -- the same precedence an explicit :ssl_mode already
+    # has over :sslverify.
+    TLS_OPTION_ALIASES = {
+      tls_key: :sslkey,
+      tls_cert: :sslcert,
+      tls_ca: :sslca,
+      tls_capath: :sslcapath,
+      tls_cipher: :sslcipher,
+    }.freeze
+    private_constant :TLS_OPTION_ALIASES
+
     def initialize(opts = {})
       raise Mysql2::Error, "Options parameter must be a Hash" unless opts.is_a? Hash
 
@@ -26,6 +42,8 @@ module Mysql2
       @read_timeout = nil
       @query_options = self.class.default_query_options.dup
       @query_options.merge! opts
+
+      apply_tls_option_aliases(opts)
 
       initialize_ext
 
@@ -156,6 +174,10 @@ module Mysql2
         end
       end
 
+      # Unlocks an encrypted :sslkey file -- unrelated to the verification
+      # models below, so set unconditionally rather than gated on them.
+      self.tls_passphrase = opts[:tls_passphrase].to_s if opts[:tls_passphrase]
+
       return mode unless opts[:tls_peer_fingerprint] || opts[:tls_peer_fingerprint_list]
 
       # Fingerprint pinning and CA/hostname verification are alternative
@@ -225,6 +247,10 @@ module Mysql2
 
     private
 
+    def apply_tls_option_aliases(opts)
+      TLS_OPTION_ALIASES.each { |tls_key, legacy_key| opts[legacy_key] = opts[tls_key] if opts.key?(tls_key) }
+    end
+
     # Warns once per client, before connecting, about option combinations
     # that are incoherent or silently ignored. Warnings only: the connection
     # proceeds exactly as it would have without them.
@@ -232,10 +258,23 @@ module Mysql2
       # The client key and certificate only take effect together. Given one
       # without the other, libmysqlclient silently sends no client certificate
       # and MariaDB Connector/C aborts the connection with a bare TLS error
-      # that never names the real problem.
+      # that never names the real problem. Either option may be given under
+      # its legacy :ssl* name or its :tls_* alias.
       # https://dev.mysql.com/doc/refman/en/using-encrypted-connections.html
+      effective_key = @query_options[:tls_key] || @query_options[:sslkey]
+      effective_cert = @query_options[:tls_cert] || @query_options[:sslcert]
       warn ":sslkey and :sslcert only take effect together; alone, libmysqlclient sends no client certificate and MariaDB Connector/C fails to connect" \
-        if @query_options[:sslkey].nil? != @query_options[:sslcert].nil?
+        if effective_key.nil? != effective_cert.nil?
+
+      # If a legacy :ssl* option and its :tls_* alias are both given with
+      # different values, the :tls_* value silently wins (see
+      # TLS_OPTION_ALIASES); warn so the conflict isn't invisible.
+      TLS_OPTION_ALIASES.each do |tls_key, legacy_key|
+        next unless @query_options.key?(tls_key) && @query_options.key?(legacy_key)
+        next if @query_options[tls_key] == @query_options[legacy_key]
+
+        warn ":#{legacy_key} and :#{tls_key} were both given with different values; :#{tls_key} wins"
+      end
 
       # Streaming results are never cached, so a client-wide :stream default
       # overrides the :cache_rows default on every query (see the per-query

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -26,12 +26,19 @@ module Mysql2
     # follows the same pattern here. If both spellings are given, the newer
     # :tls_* name wins -- the same precedence an explicit :ssl_mode already
     # has over :sslverify.
+    #
+    # :tls_mode/:ssl_mode is different: neither MySQL nor MariaDB has a
+    # "tls-mode" config-file alias for ssl-mode anywhere -- this one is
+    # mysql2's own invention, purely for :tls_* naming consistency. If
+    # upstream ever adds a real --tls-mode/tlsMode with different
+    # semantics, this alias becomes wrong and will need to be revisited.
     TLS_OPTION_ALIASES = {
       tls_key: :sslkey,
       tls_cert: :sslcert,
       tls_ca: :sslca,
       tls_capath: :sslcapath,
       tls_cipher: :sslcipher,
+      tls_mode: :ssl_mode,
     }.freeze
     private_constant :TLS_OPTION_ALIASES
 

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -440,6 +440,14 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
           expect(client.query('SELECT 1 AS one').first['one']).to eql(1)
         end
       end
+
+      it "connects the same using :tls_mode as with :ssl_mode" do
+        aliased_overrides = option_overrides.merge(tls_mode: :required).reject { |k, _| k == :sslverify }
+
+        new_client(aliased_overrides) do |client|
+          expect(client.query('SELECT 1 AS one').first['one']).to eql(1)
+        end
+      end
     end
   end
 
@@ -500,6 +508,12 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
           # the bogus path never reaches a real handshake; the warning precedes it.
         end
       end.not_to output(/were both given with different values/).to_stderr
+    end
+
+    it "warns when :ssl_mode and its :tls_mode alias are given with different values" do
+      expect do
+        new_client(ssl_mode: :required, tls_mode: :disabled)
+      end.to output(/:ssl_mode and :tls_mode were both given with different values; :tls_mode wins/).to_stderr
     end
   end
 

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -567,6 +567,11 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
 
     it "maps sslverify: true onto ssl_mode: :verify_identity when no ssl_mode is given" do
       skip "this build has no verifying ssl_mode" if Mysql2::Client::SSL_MODE_VERIFY_IDENTITY.zero?
+      # The mapped ssl_mode: :verify_identity goes through the same #879
+      # enforcement as an explicit one -- on a build that can't enforce it
+      # (MariaDB Connector/C older than 3.4), Client.new refuses to connect
+      # rather than silently mapping to a check it can't keep.
+      skip("DON'T WORRY, THIS TEST PASSES - but this client library cannot enforce ssl_mode: :verify_identity.") if Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION.nil?
 
       # Mirrors the "refuses verify_identity outright" predicate above: a
       # MariaDB-family build without the enforcement callback refuses the

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -419,6 +419,22 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
         new_client(option_overrides.merge(tls_version: 'TLSv1.2'))
       end.to raise_error(Mysql2::Error, /tls_version/)
     end
+
+    context "legacy :ssl* / :tls_* option aliasing" do
+      it "connects the same using :tls_key/:tls_cert/:tls_ca as with :sslkey/:sslcert/:sslca" do
+        aliased_overrides = option_overrides
+                            .reject { |k, _| %i[sslkey sslcert sslca].include?(k) }
+                            .merge(
+                              tls_key: option_overrides[:sslkey],
+                              tls_cert: option_overrides[:sslcert],
+                              tls_ca: option_overrides[:sslca],
+                            )
+
+        new_client(aliased_overrides) do |client|
+          expect(client.query('SELECT 1 AS one').first['one']).to eql(1)
+        end
+      end
+    end
   end
 
   context "option coherence warnings" do
@@ -459,6 +475,26 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
         new_client
       end.not_to output(/:sslkey and :sslcert only take effect together|:cache_rows is ignored/).to_stderr
     end
+
+    it "warns when a legacy :ssl* option and its :tls_* alias are given with different values" do
+      expect do
+        begin
+          new_client(sslkey: '/path/to/legacy-key.pem', tls_key: '/path/to/new-key.pem', tls_cert: '/path/to/client-cert.pem')
+        rescue Mysql2::Error
+          # the bogus paths never reach a real handshake; the warning precedes it.
+        end
+      end.to output(/:sslkey and :tls_key were both given with different values; :tls_key wins/).to_stderr
+    end
+
+    it "does not warn when a legacy :ssl* option and its :tls_* alias are given the same value" do
+      expect do
+        begin
+          new_client(sslkey: '/path/to/key.pem', tls_key: '/path/to/key.pem', tls_cert: '/path/to/client-cert.pem')
+        rescue Mysql2::Error
+          # the bogus path never reaches a real handshake; the warning precedes it.
+        end
+      end.not_to output(/were both given with different values/).to_stderr
+    end
   end
 
   context "TLS option validation" do
@@ -484,6 +520,14 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       expect do
         new_client(tls_peer_fingerprint: 'ab' * 32)
       end.to raise_error(Mysql2::Error::ConnectionError, /tls_peer_fingerprint/)
+    end
+
+    it "refuses :tls_passphrase on client libraries that have no way to decrypt an encrypted key" do
+      skip "this build supports :tls_passphrase" if Mysql2::Client::TLS_PASSPHRASE_SUPPORTED
+
+      expect do
+        new_client(tls_passphrase: 'secret')
+      end.to raise_error(Mysql2::Error::ConnectionError, /tls_passphrase/)
     end
 
     it "refuses verify_identity outright when this build cannot enforce hostname verification" do

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -37,8 +37,11 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
   end
 
   it "should connect via TLS" do
-    have_ssl = @client.query("SHOW VARIABLES LIKE 'have_ssl'").first['Value']
-    skip("DON'T WORRY, THIS TEST PASSES - but SSL is not enabled in your MySQL daemon.") unless have_ssl == 'YES'
+    # have_ssl was removed in newer MySQL (SSL is unconditionally compiled
+    # in there); an empty result set means "assume available", matching the
+    # "context SSL" before(:example) hook's own fallback below.
+    ssl_disabled = @client.query("SHOW VARIABLES LIKE 'have_ssl'").any? { |x| %w[OFF DISABLED].include?(x['Value']) }
+    skip("DON'T WORRY, THIS TEST PASSES - but SSL is not enabled in your MySQL daemon.") if ssl_disabled
 
     client = new_client(ssl_mode: 'required')
     expect(client.ssl_cipher).not_to be_empty

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -37,6 +37,9 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
   end
 
   it "should connect via TLS" do
+    have_ssl = @client.query("SHOW VARIABLES LIKE 'have_ssl'").first['Value']
+    skip("DON'T WORRY, THIS TEST PASSES - but SSL is not enabled in your MySQL daemon.") unless have_ssl == 'YES'
+
     client = new_client(ssl_mode: 'required')
     expect(client.ssl_cipher).not_to be_empty
   end

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -573,11 +573,6 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
 
     it "maps sslverify: true onto ssl_mode: :verify_identity when no ssl_mode is given" do
       skip "this build has no verifying ssl_mode" if Mysql2::Client::SSL_MODE_VERIFY_IDENTITY.zero?
-      # The mapped ssl_mode: :verify_identity goes through the same #879
-      # enforcement as an explicit one -- on a build that can't enforce it
-      # (MariaDB Connector/C older than 3.4), Client.new refuses to connect
-      # rather than silently mapping to a check it can't keep.
-      skip("DON'T WORRY, THIS TEST PASSES - but this client library cannot enforce ssl_mode: :verify_identity.") if Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION.nil?
 
       # Mirrors the "refuses verify_identity outright" predicate above: a
       # MariaDB-family build without the enforcement callback refuses the


### PR DESCRIPTION
## Summary

- Adds `:tls_passphrase` to decrypt an encrypted `:sslkey`/`:tls_key` private-key file, via MariaDB Connector/C's `MARIADB_OPT_TLS_PASSPHRASE`. MySQL's client library has no equivalent, so this raises on unsupported builds rather than silently connecting with an unusable key.
- Aliases `:sslkey`, `:sslcert`, `:sslca`, `:sslcapath`, and `:sslcipher` as `:tls_key`, `:tls_cert`, `:tls_ca`, `:tls_capath`, and `:tls_cipher` respectively, and recommends the new names in the README. This matches MariaDB Connector/C's own `mariadb_lib.c` config-file option table, which registers both an `ssl-*` and a `tls-*` name for these same settings (e.g. `ssl-key`/`tls-key`). MySQL's `mysql_options()` doesn't carry the identical rename for these particular options -- its own `tls-` prefix (`--tls-version`, `--tls-ciphersuites`) covers only genuinely new capabilities -- but `tls-` is still the modern TLS-config prefix direction on both client libraries, which this follows.
- `:sslverify` is intentionally left out of the rename since it already maps onto `:ssl_mode` rather than being a plain alias.
- The legacy `:ssl*` names keep working. If both spellings are given, `:tls_*` wins; a coherence warning fires if the two disagree.

Fixes #1480 (the last unchecked item -- `:tls_version` and the fingerprint-pinning options from that issue already landed via #1570 and #1572).

## Test plan

- [x] `bundle exec rake compile` — clean build
- [x] `bundle exec rubocop` — no offenses
- [x] `bundle exec rspec spec/mysql2/client_spec.rb` — 204 examples, 0 failures (24 pending, pre-existing/environment-gated, same as before this change)
- [x] Manual verification: `:tls_passphrase` raises the expected error on a client library without support; `:tls_key`/`:tls_cert` behave identically to `:sslkey`/`:sslcert`; conflicting `:sslkey`/`:tls_key` values warn with `:tls_key` winning; matching values don't warn

🤖 Generated with [Claude Code](https://claude.com/claude-code)