### PR TITLE
Match the verify_identity callback's OpenSSL to the client library's (#1575)

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,9 +100,12 @@ If you have not done so already, you will need to install the XCode select tools
 `xcode-select --install`.
 
 Later versions of MacOS no longer distribute a linkable OpenSSL library. It is
-common to use Homebrew or MacPorts to install OpenSSL. Make sure that both the
-Ruby runtime and MySQL client libraries are compiled with the same OpenSSL
-family, 3.x, since only one can be loaded at runtime.
+common to use Homebrew or MacPorts to install OpenSSL. Where mysql2 itself
+needs OpenSSL (the `verify_identity` hostname verification callback on MariaDB
+builds), it automatically links the same OpenSSL the MySQL client library
+links, since the two must be the same build; `--with-openssl-dir` overrides
+that choice, and a mismatched pairing is refused at connect time rather than
+crashing (see issue #1575).
 
 ``` sh
 $ brew install openssl@3 zstd
@@ -387,6 +390,7 @@ Runtime client library and TLS feature introspection:
 |`Mysql2::Client::TLS_PEER_IDENTITY_VERIFICATION` | :native (MySQL), :callback (MariaDB Connector/C 3.4.3+), or nil (unenforceable)
 |`Mysql2::Client::TLS_VERSION_SUPPORTED`          | true/false
 |`Mysql2::Client::TLS_SNI_SUPPORTED`              | true/false
+|`Mysql2::Client::TLS_OPENSSL_LINKAGE_CHECK`      | true/false -- whether the build checks that mysql2 and the client library resolve to the same loaded OpenSSL before enforcing `:verify_identity`
 
 #### TLS verification modes
 
@@ -412,6 +416,13 @@ Notes:
   Either upgrade the client library, or downgrade the connection to `:verify_ca`
   and accept some risk of hostname uncertainty. Relying on the CA certificate
   validation only may be acceptable in your use case at your judgment.
+- The `:verify_identity` callback verifies the connector's TLS session with the
+  OpenSSL mysql2 linked, which is only sound when both resolve to the same
+  loaded library. If the process holds two different OpenSSL builds -- commonly
+  a Ruby with its own vendored OpenSSL next to a package manager's MariaDB
+  (#1575) -- `:verify_identity` refuses to connect with an error naming both
+  libraries instead of crashing. Rebuilding the gem fixes the pairing, since
+  mysql2 links the client library's own OpenSSL.
 
 #### Certificate fingerprint pinning
 

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -201,6 +201,92 @@ typedef struct {
   void *ssl;
 } mysql2_mariadb_tls_head;
 
+/* The client library's TLS backend identity string ("OpenSSL 3.4.1 ..."),
+ * or NULL when the backend is not OpenSSL/LibreSSL -- under Schannel or
+ * GnuTLS, ctls->ssl is a different animal entirely and no OpenSSL-based
+ * verification can apply to it. */
+static const char *mysql2_tls_openssl_library(MYSQL *mysql) {
+  const char *tls_library = NULL;
+
+  if (mariadb_get_infov(mysql, MARIADB_TLS_LIBRARY, (void *)&tls_library) != 0 ||
+      tls_library == NULL ||
+      (strncmp(tls_library, "OpenSSL", 7) != 0 && strncmp(tls_library, "LibreSSL", 8) != 0))
+    return NULL;
+  return tls_library;
+}
+
+#ifdef MYSQL2_OPENSSL_LINKAGE_CHECK
+#include <dlfcn.h>
+#include <openssl/crypto.h>
+
+#if defined(OPENSSL_VERSION_NUMBER) && OPENSSL_VERSION_NUMBER >= 0x10100000L
+#define MYSQL2_OPENSSL_VERSION_STRING OpenSSL_version(OPENSSL_VERSION)
+#else
+#define MYSQL2_OPENSSL_VERSION_STRING SSLeay_version(SSLEAY_VERSION)
+#endif
+
+/* Compare where this extension and the client library each resolve the
+ * OpenSSL symbols the verification callback calls. SSL and X509 are opaque
+ * types whose layout is private to each OpenSSL build, so handing the
+ * client library's TLS session to another build's accessors is undefined
+ * behavior -- in practice a segfault inside libcrypto (#1575). Two builds
+ * commonly coexist in one process (a language runtime's vendored OpenSSL
+ * plus the package manager's build the client library links), and macOS
+ * two-level namespace binding resolves each image's references separately,
+ * so nothing else forces agreement. The dynamic loader is the authority on
+ * what actually resolved: for one representative symbol per OpenSSL
+ * library, the address this extension linked must be the address the
+ * client library's image resolves through its own dependencies. Returns
+ * NULL when they agree, or a description naming both images.
+ * connector_openssl is the client library's backend identity string, NULL
+ * when unknown. */
+static const char *mysql2_tls_openssl_linkage_mismatch(const char *connector_openssl, char *detail, size_t detail_len) {
+  static const char *const symbol_names[] = { "SSL_get_verify_result", "X509_check_host" };
+  void *const local_symbols[] = { (void *)SSL_get_verify_result, (void *)X509_check_host };
+  Dl_info connector_image, local_image, resolved_image;
+  void *handle;
+  size_t i;
+  const char *mismatch = NULL;
+
+  /* Test seam: exercising the refusal below needs two OpenSSL builds
+   * resolved into one process, which CI images (a single OpenSSL install)
+   * cannot produce, so the spec suite forces the loader's verdict instead.
+   * Forcing can only refuse a connection that would otherwise proceed,
+   * never permit one. */
+  if (getenv("MYSQL2_TEST_FORCE_OPENSSL_LINKAGE_MISMATCH") != NULL)
+    return "forced by MYSQL2_TEST_FORCE_OPENSSL_LINKAGE_MISMATCH";
+
+  if (!dladdr((void *)mariadb_get_infov, &connector_image) || connector_image.dli_fname == NULL)
+    return "the client library's loaded image could not be located (dladdr)";
+
+  handle = dlopen(connector_image.dli_fname, RTLD_LAZY | RTLD_NOLOAD);
+  if (handle == NULL)
+    return "the client library's loaded image could not be reopened (dlopen)";
+
+  for (i = 0; i < sizeof(local_symbols) / sizeof(local_symbols[0]); i++) {
+    void *resolved = dlsym(handle, symbol_names[i]);
+    if (resolved != local_symbols[i]) {
+      if (!dladdr(local_symbols[i], &local_image) || local_image.dli_fname == NULL)
+        local_image.dli_fname = "an unknown image";
+      if (resolved == NULL || !dladdr(resolved, &resolved_image) || resolved_image.dli_fname == NULL)
+        resolved_image.dli_fname = "no image in its linkage";
+      snprintf(detail, detail_len,
+               "mysql2 calls %s in %s (%s) but the client library %s resolves it in %s (%s)",
+               symbol_names[i],
+               local_image.dli_fname, MYSQL2_OPENSSL_VERSION_STRING,
+               connector_image.dli_fname,
+               resolved_image.dli_fname,
+               connector_openssl != NULL ? connector_openssl : "unknown");
+      mismatch = detail;
+      break;
+    }
+  }
+
+  dlclose(handle);
+  return mismatch;
+}
+#endif /* MYSQL2_OPENSSL_LINKAGE_CHECK */
+
 /* Report through the public NET error fields -- the same fields the
  * connector's my_set_error fills -- so mysql_error() surfaces the real
  * reason for the refused connection. */
@@ -219,7 +305,6 @@ static void mysql2_tls_set_error(MYSQL *mysql, const char *detail) {
  * since this refusal is what a misconfigured caller actually sees -- and
  * sets *status to the matching MARIADB_TLS_VERIFY_* bit. */
 static const char *mysql2_tls_check_peer_identity(MYSQL *mysql, mysql2_mariadb_tls_head *ctls, unsigned int *status, char *detail, size_t detail_len) {
-  const char *tls_library = NULL;
   const char *host;
   const char *ca;
   SSL *ssl;
@@ -230,12 +315,9 @@ static const char *mysql2_tls_check_peer_identity(MYSQL *mysql, mysql2_mariadb_t
   *status = MARIADB_TLS_VERIFY_UNKNOWN;
 
   /* ctls->ssl is only an OpenSSL SSL* when the connector was built against
-   * OpenSSL or LibreSSL; under Schannel or GnuTLS it is a different
-   * animal entirely and this shim cannot verify anything -- refuse rather
-   * than guess. */
-  if (mariadb_get_infov(mysql, MARIADB_TLS_LIBRARY, (void *)&tls_library) != 0 ||
-      tls_library == NULL ||
-      (strncmp(tls_library, "OpenSSL", 7) != 0 && strncmp(tls_library, "LibreSSL", 8) != 0))
+   * OpenSSL or LibreSSL -- this shim cannot verify any other backend's
+   * session, so refuse rather than guess. */
+  if (mysql2_tls_openssl_library(mysql) == NULL)
     return "hostname verification requires an OpenSSL-based MariaDB Connector/C build";
 
   ssl = (SSL *)ctls->ssl;
@@ -374,6 +456,33 @@ static VALUE rb_set_ssl_mode_option(VALUE self, VALUE setting) {
        * when it isn't available) is MariaDB-only. */
       if (val == SSL_MODE_VERIFY_IDENTITY && mariadb_family) {
 #ifdef MYSQL2_VERIFY_IDENTITY_SHIM
+#ifdef MYSQL2_OPENSSL_LINKAGE_CHECK
+        /* The verification callback may hand the client library's TLS
+         * session to the OpenSSL functions this extension linked only when
+         * both resolve to the same loaded library; a second co-resident
+         * build's accessors misread the session's opaque structs and crash
+         * inside libcrypto (#1575). Refuse up front, while the mismatch can
+         * still be reported as an error rather than a segfault. Skipped for
+         * Schannel/GnuTLS backends, whose refusal -- with an accurate
+         * message -- lives in the callback itself. */
+        {
+          const char *connector_openssl = mysql2_tls_openssl_library(wrapper->client);
+          if (connector_openssl != NULL || getenv("MYSQL2_TEST_FORCE_OPENSSL_LINKAGE_MISMATCH") != NULL) {
+            char linkage_detail[1024];
+            const char *mismatch = mysql2_tls_openssl_linkage_mismatch(connector_openssl, linkage_detail, sizeof(linkage_detail));
+            if (mismatch != NULL)
+              rb_raise(cMysql2ConnectionError,
+                       "ssl_mode: :verify_identity cannot be enforced: mysql2 and the client "
+                       "library link two different OpenSSL builds -- %s. Calling one build's "
+                       "functions on the other's TLS session crashes rather than verifies "
+                       "(#1575), so refusing to connect instead. Rebuild mysql2 so both link "
+                       "the same OpenSSL -- current mysql2 gems link the client library's own "
+                       "OpenSSL automatically, or name it explicitly: gem install mysql2 -- "
+                       "--with-openssl-dir=<prefix of the client library's OpenSSL>.",
+                       mismatch);
+          }
+        }
+#endif
         /* Both registrations are checked: a runtime client library that
          * rejects either option (say, an older libmariadb.so than the
          * headers this gem was built against) cannot enforce verification
@@ -3089,6 +3198,16 @@ void init_mysql2_client(void) {
   rb_const_set(cMysql2Client, rb_intern("TLS_PEER_IDENTITY_VERIFICATION"), ID2SYM(rb_intern("callback")));
 #else
   rb_const_set(cMysql2Client, rb_intern("TLS_PEER_IDENTITY_VERIFICATION"), Qnil);
+#endif
+
+  /* Whether :callback enforcement first verifies, via the dynamic loader,
+   * that mysql2 and the client library resolve OpenSSL to the same loaded
+   * library -- refusing the connection on a mismatch instead of crashing
+   * on a foreign build's TLS session (#1575). */
+#ifdef MYSQL2_OPENSSL_LINKAGE_CHECK
+  rb_const_set(cMysql2Client, rb_intern("TLS_OPENSSL_LINKAGE_CHECK"), Qtrue);
+#else
+  rb_const_set(cMysql2Client, rb_intern("TLS_OPENSSL_LINKAGE_CHECK"), Qfalse);
 #endif
 
 #ifdef HAVE_CONST_MARIADB_OPT_TLS_PEER_FP

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -1,5 +1,6 @@
 require 'mkmf'
 require 'English'
+require 'shellwords'
 
 ### Some helper functions
 
@@ -26,6 +27,29 @@ def add_ssl_defines(header)
     has_enforce_support = have_const('MYSQL_OPT_SSL_ENFORCE', header)
     $CFLAGS << ' -DNO_SSL_MODE_SUPPORT' if !has_verify_support && !has_enforce_support
   end
+end
+
+# Absolute paths of the libssl/libcrypto dylibs the verify_identity
+# enforcement callback should link: the ones under an explicit
+# --with-openssl-dir, or failing that, the exact dylibs the mysql client
+# library's own recorded install names point at (macOS only -- see the
+# verify_identity section below for why the pairing matters).
+def verify_identity_openssl_dylibs(explicit_libdirs)
+  return [] unless RUBY_PLATFORM =~ /darwin/
+
+  dylibs =
+    if explicit_libdirs.empty?
+      lib_dirs = "#{$libs} #{$LDFLAGS}".scan(/-L\s*(\S+)/).flatten + $LIBPATH
+      lib_names = $libs.scan(/-l(mariadb|mysqlclient|perconaserverclient)\b/).flatten
+      connector = lib_dirs.product(lib_names).flat_map { |dir, name| Dir["#{dir}/lib#{name}*.dylib"] }.first
+      connector ? `otool -L #{connector.shellescape}`.scan(%r{^\s+(/\S+/lib(?:ssl|crypto)\.[^\s/]*\.dylib)}).flatten : []
+    else
+      explicit_libdirs.flat_map do |dir|
+        %w[ssl crypto].map { |name| Dir["#{dir}/lib#{name}.*.dylib"].first || Dir["#{dir}/lib#{name}.dylib"].first }
+      end.compact
+    end
+
+  dylibs.size == 2 && dylibs.all? { |dylib| File.exist?(dylib) } ? dylibs : []
 end
 
 ### Check for Ruby C extension interfaces
@@ -58,6 +82,7 @@ have_func('clock_gettime', 'time.h')
 ### Find OpenSSL library
 
 # User-specified OpenSSL if explicitly specified
+openssl_lib_dirs = []
 if with_config('openssl-dir')
   _, lib = dir_config('openssl')
   if lib
@@ -71,6 +96,7 @@ if with_config('openssl-dir')
     abort "-----\nCannot find library dir(s) #{lib}\n-----" unless lib && lib.split(File::PATH_SEPARATOR).any? { |dir| File.directory?(dir) }
     warn "-----\nUsing --with-openssl-dir=#{File.dirname lib}\n-----"
     $LDFLAGS << " -L#{lib}"
+    openssl_lib_dirs = lib.split(File::PATH_SEPARATOR)
   end
 # Homebrew OpenSSL on MacOS
 elsif RUBY_PLATFORM =~ /darwin/ && system('command -v brew')
@@ -242,14 +268,47 @@ have_const('MARIADB_OPT_TLS_PASSPHRASE', mysql_h)
 # - OpenSSL itself, for SSL_get_verify_result and X509_check_host;
 # - the installed ma_pvio.h MARIADB_PVIO layout, which is how the callback
 #   reaches the MYSQL handle and the TLS session from its argument.
-have_verify_identity_shim =
+have_verification_callback =
   have_tls_introspection &&
   have_const('MARIADB_OPT_TLS_VERIFICATION_CALLBACK', mysql_h) &&
-  have_const('MARIADB_TLS_LIBRARY', mysql_h) &&
+  have_const('MARIADB_TLS_LIBRARY', mysql_h)
+
+# The callback links OpenSSL only to operate on TLS sessions the client
+# library owns, so the correct OpenSSL is the very build the client library
+# links -- SSL and X509 are opaque types whose layout is private to each
+# build, and calling one build's accessors on another build's session
+# crashes (#1575). Resolving -lssl/-lcrypto off the search path can land on
+# a different installation: several commonly coexist (a package manager's,
+# a language runtime's vendored copy), Ruby's own libdir -- which mkmf
+# always searches first, ahead of every directory this script could add --
+# may hold static archives of one of them, and mariadb_config doesn't say
+# where the connector's OpenSSL lives (--libs_sys names -lssl with no -L).
+# On macOS, whose two-level namespace binding is what lets two loaded
+# OpenSSLs coexist without interposition forcing agreement, the client
+# library's recorded install names identify its exact dylibs: link those
+# very files, bypassing library search entirely, and compile against the
+# headers installed next to them. An explicit --with-openssl-dir names the
+# dylibs to link the same way; the runtime linkage check below guards
+# whatever was linked either way.
+verify_identity_dylibs = have_verification_callback ? verify_identity_openssl_dylibs(openssl_lib_dirs) : []
+verify_identity_dylibs.each do |dylib|
+  warn "-----\nLinking the verify_identity callback against #{dylib}\n-----"
+  $libs << " #{dylib}"
+  incdir = File.expand_path('../../include', dylib)
+  $INCFLAGS << " -I#{incdir}" if File.directory?(incdir) && !$INCFLAGS.include?(" -I#{incdir}")
+end
+
+have_verify_identity_shim =
+  have_verification_callback &&
   have_header('openssl/ssl.h') &&
   have_header('openssl/x509v3.h') &&
-  have_library('crypto', 'X509_check_host', 'openssl/x509v3.h') &&
-  have_library('ssl', 'SSL_get_verify_result', 'openssl/ssl.h') &&
+  (if verify_identity_dylibs.empty?
+     have_library('crypto', 'X509_check_host', 'openssl/x509v3.h') &&
+       have_library('ssl', 'SSL_get_verify_result', 'openssl/ssl.h')
+   else
+     have_func('X509_check_host', 'openssl/x509v3.h') &&
+       have_func('SSL_get_verify_result', 'openssl/ssl.h')
+   end) &&
   checking_for('MARIADB_PVIO layout for the verify_identity callback') do
     pvio_h = [prefix, 'ma_pvio.h'].compact.join('/')
     try_compile(<<-SRC)
@@ -266,6 +325,44 @@ int main(void) {
     SRC
   end
 $CFLAGS << ' -DMYSQL2_VERIFY_IDENTITY_SHIM' if have_verify_identity_shim
+
+# Runtime backstop for the same invariant (#1575): the loader, not the
+# build, has the last word on which OpenSSL each image resolved -- a gem
+# built before this guard existed, or a client library repackaged against a
+# different OpenSSL after the gem was built, still collides. client.c
+# compares, per OpenSSL library, the address this extension linked for a
+# symbol the callback calls against the address the client library's image
+# resolves through its own dependencies, and :verify_identity refuses the
+# connection on disagreement instead of crashing inside libcrypto. glibc
+# keeps RTLD_NOLOAD, dladdr, and Dl_info behind _GNU_SOURCE; platforms
+# without this dlfcn surface (Windows) skip the check and keep the shim's
+# existing behavior.
+if have_verify_identity_shim
+  dlfcn_src = <<-SRC
+#include <dlfcn.h>
+int main(void) {
+  Dl_info info;
+  void *handle = dlopen("libssl", RTLD_LAZY | RTLD_NOLOAD);
+  void *sym = handle != NULL ? dlsym(handle, "SSL_get_verify_result") : NULL;
+  return dladdr(sym, &info) != 0 && info.dli_fname != NULL;
+}
+  SRC
+  have_linkage_check =
+    checking_for('dlopen/dlsym/dladdr to verify OpenSSL linkage identity') do
+      if try_link(dlfcn_src)
+        true
+      elsif try_link(dlfcn_src, '-D_GNU_SOURCE')
+        $CFLAGS << ' -D_GNU_SOURCE'
+        true
+      elsif have_library('dl') && try_link(dlfcn_src, '-D_GNU_SOURCE')
+        $CFLAGS << ' -D_GNU_SOURCE'
+        true
+      else
+        false
+      end
+    end
+  $CFLAGS << ' -DMYSQL2_OPENSSL_LINKAGE_CHECK' if have_linkage_check
+end
 
 # detect mysql functions
 have_func('mysql_ssl_set', mysql_h)

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -565,6 +565,25 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       end.to raise_error(Mysql2::Error::ConnectionError, /cannot be enforced/)
     end
 
+    it "refuses verify_identity when mysql2 and the client library link different OpenSSL builds" do
+      skip "this build does not verify OpenSSL linkage identity" unless Mysql2::Client::TLS_OPENSSL_LINKAGE_CHECK
+
+      # A real mismatch takes two OpenSSL builds resolved into one process
+      # -- a mise/rbenv-built Ruby's vendored OpenSSL alongside the package
+      # manager's build the connector links (#1575) -- which CI images, with
+      # their single OpenSSL install, cannot produce. Force the loader's
+      # verdict instead: the seam can only refuse a connection that would
+      # otherwise proceed, never permit one.
+      begin
+        ENV['MYSQL2_TEST_FORCE_OPENSSL_LINKAGE_MISMATCH'] = '1'
+        expect do
+          new_client(ssl_mode: :verify_identity)
+        end.to raise_error(Mysql2::Error::ConnectionError, /different OpenSSL builds.+--with-openssl-dir/m)
+      ensure
+        ENV.delete('MYSQL2_TEST_FORCE_OPENSSL_LINKAGE_MISMATCH')
+      end
+    end
+
     it "refuses sslverify: false combined with a verifying ssl_mode" do
       skip "this build has no verifying ssl_mode" if Mysql2::Client::SSL_MODE_VERIFY_IDENTITY.zero?
 


### PR DESCRIPTION
Fixes #1575.

## Root cause

The #1570 `verify_identity` enforcement callback verifies the connector's TLS session by calling OpenSSL directly — `SSL_get_app_data`, `SSL_get_verify_result`, `SSL_get_peer_certificate`, `X509_check_host` — on the `SSL*` the connector created. Those calls resolve against whatever OpenSSL `mysql2.bundle` linked; the session belongs to whatever OpenSSL `libmariadb` linked. `SSL`/`X509` are opaque types whose layout is private to each build, so when those are two different builds the accessors misread the session — the deterministic segfault inside `CRYPTO_get_ex_data` in the issue. Nothing tied the two together: the extconf probes took whatever `-lssl -lcrypto` resolved to off the default search path.

I could reproduce this on a stock setup without MacPorts at all: a mise-built Ruby 4.0.6 keeps **static** `libssl.a`/`libcrypto.a` (OpenSSL 3.5.5) in Ruby's own libdir, which mkmf always searches first (`$DEFLIBPATH`) — ahead of every `-L` extconf can add, including `--with-openssl-dir`'s. A default build against Homebrew's mariadb-connector-c silently static-linked Ruby's OpenSSL into `mysql2.bundle` while the connector loaded Homebrew's 3.6.3. That pairing happened to work by layout luck; pairing with openssl@1.1 instead crashes with the issue's exact stack (`CRYPTO_get_ex_data` ← `mysql2_tls_check_peer_identity` ← `mysql2_tls_verification_callback`), no options beyond `ssl_mode: :verify_identity`.

## Fix

Both directions suggested in the issue, each covering what the other cannot see:

**1. Link time (extconf.rb, macOS).** Link the callback against the exact OpenSSL the client library links. `mariadb_config` doesn't say where that is (`--libs_sys` names `-lssl` with no `-L`), but the connector dylib's recorded install names do: read them with `otool -L` and pass those dylib **paths** straight to the linker. Full paths rather than `-L`/`-l` because no search-path ordering can beat mkmf's `$DEFLIBPATH` when Ruby's libdir holds OpenSSL static archives — which is also why `--with-openssl-dir` now selects its dylibs the same way. Headers come from the include directory installed next to the chosen dylibs, keeping compile and link on the same build. macOS-only by scope: two-level namespace binding is what lets two loaded OpenSSLs coexist with each image resolving separately, while ELF resolves shared symbols by SONAME process-wide (the first loaded `libssl.so.3` wins for every image), so Linux cannot bind mysql2 and libmariadb to two different loaded OpenSSLs this way.

**2. Runtime (client.c).** Before registering the callback, `:verify_identity` asks the dynamic loader — the only authority on what actually resolved — whether this extension and the client library's image agree on one address per OpenSSL library (`SSL_get_verify_result` for libssl, `X509_check_host` for libcrypto; `dladdr` to find the connector's image, `dlopen(RTLD_NOLOAD)` + `dlsym` to resolve through the connector's own dependency scope). Disagreement refuses the connection before anything touches the network, with an error naming both images and versions and the rebuild remedy — the same enforce-or-refuse posture as #1570. This catches what extconf cannot see: gems built before this change, a connector repackaged against a different OpenSSL after the gem was built, and the static-archive absorption above.

Loader identity was chosen over comparing version strings (`OpenSSL_version` vs the connector's `MARIADB_TLS_LIBRARY` report): two distinct same-version installs compare equal while remaining formally incompatible builds, and a version string can't name the images for the remedy. The strict form knowingly refuses same-version-different-install pairings that would have worked by layout luck; for a crash-or-verify security path that trade is deliberate, and the link-time layer makes common builds converge on one library anyway.

The check needs `dlopen`/`dlsym`/`dladdr`/`RTLD_NOLOAD` (glibc gates the latter two behind `_GNU_SOURCE`, added when needed); where that surface is missing (Windows) the probe compiles the check out and behavior is unchanged. `Mysql2::Client::TLS_OPENSSL_LINKAGE_CHECK` reports whether a build carries it. GnuTLS/Schannel connectors skip the check — the callback's own OpenSSL-backend refusal already covers them with an accurate message.

## What was verified, and where

On the repro machine (macOS arm64, mise Ruby 4.0.6 with vendored static OpenSSL 3.5.5, Homebrew mariadb-connector-c 3.4.7 against openssl@3 3.6.3):

* master + openssl@1.1 pairing: deterministic segfault, same stack as the issue.
* this branch, default build: links the connector's own `libssl.3`/`libcrypto.3` (otool-verified, no static OpenSSL absorbed), the runtime check passes, and `verify_identity` proceeds to real certificate verification.
* this branch, deliberately mismatched openssl@1.1 build: refuses at `Client.new` — `mysql2 calls SSL_get_verify_result in .../libssl.1.1.dylib (OpenSSL 1.1.1w ...) but the client library .../libmariadb.3.dylib resolves it in .../libssl.3.dylib (OpenSSL 3.6.3 ...)` — instead of crashing.
* `client_spec` compared against master on the same build config: no new failures (the pre-existing environment-specific Timeout-interrupt failures are identical on both).

What CI can and cannot verify: CI images carry a single OpenSSL install, so they **cannot produce the real mismatch** (that's why #1570's matrix never saw this). The refusal spec therefore forces the loader's verdict through a fail-closed-only env seam (`MYSQL2_TEST_FORCE_OPENSSL_LINKAGE_MISMATCH` — it can only refuse a connection, never permit one). What CI does prove: the real check runs, and must keep passing, inside every existing `verify_identity` leg (macOS mariadb@11.8 with the explicit `--with-openssl-dir` path, Ubuntu/Fedora MariaDB legs with the `have_library` fallback + `_GNU_SOURCE` probe), and the macOS legs exercise the new full-path linking.
