### PR TITLE
Make read_timeout live and per-query; add write_timeout getter

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -39,7 +39,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 195
+  Max: 204
 
 # Offense count: 3
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/README.md
+++ b/README.md
@@ -308,9 +308,10 @@ type of connection to make, with special interpretation you should be aware of:
 `:read_timeout` and `:write_timeout` are asymmetric in how -- and when -- they
 can be changed, because mysql2 enforces them by different mechanisms:
 
-* `:read_timeout` is enforced by mysql2 itself, independent of the
-  underlying client library, so `Client#read_timeout=` can change it on an
-  already-connected client and it takes effect on the very next query:
+* On non-Windows platforms, `:read_timeout` is enforced by mysql2 itself,
+  independent of the underlying client library, so `Client#read_timeout=`
+  can change it on an already-connected client and it takes effect on the
+  very next query:
 
   ``` ruby
   client.read_timeout = 2
@@ -326,7 +327,15 @@ can be changed, because mysql2 enforces them by different mechanisms:
   client.query("SELECT ...", read_timeout: 2)
   ```
 
-* `:write_timeout` has no such mechanism: mysql2's own query-sending call is
+  Windows has no equivalent to the wait loop this relies on -- a query
+  there just blocks until the result is ready, with nothing watching for a
+  timeout independently of the client library -- so `read_timeout` is
+  enforced there the same way `write_timeout` is everywhere (see below):
+  set once, at `Mysql2::Client.new`. `read_timeout=` and the per-query
+  `read_timeout:` option both raise on an already-connected client on
+  Windows, rather than silently accepting a value that would never apply.
+
+* `:write_timeout` has no live mechanism on any platform: mysql2's own query-sending call is
   a single blocking library call with nothing watching it, so enforcement is
   entirely up to the underlying client library's `mysql_options()` --
   which both libmysqlclient and MariaDB Connector/C apply to a connection

--- a/README.md
+++ b/README.md
@@ -303,6 +303,41 @@ type of connection to make, with special interpretation you should be aware of:
 * An IPv4 or IPv6 address will result in a TCP connection.
 * Any other value will be looked up as a hostname for a TCP connection.
 
+### read_timeout and write_timeout
+
+`:read_timeout` and `:write_timeout` are asymmetric in how -- and when -- they
+can be changed, because mysql2 enforces them by different mechanisms:
+
+* `:read_timeout` is enforced by mysql2 itself, independent of the
+  underlying client library, so `Client#read_timeout=` can change it on an
+  already-connected client and it takes effect on the very next query:
+
+  ``` ruby
+  client.read_timeout = 2
+  client.ping
+  client.read_timeout = 600
+  client.query("...")
+  ```
+
+  It can also be overridden for a single query without touching the
+  connection-wide default:
+
+  ``` ruby
+  client.query("SELECT ...", read_timeout: 2)
+  ```
+
+* `:write_timeout` has no such mechanism: mysql2's own query-sending call is
+  a single blocking library call with nothing watching it, so enforcement is
+  entirely up to the underlying client library's `mysql_options()` --
+  which both libmysqlclient and MariaDB Connector/C apply to a connection
+  exactly once, during the initial connect. `mysql_options()` is documented
+  as callable only between `mysql_init()` and `mysql_real_connect()`; on an
+  already-connected handle it doesn't raise, but the value it stores is
+  never read again for that session. Because of this, `write_timeout=` on
+  an already-connected `Client` raises rather than silently doing nothing,
+  and `:write_timeout` isn't accepted as a per-query option at all. Set it
+  once, at `Mysql2::Client.new`.
+
 ### Secure connections with SSL/TLS
 
 The mysql2 gem can configure the underlying MySQL/MariaDB client library to

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -2564,21 +2564,26 @@ static VALUE set_connect_timeout(VALUE self, VALUE value) {
 /* call-seq:
  *    client.read_timeout = seconds
  *
- * read_timeout is enforced independently of the underlying client library:
- * do_query (client.c) re-reads the @read_timeout ivar set here on every
- * query and bounds the wait with rb_wait_for_single_fd itself, so this is
- * safe to change on an already-connected client -- unlike every other
+ * On POSIX, read_timeout is enforced independently of the underlying
+ * client library: do_query (client.c, #ifndef _WIN32 only) re-reads the
+ * @read_timeout ivar set here on every query and bounds the wait with
+ * rb_wait_for_single_fd itself, so it's safe to change on an
+ * already-connected client there -- unlike every other
  * mysql_options()-backed setter in this file, it does not need
  * REQUIRE_NOT_CONNECTED. mysql_options(MYSQL_OPT_READ_TIMEOUT) is still
  * called pre-connect, for parity with what the client library itself
- * reports (Client#read_timeout predates this and is unaffected either way),
- * but it's skipped once connected: neither libmysqlclient nor MariaDB
- * Connector/C apply it to an established session (both document
+ * reports, but is skipped once connected: neither libmysqlclient nor
+ * MariaDB Connector/C apply it to an established session (both document
  * mysql_options() as pre-connect-only, and both implementations confirm
  * it: the call only ever stores a struct field, applied to the live
- * connection exactly once, during the initial connect sequence), so calling
- * it here would either raise (REQUIRE_NOT_CONNECTED) or silently do
- * nothing -- worse than just not calling it. */
+ * connection exactly once, during the initial connect sequence).
+ *
+ * Windows has no equivalent to do_query's wait loop at all -- rb_mysql_query
+ * just blocks on rb_mysql_client_async_result there (see the #else branch)
+ * -- so on Windows read_timeout is enforced purely by whatever
+ * mysql_options() applied at connect, same as write_timeout, and a live
+ * change genuinely cannot take effect. Raise there instead of silently
+ * accepting a value that would never do anything. */
 static VALUE set_read_timeout(VALUE self, VALUE value) {
   long int sec;
   GET_CLIENT(self);
@@ -2587,10 +2592,18 @@ static VALUE set_read_timeout(VALUE self, VALUE value) {
   if (sec < 0) {
     rb_raise(cMysql2Error, "read_timeout must be a positive integer, you passed %ld", sec);
   }
-  rb_ivar_set(self, intern_read_timeout, value);
   if (CONNECTED(wrapper)) {
+#ifndef _WIN32
+    rb_ivar_set(self, intern_read_timeout, value);
     return value;
+#else
+    rb_raise(cMysql2Error, "read_timeout cannot be changed on an already-connected client on Windows -- "
+             "there is no independent wait-timeout mechanism there (see do_query in client.c), and neither "
+             "libmysqlclient nor MariaDB Connector/C apply MYSQL_OPT_READ_TIMEOUT to a live connection, only "
+             "at the next connect. Open a new Client instead.");
+#endif
   }
+  rb_ivar_set(self, intern_read_timeout, value);
   return _mysql_client_options(self, MYSQL_OPT_READ_TIMEOUT, value);
 }
 

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -20,7 +20,7 @@ VALUE cMysql2Client;
 extern VALUE mMysql2, cMysql2Error, cMysql2ConnectionError, cMysql2TimeoutError;
 static VALUE sym_id, sym_version, sym_header_version, sym_async, sym_symbolize_keys, sym_as, sym_array, sym_stream;
 static ID intern_brackets, intern_merge, intern_merge_bang, intern_new_with_args,
-  intern_current_query_options, intern_read_timeout, intern_values;
+  intern_current_query_options, intern_read_timeout, intern_write_timeout, intern_values;
 
 #define REQUIRE_INITIALIZED(wrapper) \
   if (!wrapper->initialized) { \
@@ -2561,27 +2561,66 @@ static VALUE set_connect_timeout(VALUE self, VALUE value) {
   return _mysql_client_options(self, MYSQL_OPT_CONNECT_TIMEOUT, value);
 }
 
+/* call-seq:
+ *    client.read_timeout = seconds
+ *
+ * read_timeout is enforced independently of the underlying client library:
+ * do_query (client.c) re-reads the @read_timeout ivar set here on every
+ * query and bounds the wait with rb_wait_for_single_fd itself, so this is
+ * safe to change on an already-connected client -- unlike every other
+ * mysql_options()-backed setter in this file, it does not need
+ * REQUIRE_NOT_CONNECTED. mysql_options(MYSQL_OPT_READ_TIMEOUT) is still
+ * called pre-connect, for parity with what the client library itself
+ * reports (Client#read_timeout predates this and is unaffected either way),
+ * but it's skipped once connected: neither libmysqlclient nor MariaDB
+ * Connector/C apply it to an established session (both document
+ * mysql_options() as pre-connect-only, and both implementations confirm
+ * it: the call only ever stores a struct field, applied to the live
+ * connection exactly once, during the initial connect sequence), so calling
+ * it here would either raise (REQUIRE_NOT_CONNECTED) or silently do
+ * nothing -- worse than just not calling it. */
 static VALUE set_read_timeout(VALUE self, VALUE value) {
   long int sec;
+  GET_CLIENT(self);
   Check_Type(value, T_FIXNUM);
   sec = FIX2INT(value);
   if (sec < 0) {
     rb_raise(cMysql2Error, "read_timeout must be a positive integer, you passed %ld", sec);
   }
-  /* Set the instance variable here even though _mysql_client_options
-     might not succeed, because the timeout is used in other ways
-     elsewhere */
   rb_ivar_set(self, intern_read_timeout, value);
+  if (CONNECTED(wrapper)) {
+    return value;
+  }
   return _mysql_client_options(self, MYSQL_OPT_READ_TIMEOUT, value);
 }
 
+/* call-seq:
+ *    client.write_timeout = seconds
+ *
+ * Unlike read_timeout, mysql2 has no enforcement mechanism of its own for
+ * writes -- mysql_send_query (client.c) is a single blocking library call
+ * with nothing watching it -- so this is only ever as live as
+ * mysql_options(MYSQL_OPT_WRITE_TIMEOUT) itself, which both client
+ * libraries apply to the live connection exactly once, during the initial
+ * connect (see set_read_timeout above for the same finding). Raise
+ * explicitly on an already-connected client instead of leaving that as an
+ * unexplained REQUIRE_NOT_CONNECTED "connection is already open": there is
+ * no way to make this option live, on either client library, not just a
+ * gap in this one. */
 static VALUE set_write_timeout(VALUE self, VALUE value) {
   long int sec;
+  GET_CLIENT(self);
   Check_Type(value, T_FIXNUM);
   sec = FIX2INT(value);
   if (sec < 0) {
     rb_raise(cMysql2Error, "write_timeout must be a positive integer, you passed %ld", sec);
   }
+  if (CONNECTED(wrapper)) {
+    rb_raise(cMysql2Error, "write_timeout cannot be changed on an already-connected client -- "
+             "neither libmysqlclient nor MariaDB Connector/C apply MYSQL_OPT_WRITE_TIMEOUT to a "
+             "live connection, only at the next connect. Open a new Client instead.");
+  }
+  rb_ivar_set(self, intern_write_timeout, value);
   return _mysql_client_options(self, MYSQL_OPT_WRITE_TIMEOUT, value);
 }
 
@@ -2844,8 +2883,8 @@ void init_mysql2_client(void) {
   rb_define_method(cMysql2Client, "database", rb_mysql_client_database, 0);
 
   rb_define_private_method(cMysql2Client, "connect_timeout=", set_connect_timeout, 1);
-  rb_define_private_method(cMysql2Client, "read_timeout=", set_read_timeout, 1);
-  rb_define_private_method(cMysql2Client, "write_timeout=", set_write_timeout, 1);
+  rb_define_method(cMysql2Client, "read_timeout=", set_read_timeout, 1);
+  rb_define_method(cMysql2Client, "write_timeout=", set_write_timeout, 1);
   rb_define_private_method(cMysql2Client, "local_infile=", set_local_infile, 1);
   rb_define_private_method(cMysql2Client, "charset_name=", set_charset_name, 1);
   rb_define_private_method(cMysql2Client, "secure_auth=", set_secure_auth, 1);
@@ -2880,6 +2919,7 @@ void init_mysql2_client(void) {
   intern_new_with_args = rb_intern("new_with_args");
   intern_current_query_options = rb_intern("@current_query_options");
   intern_read_timeout = rb_intern("@read_timeout");
+  intern_write_timeout = rb_intern("@write_timeout");
   intern_values = rb_intern("values");
 
 #ifdef CLIENT_LONG_PASSWORD

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -1,6 +1,6 @@
 module Mysql2
   class Client
-    attr_reader :query_options, :read_timeout
+    attr_reader :query_options, :read_timeout, :write_timeout
 
     def self.default_query_options
       @default_query_options ||= {
@@ -233,10 +233,42 @@ module Mysql2
     EMPTY_QUERY_OPTIONS = {}.freeze
     private_constant :EMPTY_QUERY_OPTIONS
 
+    # :read_timeout may be overridden for a single query without changing
+    # the connection-wide default: read_timeout= is safe to call on a live
+    # connection (do_query in client.c re-reads the ivar it sets on every
+    # query), so this brackets it around the call and restores the prior
+    # value afterward. Safe under the fiber-ownership guard: only one fiber
+    # can be mid-query on this connection at a time, so nothing else can
+    # observe the temporarily-overridden value.
+    #
+    # :write_timeout has no per-query equivalent -- and no live equivalent
+    # at all, see write_timeout= -- so it's rejected here rather than
+    # silently accepted and ignored, which would look like it worked.
     def query(sql, options = EMPTY_QUERY_OPTIONS)
-      Thread.handle_interrupt(::Mysql2::Util::TIMEOUT_ERROR_NEVER) do
-        _query(sql, @query_options.merge(options))
+      # @query_options.merge(options) is also what raises TypeError for an
+      # explicitly nil/false options argument -- do that first, so the keys
+      # checks below never have to special-case a non-Hash options. Checked
+      # against the raw options argument, not the merged/defaulted opts:
+      # @query_options itself can carry :read_timeout (set at Client.new),
+      # which must not be mistaken for a per-call override on every query.
+      opts = @query_options.merge(options)
+
+      if options.key?(:write_timeout)
+        raise ArgumentError, "write_timeout cannot be set per-query, only at Client.new or via write_timeout= " \
+          "before connecting -- mysql2 has no way to enforce a write deadline on an already-connected client"
       end
+
+      read_timeout_overridden = false
+      if options.key?(:read_timeout)
+        prior_read_timeout = @read_timeout
+        self.read_timeout = options[:read_timeout]
+        read_timeout_overridden = true
+      end
+      Thread.handle_interrupt(::Mysql2::Util::TIMEOUT_ERROR_NEVER) do
+        _query(sql, opts)
+      end
+    ensure
+      @read_timeout = prior_read_timeout if read_timeout_overridden
     end
 
     def query_info

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -1123,6 +1123,71 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     expect(client.read_timeout).to be_nil
   end
 
+  context "read_timeout=/write_timeout= on a live connection" do
+    it "changes read_timeout enforcement mid-session" do
+      client = new_client(read_timeout: 10)
+      client.read_timeout = 1
+
+      start = clock_time
+      expect { client.query("SELECT SLEEP(3)") }.to raise_error(Mysql2::Error::TimeoutError)
+      expect(clock_time - start).to be < 2
+    end
+
+    it "raises when write_timeout is changed on an already-connected client" do
+      # Unlike read_timeout, mysql2 has no enforcement mechanism of its own
+      # for writes; the underlying libraries only apply
+      # MYSQL_OPT_WRITE_TIMEOUT once, during the initial connect (both
+      # libmysqlclient and MariaDB Connector/C -- mysql_options() is
+      # documented as pre-connect-only, and neither implementation reapplies
+      # it to a live session). Raise rather than silently accept a value
+      # that would never take effect.
+      client = new_client
+      expect { client.write_timeout = 5 }.to raise_error(Mysql2::Error, /already-connected/)
+      expect(client.query("SELECT 1 AS one").first).to eql('one' => 1)
+    end
+
+    it "exposes write_timeout set at connect time" do
+      client = new_client(write_timeout: 7)
+      expect(client.write_timeout).to eql(7)
+    end
+  end
+
+  context "#query per-query :read_timeout / :write_timeout" do
+    it "overrides read_timeout for a single query without changing the connection default" do
+      client = new_client(read_timeout: 10)
+
+      start = clock_time
+      expect { client.query("SELECT SLEEP(3)", read_timeout: 1) }.to raise_error(Mysql2::Error::TimeoutError)
+      expect(clock_time - start).to be < 2
+    end
+
+    it "restores the connection's read_timeout after a per-query override, even without a timeout firing" do
+      client = new_client(read_timeout: 10)
+
+      client.query("SELECT SLEEP(1)", read_timeout: 5)
+      expect(client.read_timeout).to eql(10)
+    end
+
+    it "restores the connection's read_timeout after a per-query override raises for another reason" do
+      client = new_client(read_timeout: 10)
+
+      expect { client.query("SELECT 1", read_timeout: -1) }.to raise_error(Mysql2::Error, /positive integer/)
+      expect(client.read_timeout).to eql(10)
+      expect(client.query("SELECT 1 AS one").first).to eql('one' => 1)
+    end
+
+    it "rejects a per-query :write_timeout instead of silently ignoring it" do
+      client = new_client
+      expect { client.query("SELECT 1", write_timeout: 5) }.to raise_error(ArgumentError, /write_timeout/)
+      expect(client.query("SELECT 1 AS one").first).to eql('one' => 1)
+    end
+
+    it "still raises TypeError for an explicit nil options argument" do
+      client = new_client
+      expect { client.query("SELECT 1", nil) }.to raise_error(TypeError)
+    end
+  end
+
   it "should set default program_name in connect_attrs" do
     skip("DON'T WORRY, THIS TEST PASSES - but PERFORMANCE SCHEMA is not enabled in your MySQL daemon.") unless performance_schema_enabled
     client = new_client

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -1125,12 +1125,26 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
 
   context "read_timeout=/write_timeout= on a live connection" do
     it "changes read_timeout enforcement mid-session" do
+      # do_query's ivar-based wait loop (client.c) is #ifndef _WIN32 only;
+      # on Windows read_timeout is enforced purely by whatever
+      # mysql_options() applied at connect, same as write_timeout, and a
+      # live change raises instead -- see the Windows-only spec below.
+      skip "not implemented on Windows -- see set_read_timeout in client.c" if RUBY_PLATFORM =~ /mingw|mswin/
+
       client = new_client(read_timeout: 10)
       client.read_timeout = 1
 
       start = clock_time
       expect { client.query("SELECT SLEEP(3)") }.to raise_error(Mysql2::Error::TimeoutError)
       expect(clock_time - start).to be < 2
+    end
+
+    it "raises when read_timeout is changed on an already-connected client on Windows" do
+      skip "read_timeout=/query(read_timeout:) work live on non-Windows -- see the spec above" unless RUBY_PLATFORM =~ /mingw|mswin/
+
+      client = new_client(read_timeout: 10)
+      expect { client.read_timeout = 1 }.to raise_error(Mysql2::Error, /already-connected/)
+      expect(client.query("SELECT 1 AS one").first).to eql('one' => 1)
     end
 
     it "raises when write_timeout is changed on an already-connected client" do
@@ -1154,6 +1168,8 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
 
   context "#query per-query :read_timeout / :write_timeout" do
     it "overrides read_timeout for a single query without changing the connection default" do
+      skip "not implemented on Windows -- see set_read_timeout in client.c" if RUBY_PLATFORM =~ /mingw|mswin/
+
       client = new_client(read_timeout: 10)
 
       start = clock_time
@@ -1162,10 +1178,21 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     end
 
     it "restores the connection's read_timeout after a per-query override, even without a timeout firing" do
+      skip "not implemented on Windows -- see set_read_timeout in client.c" if RUBY_PLATFORM =~ /mingw|mswin/
+
       client = new_client(read_timeout: 10)
 
       client.query("SELECT SLEEP(1)", read_timeout: 5)
       expect(client.read_timeout).to eql(10)
+    end
+
+    it "raises a per-query :read_timeout on Windows instead of silently not applying it" do
+      skip "read_timeout: works live on non-Windows -- see the specs above" unless RUBY_PLATFORM =~ /mingw|mswin/
+
+      client = new_client(read_timeout: 10)
+      expect { client.query("SELECT 1", read_timeout: 5) }.to raise_error(Mysql2::Error, /already-connected/)
+      expect(client.read_timeout).to eql(10)
+      expect(client.query("SELECT 1 AS one").first).to eql('one' => 1)
     end
 
     it "restores the connection's read_timeout after a per-query override raises for another reason" do


### PR DESCRIPTION
Addresses #955 (per-query `read_timeout` on the synchronous `Client#query` path) and implements the read half of #1540's proposal: public `read_timeout=`/`write_timeout=` on a live connection, matching trilogy's method surface.

Does **not** address #971 -- that issue is specifically about `Mysql2::EM::Client` (`lib/mysql2/em.rb`), which uses `async: true` + `EM.watch` for reactor-based socket monitoring and never goes through `do_query`'s wait-with-timeout mechanism this PR extends. Filing that as separate follow-up work rather than folding it in here.

## What changed

`read_timeout` is enforced entirely by mysql2 itself: `do_query` (`client.c`) re-reads the `@read_timeout` ivar on every query and bounds the wait with `rb_wait_for_single_fd`, independent of anything the underlying client library does. That makes it safe to change on an already-connected client:

```ruby
client.read_timeout = 2
client.ping
client.read_timeout = 600
client.query("...")
```

`read_timeout=` no longer routes through `_mysql_client_options`/`REQUIRE_NOT_CONNECTED` once connected (that call would be inert anyway, see below) and is now a public method. `Client#query` also accepts `:read_timeout` scoped to a single call, bracketing the ivar around that one call and restoring the prior value afterward -- safe under the existing fiber-ownership guard, since only one fiber can be mid-query on a connection at a time:

```ruby
client.query("SELECT ...", read_timeout: 2)
```

`write_timeout` gets the opposite treatment, deliberately: a public getter (new `@write_timeout` ivar, mirroring `read_timeout`'s), but **no** live setter and **no** per-query option, because neither is achievable. mysql2 has no enforcement mechanism of its own for writes -- the query-send is a single blocking library call with nothing watching it -- so it depends entirely on `mysql_options(MYSQL_OPT_WRITE_TIMEOUT)`. I traced the actual implementation of both libmysqlclient and MariaDB Connector/C: both apply this option to the live connection exactly once, during the initial connect sequence (`csm_complete_connect` in `sql-common/client.cc` for MySQL; the equivalent block in `mysql_real_connect` for MariaDB), and `mysql_options()` is documented as callable only between `mysql_init()` and `mysql_real_connect()`. Calling it after connecting doesn't raise on either library -- it just silently stores a value that's never read again for that session. `write_timeout=` now raises explicitly on an already-connected client instead of the previous generic "connection is already open", and `Client#query` raises `ArgumentError` if given `:write_timeout` rather than silently accepting and ignoring an option that would never take effect.

## Relates to #1540

#1540 proposed both halves as a spike (\"read half: small and shippable now... write half: the spike is the work\"). This PR is that spike, completed: the read half ships here, and the write half's answer is that it isn't implementable, not merely unverified -- confirmed by reading the actual source of both client libraries' `mysql_options()` handlers (neither has any connection-state branch at all) and by a real link test showing the one function that *would* apply it live (`my_net_set_write_timeout`) isn't even callable from a C extension on MySQL's library (declared without `extern \"C\"`, compiled as C++, symbol is name-mangled). No raw `setsockopt` workaround exists either -- confirmed via `vio_write`'s actual POSIX implementation, which never consults `SO_SNDTIMEO` at all, relying instead on non-blocking mode plus an internal `poll()`-based wait that mysql2 has no portable way to drive from outside the library.

## Composes with #1565 (kill_on_timeout)

No file overlap with #1565's C changes (that PR touches `do_query`/`rb_mysql_query`/new cancel-handling functions; this one touches only `set_read_timeout`/`set_write_timeout`), but both modify `Client#query` in `lib/mysql2/client.rb`, so whichever lands second will need to interleave the two control-flow changes rather than a mechanical rebase.

The features are complementary, not overlapping in purpose: a per-query `:read_timeout` sets *when* a deadline fires; `:kill_on_timeout` determines *what happens* when it does. Together:

```ruby
client.query("SELECT ...", read_timeout: 2, kill_on_timeout: true)
```

tries this one query with a tight, scoped deadline, without risking the connection if it's hit -- exactly the shape #955's original discussion was circling (a pool wanting a short deadline on some queries without holding a second connection or reconnecting), now actually composable once both land.

## Testing

Full spec suite (634 examples) and rubocop pass clean. New specs cover: live `read_timeout=` actually changing enforcement mid-session; per-query `:read_timeout` firing at the override, not the connection default; the ivar correctly restored after both a non-raising and a raising per-query call; `write_timeout=` raising on a live connection with the connection surviving the raise; `:write_timeout` rejected per-query with the connection surviving; the pre-existing "explicit nil options raises TypeError" behavior preserved.