### PR TITLE
Guard the sslverify mapping spec for unenforceable verify_identity builds

### DIFF
--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -524,8 +524,22 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     it "maps sslverify: true onto ssl_mode: :verify_identity when no ssl_mode is given" do
       skip "this build has no verifying ssl_mode" if Mysql2::Client::SSL_MODE_VERIFY_IDENTITY.zero?
 
-      client = Klient.new(sslverify: true)
-      expect(client.connect_args.last[6] & Mysql2::Client::SSL_VERIFY_SERVER_CERT).not_to eql(0)
+      # Mirrors the "refuses verify_identity outright" predicate above: a
+      # MariaDB-family build without the enforcement callback refuses the
+      # mapped :verify_identity at Client.new rather than silently skipping
+      # the hostname check. That refusal is itself proof the mapping
+      # happened -- :sslverify alone never trips verify_identity
+      # enforcement (see "does not refuse sslverify: false" above).
+      version = Mysql2::Client.info[:id]
+      mysql_native_verify = (50703...50711).cover?(version) || (60103...60200).cover?(version)
+      mariadb = version >= 30000 && !mysql_native_verify
+
+      if mariadb && Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION.nil?
+        expect { Klient.new(sslverify: true) }.to raise_error(Mysql2::Error::ConnectionError, /cannot be enforced/)
+      else
+        client = Klient.new(sslverify: true)
+        expect(client.connect_args.last[6] & Mysql2::Client::SSL_VERIFY_SERVER_CERT).not_to eql(0)
+      end
     end
 
     it "lets an explicit ssl_mode win over sslverify: true" do


### PR DESCRIPTION
Master's Build workflow has been red since #1572 merged: runs [32062147833](https://github.com/brianmario/mysql2/actions/runs/32062147833) (3df3179, the #1572 merge commit itself), [32064123836](https://github.com/brianmario/mysql2/actions/runs/32064123836) (9dab159), and [32064696205](https://github.com/brianmario/mysql2/actions/runs/32064696205) (a8b6c4d) all fail the same single spec on the same three legs — ubuntu-22.04 ruby 3.0/mariadb 10.6, ruby 2.7/mariadb 10.11, ruby 3.0/mariadb 10.11:

```
rspec ./spec/mysql2/client_spec.rb:524 # Mysql2::Client TLS option validation
  maps sslverify: true onto ssl_mode: :verify_identity when no ssl_mode is given

Mysql2::Error::ConnectionError:
  ssl_mode: :verify_identity cannot be enforced by this mysql2 build (client library 3.3.19) ...
```

Diagnosed in https://github.com/brianmario/mysql2/pull/1565#issuecomment-5320011812: those legs build against MariaDB Connector/C 3.3.19, where #1570's fail-closed enforcement correctly refuses `:verify_identity` (< 3.4 cannot do hostname verification). The #1572 spec maps `sslverify: true` onto `ssl_mode: :verify_identity`, and that mapped mode trips the refusal in `Client#initialize` — before the spec's stubbed `connect` ever runs. The enforcement is behaving exactly as designed; only the spec lacked the guard its siblings have.

### Fix

Spec-only. Branch on the same enforceability predicate the sibling "refuses verify_identity outright" spec (`client_spec.rb:489`) already computes, mirroring the branch shape of the peer-identity specs around `:269`:

- **Enforceable builds** (`:native` / `:callback`): unchanged — assert the `SSL_VERIFY_SERVER_CERT` connect flag via `Klient#connect_args`.
- **Unenforceable MariaDB-family builds** (`TLS_PEER_IDENTITY_VERIFICATION` nil): assert the `/cannot be enforced/` `ConnectionError` instead of skipping. The refusal is itself proof the mapping happened — `:sslverify` alone never trips verify_identity enforcement (the adjacent `sslverify: false` specs show that) — so the spec's real assertion, *the mapping occurred*, is exercised on every build.

### Verification

Both branches were exercised against real builds locally:

- Built MariaDB Connector/C **3.3.19** from source and compiled the gem against it (`TLS_PEER_IDENTITY_VERIFICATION` = nil, same as the red legs): the pre-fix spec reproduces the CI failure verbatim; the guarded spec passes, as does the full "TLS option validation" context (7 examples, 0 failures).
- Against libmysqlclient 9.6 (`:native`): else branch runs, unchanged assertion passes; context green.
- RuboCop clean.

This unbreaks the three required legs for every open PR — they currently inherit this failure regardless of their own changes.
