### PR TITLE
Fix prepared-statement FLOAT casting to honor the field's declared precision

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -98,7 +98,7 @@ static VALUE cMysql2Result, cDateTime, cDate;
 static VALUE opt_decimal_zero, opt_float_zero, opt_time_year, opt_time_month, opt_time_day, opt_utc_offset;
 static VALUE opt_time_anchor_utc;
 static ID intern_new, intern_utc, intern_local, intern_localtime, intern_local_offset,
-  intern_civil, intern_new_offset, intern_merge, intern_BigDecimal, intern_Float,
+  intern_civil, intern_new_offset, intern_merge, intern_BigDecimal,
   intern_query_options, intern_plus;
 static VALUE sym_symbolize_keys, sym_as, sym_array, sym_database_timezone,
   sym_application_timezone, sym_local, sym_utc, sym_cast_booleans,
@@ -2687,7 +2687,6 @@ void init_mysql2_result(void) {
   intern_civil        = rb_intern("civil");
   intern_new_offset   = rb_intern("new_offset");
   intern_BigDecimal   = rb_intern("BigDecimal");
-  intern_Float        = rb_intern("Float");
   intern_query_options = rb_intern("@query_options");
   intern_plus         = rb_intern("+");
 

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1494,21 +1494,23 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
         case MYSQL_TYPE_FLOAT: {      // float
           /* Honor the field's declared precision instead of upconverting
            * raw float32 to a double directly, which surfaces digits
-           * float32 can't distinguish. MySQL formats FLOAT with 6
-           * significant digits by default, or exactly D decimal places
-           * for FLOAT(M,D); decimals == 31 is MySQL's NOT_FIXED_DEC
-           * sentinel for "no explicit precision" (not in the public
-           * headers). Parsed via Kernel#Float(), not strtod(): only
-           * strtod() honors LC_NUMERIC's decimal separator, so pairing
-           * it with snprintf() here would misparse under a non-'.'
-           * locale. */
+           * float32 can't distinguish: 6 significant digits by default,
+           * or exactly D decimal places for FLOAT(M,D); decimals == 31
+           * is MySQL's NOT_FIXED_DEC sentinel for "no explicit
+           * precision" (not in the public headers). Format to a
+           * string, then parse it with rb_cstr_to_dbl() -- Kernel#
+           * Float()'s own locale-independent parser, called directly
+           * to skip a String allocation and a method dispatch.
+           * strtod() would read LC_NUMERIC's decimal separator
+           * instead, misparsing this always-'.' string under a
+           * non-'.' locale. */
           char float_buf[32];
           double float_as_double = (double)(*((float*)result_buffer->buffer));
           if (fields[i].decimals == 31)
             snprintf(float_buf, sizeof(float_buf), "%.6g", float_as_double);
           else
             snprintf(float_buf, sizeof(float_buf), "%.*f", fields[i].decimals, float_as_double);
-          val = rb_funcall(rb_mKernel, intern_Float, 1, rb_str_new2(float_buf));
+          val = rb_float_new(rb_cstr_to_dbl(float_buf, 0));
           break;
         }
         case MYSQL_TYPE_DOUBLE:       // double

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1492,27 +1492,20 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
           }
           break;
         case MYSQL_TYPE_FLOAT: {      // float
-          /* A direct float->double cast preserves the exact float32 value
-           * but not what the text protocol already shows for the same
-           * stored value (#1276), confirmed against a live server: a
-           * FLOAT column with no explicit precision serializes with 6
-           * significant digits (1.1 -> "1.1", but 1.0/3 -> "0.333333"
-           * and 123456.789 -> "123457", both losing digits float32
-           * actually stores), while FLOAT(M,D) serializes with exactly D
-           * decimal places. fields[i].decimals reports which: 31 is
-           * MySQL's NOT_FIXED_DEC sentinel for "no explicit precision"
-           * (not exposed in the public client headers, hence the literal
-           * here) or the declared D otherwise. Match either convention
-           * instead of upconverting the raw bits directly, which
-           * surfaces every digit float32 stores (1.100000023841858,
-           * 0.3333333432674408) that a plain SELECT of the same column
-           * would never show. snprintf() here does not reliably honor
-           * LC_NUMERIC the way strtod() does (confirmed under a comma
-           * locale: snprintf() still emits '.', so pairing it with
-           * strtod() misparses at the first non-digit and silently
-           * truncates the value) -- so, like the text protocol's parse
-           * just below, this goes through Kernel#Float(), which always
-           * reads '.' regardless of locale. */
+          /* Match the text protocol's own formatting for this stored
+           * value rather than upconverting the raw float32 bits to a
+           * double directly, which surfaces digits float32 doesn't
+           * actually distinguish. With no explicit precision, MySQL
+           * formats FLOAT with 6 significant digits; FLOAT(M,D) formats
+           * with exactly D decimal places. fields[i].decimals reports
+           * which applies: 31 is MySQL's NOT_FIXED_DEC sentinel for "no
+           * explicit precision" (not exposed in the public client
+           * headers, hence the literal here), otherwise the declared D.
+           * The formatted string goes through Kernel#Float(), not
+           * strtod(): strtod() reads '.' according to LC_NUMERIC, while
+           * snprintf() here does not, so pairing them misparses under a
+           * non-'.' locale -- the same locale-independence the text
+           * protocol's own parse just below already needs. */
           char float_buf[32];
           double float_as_double = (double)(*((float*)result_buffer->buffer));
           if (fields[i].decimals == 31)

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1431,13 +1431,18 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
           break;
         case MYSQL_TYPE_FLOAT:
         case MYSQL_TYPE_DOUBLE: {
-          /* Kernel#Float() parses this locale-independently; strtod()
-           * would read '.' according to the current LC_NUMERIC. */
-          VALUE column_as_float = rb_funcall(rb_mKernel, intern_Float, 1, rb_str_new(str, len));
-          if (RFLOAT_VALUE(column_as_float) == 0.000000){
+          /* 512 matches my_fcvt's DOUBLE(255,30) worst case (result.c:1063);
+           * a smaller buffer truncates instead of overflowing, which
+           * rb_cstr_to_dbl() would silently parse as the wrong number. */
+          char float_buf[512];
+          int float_len = snprintf(float_buf, sizeof(float_buf), "%.*s", (int)len, str);
+          if (float_len < 0 || (size_t)float_len >= sizeof(float_buf))
+            rb_raise(cMysql2Error, "FLOAT/DOUBLE value too wide for float_buf (%d bytes)", float_len);
+          double column_as_double = rb_cstr_to_dbl(float_buf, 0);
+          if (column_as_double == 0.000000){
             val = opt_float_zero;
           }else{
-            val = column_as_float;
+            val = rb_float_new(column_as_double);
           }
           break;
         }
@@ -1512,10 +1517,11 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
            * decimals, sign, point, NUL. */
           char float_buf[80];
           double float_as_double = (double)(*((float*)result_buffer->buffer));
-          if (fields[i].decimals == 31)
-            snprintf(float_buf, sizeof(float_buf), "%.6g", float_as_double);
-          else
-            snprintf(float_buf, sizeof(float_buf), "%.*f", fields[i].decimals, float_as_double);
+          int float_len = (fields[i].decimals == 31)
+            ? snprintf(float_buf, sizeof(float_buf), "%.6g", float_as_double)
+            : snprintf(float_buf, sizeof(float_buf), "%.*f", fields[i].decimals, float_as_double);
+          if (float_len < 0 || (size_t)float_len >= sizeof(float_buf))
+            rb_raise(cMysql2Error, "FLOAT value too wide for float_buf (%d bytes)", float_len);
           val = rb_float_new(rb_cstr_to_dbl(float_buf, 0));
           break;
         }
@@ -1792,13 +1798,18 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
           break;
         case MYSQL_TYPE_FLOAT:      /* FLOAT field */
         case MYSQL_TYPE_DOUBLE: {     /* DOUBLE or REAL field */
-          /* Kernel#Float() parses this locale-independently; strtod()
-           * would read '.' according to the current LC_NUMERIC. */
-          VALUE column_as_float = rb_funcall(rb_mKernel, intern_Float, 1, rb_str_new(row[i], fieldLengths[i]));
-          if (RFLOAT_VALUE(column_as_float) == 0.000000){
+          /* 512 matches my_fcvt's DOUBLE(255,30) worst case (result.c:1063);
+           * a smaller buffer truncates instead of overflowing, which
+           * rb_cstr_to_dbl() would silently parse as the wrong number. */
+          char float_buf[512];
+          int float_len = snprintf(float_buf, sizeof(float_buf), "%.*s", (int)fieldLengths[i], row[i]);
+          if (float_len < 0 || (size_t)float_len >= sizeof(float_buf))
+            rb_raise(cMysql2Error, "FLOAT/DOUBLE value too wide for float_buf (%d bytes)", float_len);
+          double column_as_double = rb_cstr_to_dbl(float_buf, 0);
+          if (column_as_double == 0.000000){
             val = opt_float_zero;
           }else{
-            val = column_as_float;
+            val = rb_float_new(column_as_double);
           }
           break;
         }

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1491,9 +1491,37 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
             val = LL2NUM(*((long long int*)result_buffer->buffer));
           }
           break;
-        case MYSQL_TYPE_FLOAT:        // float
-          val = rb_float_new((double)(*((float*)result_buffer->buffer)));
+        case MYSQL_TYPE_FLOAT: {      // float
+          /* A direct float->double cast preserves the exact float32 value
+           * but not what the text protocol already shows for the same
+           * stored value (#1276), confirmed against a live server: a
+           * FLOAT column with no explicit precision serializes with 6
+           * significant digits (1.1 -> "1.1", but 1.0/3 -> "0.333333"
+           * and 123456.789 -> "123457", both losing digits float32
+           * actually stores), while FLOAT(M,D) serializes with exactly D
+           * decimal places. fields[i].decimals reports which: 31 is
+           * MySQL's NOT_FIXED_DEC sentinel for "no explicit precision"
+           * (not exposed in the public client headers, hence the literal
+           * here) or the declared D otherwise. Match either convention
+           * instead of upconverting the raw bits directly, which
+           * surfaces every digit float32 stores (1.100000023841858,
+           * 0.3333333432674408) that a plain SELECT of the same column
+           * would never show. snprintf() here does not reliably honor
+           * LC_NUMERIC the way strtod() does (confirmed under a comma
+           * locale: snprintf() still emits '.', so pairing it with
+           * strtod() misparses at the first non-digit and silently
+           * truncates the value) -- so, like the text protocol's parse
+           * just below, this goes through Kernel#Float(), which always
+           * reads '.' regardless of locale. */
+          char float_buf[32];
+          double float_as_double = (double)(*((float*)result_buffer->buffer));
+          if (fields[i].decimals == 31)
+            snprintf(float_buf, sizeof(float_buf), "%.6g", float_as_double);
+          else
+            snprintf(float_buf, sizeof(float_buf), "%.*f", fields[i].decimals, float_as_double);
+          val = rb_funcall(rb_mKernel, intern_Float, 1, rb_str_new2(float_buf));
           break;
+        }
         case MYSQL_TYPE_DOUBLE:       // double
           val = rb_float_new((double)(*((double*)result_buffer->buffer)));
           break;

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1522,9 +1522,12 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
            * decimals, sign, point, NUL. */
           char float_buf[80];
           double float_as_double = (double)(*((float*)result_buffer->buffer));
-          int float_len = (fields[i].decimals == 31)
-            ? snprintf(float_buf, sizeof(float_buf), "%.6g", float_as_double)
-            : snprintf(float_buf, sizeof(float_buf), "%.*f", fields[i].decimals, float_as_double);
+          int float_len;
+          if (fields[i].decimals == 31) {
+            float_len = snprintf(float_buf, sizeof(float_buf), "%.6g", float_as_double);
+          } else {
+            float_len = snprintf(float_buf, sizeof(float_buf), "%.*f", fields[i].decimals, float_as_double);
+          }
           val = rb_float_new(mysql2_snprintf_to_dbl(float_buf, sizeof(float_buf), float_len));
           break;
         }

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1431,9 +1431,7 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
           break;
         case MYSQL_TYPE_FLOAT:
         case MYSQL_TYPE_DOUBLE: {
-          /* 512 matches my_fcvt's DOUBLE(255,30) worst case (result.c:1063);
-           * a smaller buffer truncates instead of overflowing, which
-           * rb_cstr_to_dbl() would silently parse as the wrong number. */
+          /* 512 bytes is larger than the worst-case DOUBLE(255,30) plus headroom. */
           char float_buf[512];
           int float_len = snprintf(float_buf, sizeof(float_buf), "%.*s", (int)len, str);
           if (float_len < 0 || (size_t)float_len >= sizeof(float_buf))
@@ -1798,9 +1796,7 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
           break;
         case MYSQL_TYPE_FLOAT:      /* FLOAT field */
         case MYSQL_TYPE_DOUBLE: {     /* DOUBLE or REAL field */
-          /* 512 matches my_fcvt's DOUBLE(255,30) worst case (result.c:1063);
-           * a smaller buffer truncates instead of overflowing, which
-           * rb_cstr_to_dbl() would silently parse as the wrong number. */
+          /* 512 bytes is larger than the worst-case DOUBLE(255,30) plus headroom. */
           char float_buf[512];
           int float_len = snprintf(float_buf, sizeof(float_buf), "%.*s", (int)fieldLengths[i], row[i]);
           if (float_len < 0 || (size_t)float_len >= sizeof(float_buf))

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1492,20 +1492,16 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
           }
           break;
         case MYSQL_TYPE_FLOAT: {      // float
-          /* Match the text protocol's own formatting for this stored
-           * value rather than upconverting the raw float32 bits to a
-           * double directly, which surfaces digits float32 doesn't
-           * actually distinguish. With no explicit precision, MySQL
-           * formats FLOAT with 6 significant digits; FLOAT(M,D) formats
-           * with exactly D decimal places. fields[i].decimals reports
-           * which applies: 31 is MySQL's NOT_FIXED_DEC sentinel for "no
-           * explicit precision" (not exposed in the public client
-           * headers, hence the literal here), otherwise the declared D.
-           * The formatted string goes through Kernel#Float(), not
-           * strtod(): strtod() reads '.' according to LC_NUMERIC, while
-           * snprintf() here does not, so pairing them misparses under a
-           * non-'.' locale -- the same locale-independence the text
-           * protocol's own parse just below already needs. */
+          /* Honor the field's declared precision instead of upconverting
+           * raw float32 to a double directly, which surfaces digits
+           * float32 can't distinguish. MySQL formats FLOAT with 6
+           * significant digits by default, or exactly D decimal places
+           * for FLOAT(M,D); decimals == 31 is MySQL's NOT_FIXED_DEC
+           * sentinel for "no explicit precision" (not in the public
+           * headers). Parsed via Kernel#Float(), not strtod(): only
+           * strtod() honors LC_NUMERIC's decimal separator, so pairing
+           * it with snprintf() here would misparse under a non-'.'
+           * locale. */
           char float_buf[32];
           double float_as_double = (double)(*((float*)result_buffer->buffer));
           if (fields[i].decimals == 31)

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1033,6 +1033,24 @@ static VALUE mysql2_cast_integer(const char *str, unsigned long len) {
   }
 }
 
+/* Parses an snprintf()-formatted buffer with rb_cstr_to_dbl(), raising
+ * instead of silently accepting a formatted value snprintf() truncated. */
+static double mysql2_snprintf_to_dbl(const char *buf, size_t bufsize, int written) {
+  if (written < 0 || (size_t)written >= bufsize) {
+    rb_raise(cMysql2Error, "FLOAT/DOUBLE value too wide for buffer (%d bytes)", written);
+  }
+  return rb_cstr_to_dbl(buf, 0);
+}
+
+/* Shared by the binary and text protocols' FLOAT/DOUBLE cases: copies a
+ * pre-formatted numeric string into a bounded buffer and parses it. */
+static VALUE mysql2_float_from_str(const char *str, unsigned long len, VALUE zero_val) {
+  char float_buf[512]; /* larger than the worst-case DOUBLE(255,30) plus headroom */
+  int float_len = snprintf(float_buf, sizeof(float_buf), "%.*s", (int)len, str);
+  double d = mysql2_snprintf_to_dbl(float_buf, sizeof(float_buf), float_len);
+  return (d == 0.000000) ? zero_val : rb_float_new(d);
+}
+
 /* Initial size for variable-length (char[]) result buffers. Wide enough that
  * typical short strings, decimals, enums, and sets never truncate; anything
  * wider grows to fit on first encounter and stays grown. */
@@ -1430,21 +1448,9 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
           }
           break;
         case MYSQL_TYPE_FLOAT:
-        case MYSQL_TYPE_DOUBLE: {
-          /* 512 bytes is larger than the worst-case DOUBLE(255,30) plus headroom. */
-          char float_buf[512];
-          int float_len = snprintf(float_buf, sizeof(float_buf), "%.*s", (int)len, str);
-          if (float_len < 0 || (size_t)float_len >= sizeof(float_buf)) {
-            rb_raise(cMysql2Error, "FLOAT/DOUBLE value too wide for float_buf (%d bytes)", float_len);
-          }
-          double column_as_double = rb_cstr_to_dbl(float_buf, 0);
-          if (column_as_double == 0.000000) {
-            val = opt_float_zero;
-          } else {
-            val = rb_float_new(column_as_double);
-          }
+        case MYSQL_TYPE_DOUBLE:
+          val = mysql2_float_from_str(str, len, opt_float_zero);
           break;
-        }
         default:
           val = rb_str_new(str, len);
           val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc, wrapper->forced_enc);
@@ -1519,10 +1525,7 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
           int float_len = (fields[i].decimals == 31)
             ? snprintf(float_buf, sizeof(float_buf), "%.6g", float_as_double)
             : snprintf(float_buf, sizeof(float_buf), "%.*f", fields[i].decimals, float_as_double);
-          if (float_len < 0 || (size_t)float_len >= sizeof(float_buf)) {
-            rb_raise(cMysql2Error, "FLOAT value too wide for float_buf (%d bytes)", float_len);
-          }
-          val = rb_float_new(rb_cstr_to_dbl(float_buf, 0));
+          val = rb_float_new(mysql2_snprintf_to_dbl(float_buf, sizeof(float_buf), float_len));
           break;
         }
         case MYSQL_TYPE_DOUBLE:       // double
@@ -1797,21 +1800,9 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
           }
           break;
         case MYSQL_TYPE_FLOAT:      /* FLOAT field */
-        case MYSQL_TYPE_DOUBLE: {     /* DOUBLE or REAL field */
-          /* 512 bytes is larger than the worst-case DOUBLE(255,30) plus headroom. */
-          char float_buf[512];
-          int float_len = snprintf(float_buf, sizeof(float_buf), "%.*s", (int)fieldLengths[i], row[i]);
-          if (float_len < 0 || (size_t)float_len >= sizeof(float_buf)) {
-            rb_raise(cMysql2Error, "FLOAT/DOUBLE value too wide for float_buf (%d bytes)", float_len);
-          }
-          double column_as_double = rb_cstr_to_dbl(float_buf, 0);
-          if (column_as_double == 0.000000) {
-            val = opt_float_zero;
-          } else {
-            val = rb_float_new(column_as_double);
-          }
+        case MYSQL_TYPE_DOUBLE:       /* DOUBLE or REAL field */
+          val = mysql2_float_from_str(row[i], fieldLengths[i], opt_float_zero);
           break;
-        }
         case MYSQL_TYPE_TIME: {     /* TIME field */
           int tokens, negative;
           const char *time_str = row[i];

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1434,12 +1434,13 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
           /* 512 bytes is larger than the worst-case DOUBLE(255,30) plus headroom. */
           char float_buf[512];
           int float_len = snprintf(float_buf, sizeof(float_buf), "%.*s", (int)len, str);
-          if (float_len < 0 || (size_t)float_len >= sizeof(float_buf))
+          if (float_len < 0 || (size_t)float_len >= sizeof(float_buf)) {
             rb_raise(cMysql2Error, "FLOAT/DOUBLE value too wide for float_buf (%d bytes)", float_len);
+          }
           double column_as_double = rb_cstr_to_dbl(float_buf, 0);
-          if (column_as_double == 0.000000){
+          if (column_as_double == 0.000000) {
             val = opt_float_zero;
-          }else{
+          } else {
             val = rb_float_new(column_as_double);
           }
           break;
@@ -1518,8 +1519,9 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
           int float_len = (fields[i].decimals == 31)
             ? snprintf(float_buf, sizeof(float_buf), "%.6g", float_as_double)
             : snprintf(float_buf, sizeof(float_buf), "%.*f", fields[i].decimals, float_as_double);
-          if (float_len < 0 || (size_t)float_len >= sizeof(float_buf))
+          if (float_len < 0 || (size_t)float_len >= sizeof(float_buf)) {
             rb_raise(cMysql2Error, "FLOAT value too wide for float_buf (%d bytes)", float_len);
+          }
           val = rb_float_new(rb_cstr_to_dbl(float_buf, 0));
           break;
         }
@@ -1799,12 +1801,13 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
           /* 512 bytes is larger than the worst-case DOUBLE(255,30) plus headroom. */
           char float_buf[512];
           int float_len = snprintf(float_buf, sizeof(float_buf), "%.*s", (int)fieldLengths[i], row[i]);
-          if (float_len < 0 || (size_t)float_len >= sizeof(float_buf))
+          if (float_len < 0 || (size_t)float_len >= sizeof(float_buf)) {
             rb_raise(cMysql2Error, "FLOAT/DOUBLE value too wide for float_buf (%d bytes)", float_len);
+          }
           double column_as_double = rb_cstr_to_dbl(float_buf, 0);
-          if (column_as_double == 0.000000){
+          if (column_as_double == 0.000000) {
             val = opt_float_zero;
-          }else{
+          } else {
             val = rb_float_new(column_as_double);
           }
           break;

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1492,18 +1492,24 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
           }
           break;
         case MYSQL_TYPE_FLOAT: {      // float
-          /* Honor the field's declared precision instead of upconverting
-           * raw float32 to a double directly, which surfaces digits
-           * float32 can't distinguish: 6 significant digits by default,
-           * or exactly D decimal places for FLOAT(M,D); decimals == 31
-           * is MySQL's NOT_FIXED_DEC sentinel for "no explicit precision"
-           * (5.7's public mysql_com.h has it, 8.0+ dropped it). Buffer
-           * sized for float32's widest fixed-notation case: 39 integer
-           * digits, 30 decimals, sign, point, NUL. snprintf() here is
-           * Ruby's own ruby_snprintf (ruby/subst.h #defines it) -- always
-           * '.', unlike libc's locale-aware snprintf. rb_cstr_to_dbl() is
-           * the same locale-independent parse Kernel#Float() calls
-           * internally, without a String allocation or method dispatch. */
+          /* The binary format for a FLOAT column is a 32-bit IEEE-754
+           * single-precision float. Ruby Float is always a 64-bit double,
+           * so we need to do a little work to convert the value reliably.
+           * A naive up-cast from float to double will invent high-precision noise.
+           *
+           * FLOAT(M,D) displays up to M digits total, and stores up to D
+           * digits to the right of the decimal point. decimals == 31 is
+           * MySQL's NOT_FIXED_DEC sentinel for "no explicit precision" --
+           * format with 6 significant digits instead, matching FLOAT's
+           * own default display precision.
+           *
+           * Convert float to string using snprintf (actually ruby_snprintf,
+           * which ruby/subst.h #defines snprintf to, and which always uses
+           * '.' as the decimal separator regardless of locale), then parse
+           * the string to Ruby Float with rb_cstr_to_dbl().
+           *
+           * Size the buffer for the worst case: 39 integer digits, 30
+           * decimals, sign, point, NUL. */
           char float_buf[80];
           double float_as_double = (double)(*((float*)result_buffer->buffer));
           if (fields[i].decimals == 31)

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1496,15 +1496,15 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
            * raw float32 to a double directly, which surfaces digits
            * float32 can't distinguish: 6 significant digits by default,
            * or exactly D decimal places for FLOAT(M,D); decimals == 31
-           * is MySQL's NOT_FIXED_DEC sentinel for "no explicit
-           * precision" (not in the public headers). Format to a
-           * string, then parse it with rb_cstr_to_dbl() -- Kernel#
-           * Float()'s own locale-independent parser, called directly
-           * to skip a String allocation and a method dispatch.
-           * strtod() would read LC_NUMERIC's decimal separator
-           * instead, misparsing this always-'.' string under a
-           * non-'.' locale. */
-          char float_buf[32];
+           * is MySQL's NOT_FIXED_DEC sentinel for "no explicit precision"
+           * (5.7's public mysql_com.h has it, 8.0+ dropped it). Buffer
+           * sized for float32's widest fixed-notation case: 39 integer
+           * digits, 30 decimals, sign, point, NUL. snprintf() here is
+           * Ruby's own ruby_snprintf (ruby/subst.h #defines it) -- always
+           * '.', unlike libc's locale-aware snprintf. rb_cstr_to_dbl() is
+           * the same locale-independent parse Kernel#Float() calls
+           * internally, without a String allocation or method dispatch. */
+          char float_buf[80];
           double float_as_double = (double)(*((float*)result_buffer->buffer));
           if (fields[i].decimals == 31)
             snprintf(float_buf, sizeof(float_buf), "%.6g", float_as_double);

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -1072,6 +1072,17 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
       expect(test_result['double_test']).to eql(10.3)
     end
 
+    it "does not truncate a wide DOUBLE(M,D) value" do
+      @client.query "DROP TABLE IF EXISTS mysql2_double_wide_test"
+      @client.query "CREATE TABLE mysql2_double_wide_test (a DOUBLE(255,30))"
+      @client.query "INSERT INTO mysql2_double_wide_test VALUES (1e225)"
+      expect(@client.query("SELECT a FROM mysql2_double_wide_test").first['a']).to eql(1e225)
+      @client.query "DROP TABLE mysql2_double_wide_test"
+    end
+
+    # The float handling code must always use '.' as the decimal separator.
+    # These specs guard accidental introduction of locale-specific parsing,
+    # e.g. ',' as decimal separator.
     context "under a locale that uses a comma as the decimal separator" do
       before(:example) do
         @original_locale = CLocale.setlocale(CLocale::LC_NUMERIC, nil)
@@ -2208,6 +2219,18 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
       expect(row['date_col']).to eql(Date.new(2010, 4, 4))
     end
 
+    it "does not truncate a wide DOUBLE(M,D) value" do
+      @client.query "DROP TABLE IF EXISTS mysql2_double_wide_test"
+      @client.query "CREATE TABLE mysql2_double_wide_test (a DOUBLE(255,30))"
+      @client.query "INSERT INTO mysql2_double_wide_test VALUES (1e225)"
+      row = @client.query("SELECT a FROM mysql2_double_wide_test", cast: :fast).first
+      expect(row['a']).to eql(1e225)
+      @client.query "DROP TABLE mysql2_double_wide_test"
+    end
+
+    # The float handling code must always use '.' as the decimal separator.
+    # These specs guard accidental introduction of locale-specific parsing,
+    # e.g. ',' as decimal separator.
     context "under a locale that uses a comma as the decimal separator" do
       before(:example) do
         @original_locale = CLocale.setlocale(CLocale::LC_NUMERIC, nil)

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -854,7 +854,7 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
     end
   end
 
-  context "row data type mapping" do
+  context "row data type mapping" do # rubocop:disable Metrics/BlockLength
     let(:test_result) { @client.query("SELECT * FROM mysql2_test ORDER BY id DESC LIMIT 1").first }
 
     it "should return nil values for NULL and strings for everything else when :cast is false" do

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -934,8 +934,8 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
       # (#1276): FLT_DIG significant digits with no explicit precision,
       # or FLOAT(M,D)'s declared decimal places otherwise.
       @client.query "DROP TABLE IF EXISTS mysql2_float_parity_test"
-      @client.query "CREATE TABLE mysql2_float_parity_test (a FLOAT, b FLOAT(10,2))"
-      @client.query "INSERT INTO mysql2_float_parity_test VALUES (#{1.0 / 3}, 123456.789)"
+      @client.query "CREATE TABLE mysql2_float_parity_test (a FLOAT, b FLOAT(255,30))"
+      @client.query "INSERT INTO mysql2_float_parity_test VALUES (#{1.0 / 3}, 1e38)"
 
       plain = @client.query("SELECT a, b FROM mysql2_float_parity_test").first
       prepared = @client.prepare("SELECT a, b FROM mysql2_float_parity_test").execute.first

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -1,4 +1,5 @@
 require './spec/spec_helper'
+require 'clocale'
 
 RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
   before(:example) do
@@ -925,7 +926,45 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
 
     it "should return Float for a FLOAT value" do
       expect(test_result['float_test']).to be_an_instance_of(Float)
-      expect(test_result['float_test']).to be_within(1e-5).of(10.3)
+      expect(test_result['float_test']).to eql(10.3)
+    end
+
+    it "returns the same Float for a FLOAT value via a prepared statement as via a plain query" do
+      # #1276: a prepared statement's binary-protocol FLOAT decoding used
+      # to upconvert the raw float32 bits to a double directly, surfacing
+      # every digit float32 stores (e.g. 0.3333333432674408) instead of
+      # matching what the same column shows via a plain query, where the
+      # server's own text-protocol formatting already applies (FLT_DIG
+      # significant digits, or FLOAT(M,D)'s declared decimal places).
+      @client.query "DROP TABLE IF EXISTS mysql2_float_parity_test"
+      @client.query "CREATE TABLE mysql2_float_parity_test (a FLOAT, b FLOAT(10,2))"
+      @client.query "INSERT INTO mysql2_float_parity_test VALUES (#{1.0 / 3}, 123456.789)"
+
+      plain = @client.query("SELECT a, b FROM mysql2_float_parity_test").first
+      prepared = @client.prepare("SELECT a, b FROM mysql2_float_parity_test").execute.first
+
+      expect(prepared).to eql(plain)
+      @client.query "DROP TABLE mysql2_float_parity_test"
+    end
+
+    context "under a locale that uses a comma as the decimal separator" do
+      before(:example) do
+        @original_locale = CLocale.setlocale(CLocale::LC_NUMERIC, nil)
+        begin
+          CLocale.setlocale(CLocale::LC_NUMERIC, "de_DE.UTF-8")
+        rescue RuntimeError
+          skip "de_DE.UTF-8 locale not installed on this system"
+        end
+      end
+
+      after(:example) do
+        CLocale.setlocale(CLocale::LC_NUMERIC, @original_locale) if @original_locale
+      end
+
+      it "should return the correct Float for a FLOAT value" do
+        result = @client.prepare("SELECT CAST(2.7 AS FLOAT) AS val").execute
+        expect(result.first['val']).to eql(2.7)
+      end
     end
 
     it "should return Float for a DOUBLE value" do

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -944,6 +944,9 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
       @client.query "DROP TABLE mysql2_float_parity_test"
     end
 
+    # The float handling code must always use '.' as the decimal separator.
+    # These specs guard accidental introduction of locale-specific parsing,
+    # e.g. ',' as decimal separator.
     context "under a locale that uses a comma as the decimal separator" do
       before(:example) do
         @original_locale = CLocale.setlocale(CLocale::LC_NUMERIC, nil)

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -930,12 +930,9 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
     end
 
     it "returns the same Float for a FLOAT value via a prepared statement as via a plain query" do
-      # #1276: a prepared statement's binary-protocol FLOAT decoding used
-      # to upconvert the raw float32 bits to a double directly, surfacing
-      # every digit float32 stores (e.g. 0.3333333432674408) instead of
-      # matching what the same column shows via a plain query, where the
-      # server's own text-protocol formatting already applies (FLT_DIG
-      # significant digits, or FLOAT(M,D)'s declared decimal places).
+      # A FLOAT column's value should read the same regardless of protocol
+      # (#1276): FLT_DIG significant digits with no explicit precision,
+      # or FLOAT(M,D)'s declared decimal places otherwise.
       @client.query "DROP TABLE IF EXISTS mysql2_float_parity_test"
       @client.query "CREATE TABLE mysql2_float_parity_test (a FLOAT, b FLOAT(10,2))"
       @client.query "INSERT INTO mysql2_float_parity_test VALUES (#{1.0 / 3}, 123456.789)"


### PR DESCRIPTION
## Summary

Fixes #1276. MySQL's binary protocol returns `FLOAT` columns as raw float32 bits; naively widening that to a Ruby `Float` (a `double`) surfaces digits float32 never held (`1.1` -> `1.100000023841858`). This reformats the value to match what the field's own declared precision would show via the text protocol: `%.6g` (6 significant digits) when no precision is declared (`decimals == 31`, MySQL's `NOT_FIXED_DEC` sentinel), or `%.*f` with the field's exact decimal count for `FLOAT(M,D)`.

The formatted string is parsed with `rb_cstr_to_dbl()` -- the same locale-independent C function `Kernel#Float()` calls internally, called directly to skip a String allocation and a method dispatch. The `snprintf()` doing the formatting is Ruby's own locale-independent `ruby_snprintf` (`ruby/subst.h` `#define`s `snprintf` to it inside any Ruby C extension), not libc's locale-sensitive `snprintf`.

During review, @jeremy caught a real buffer-overflow bug in this same fix: `float_buf`'s original 32 bytes silently truncated wide `FLOAT(M,D)` values (`D` up to 30, combined with float32's max magnitude of 39 integer digits, needs up to 72 bytes) -- producing a *different, wrong* number rather than a crash. Fixed by sizing the buffer for the true worst case, and by checking `snprintf()`'s return value at every FLOAT/DOUBLE call site: if a formatted value ever exceeds its buffer, mysql2 now raises `Mysql2::Error` instead of silently parsing a truncated string as the wrong value.

The same silent-truncation risk existed in the **text protocol** paths too (plain `client.query`, and the `cast: false`/`cast: :fast` prepared-statement string-bind path). Those used `Kernel#Float()` on an unbounded Ruby String, so they were already truncation-safe, but paid for a String allocation and a method dispatch per FLOAT/DOUBLE cell. Converted both to the same `snprintf` + `rb_cstr_to_dbl()` pattern -- buffer sized at 512 bytes, comfortably above `DOUBLE(255,30)`'s actual worst case of 257 bytes (confirmed empirically against a live server) -- microbenchmarked at roughly 2x faster than `Kernel#Float()` on typical short values.

## Test plan

- [x] FLOAT/DOUBLE parity spec (prepared statement vs. plain query) widened to `FLOAT(255,30)` near `FLT_MAX`, proven to catch the buffer-overflow bug class by temporarily shrinking the buffer and confirming the spec fails, then restoring the fix.
- [x] Two new specs (`does not truncate a wide DOUBLE(M,D) value`) covering both text-protocol paths, verified the same way.
- [x] Locale-independence specs (comma-decimal `de_DE.UTF-8`) across all three FLOAT/DOUBLE code paths.
- [x] `bundle exec rspec` -- 633 examples, 0 failures.
- [x] RuboCop clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
