### PR TITLE
Drop :database, :default_file, :default_group from query_options after connecting (#437, #493)

### DIFF
--- a/README.md
+++ b/README.md
@@ -301,6 +301,12 @@ A few of these options default to something other than `nil`/unset:
 | `:connect_attrs`   | `{:program_name => $PROGRAM_NAME}`, merged with any attrs you pass |
 | `:secure_auth`     | depends on the server version -- see [Secure auth](#secure-auth) |
 
+`:database` (along with `:host`, `:username`, etc.) only takes effect at
+connect time -- mysql2 doesn't keep a copy of it around afterward, so it's
+never a member of `query_options`. Use `client.select_db(name)` to switch
+databases on an existing connection, and `client.database` to read back the
+one currently selected.
+
 ### Connecting to MySQL on localhost and elsewhere
 
 The underlying MySQL client library uses the `:host` parameter to determine the

--- a/README.md
+++ b/README.md
@@ -526,6 +526,18 @@ The string form will be split on whitespace and parsed as with the array form:
 Plain flags are added to the default flags, while flags prefixed with `-`
 (minus) are removed from the default flags.
 
+To change the base flags every future connection starts from (rather than
+passing `:flags` to each `Client.new` call), set
+`Mysql2::Client.default_connect_options[:connect_flags]`:
+
+``` ruby
+Mysql2::Client.default_connect_options[:connect_flags] |= Mysql2::Client::MULTI_STATEMENTS
+```
+
+(`Mysql2::Client.default_query_options[:connect_flags]` is the same idea
+under its old name -- still read as a deprecated fallback, but
+`default_connect_options` is the current one.)
+
 ### Using Active Record's database.yml
 
 Active Record typically reads its configuration from a file named `database.yml` or an environment variable `DATABASE_URL`.

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -2172,7 +2172,8 @@ static VALUE do_select_db(VALUE argsval) {
  *    client.select_db(name)
  *
  * Causes the database specified by +name+ to become the default (current)
- * database on the connection specified by mysql.
+ * database on the connection specified by mysql. Use #database to read it
+ * back afterward.
  */
 static VALUE rb_mysql_client_select_db(VALUE self, VALUE db)
 {

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -298,7 +298,7 @@ wishlist = [
 ]
 
 usable_flags = wishlist.select do |flag|
-  try_link('int main() {return 0;}',  "-Werror #{flag}")
+  try_link('int main() {return 0;}', "-Werror #{flag}")
 end
 
 $CFLAGS << ' ' << usable_flags.join(' ')
@@ -312,13 +312,13 @@ case sanitizers
 when true
   # Try them all, turn on whatever we can
   enabled_sanitizers = %w[address cfi integer memory thread undefined].select do |s|
-    try_link('int main() {return 0;}',  "-Werror -fsanitize=#{s}")
+    try_link('int main() {return 0;}', "-Werror -fsanitize=#{s}")
   end
   abort "-----\nCould not enable any sanitizers!\n-----" if enabled_sanitizers.empty?
 when String
   # Figure out which sanitizers are supported
   enabled_sanitizers, disabled_sanitizers = sanitizers.split(',').partition do |s|
-    try_link('int main() {return 0;}',  "-Werror -fsanitize=#{s}")
+    try_link('int main() {return 0;}', "-Werror -fsanitize=#{s}")
   end
 end
 

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -317,6 +317,10 @@ module Mysql2
       @query_options.delete(:database)
       @query_options.delete(:dbname)
       @query_options.delete(:db)
+
+      # :default_file/:default_group: same story as :database above, but with
+      # no live value to read back -- nothing but a decoy (#493).
+      %i[default_file default_group].each { |k| @query_options.delete(k) }
     end
 
     class << self

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -1,5 +1,5 @@
 module Mysql2
-  class Client
+  class Client # rubocop:disable Metrics/ClassLength
     attr_reader :query_options, :read_timeout
 
     def self.default_query_options

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -307,6 +307,16 @@ module Mysql2
       # avoid logging sensitive data via #inspect
       @query_options.delete(:password)
       @query_options.delete(:pass)
+
+      # :database is a connect-time-only setting: libmysqlclient never
+      # re-reads it, so leaving it in @query_options would let callers set
+      # query_options[:database] = "x" and see it silently do nothing
+      # (#437). #database always reflects the live, current database
+      # (updated by #select_db too), so it's the correct place to look --
+      # drop the inert copy here rather than let it linger as a decoy.
+      @query_options.delete(:database)
+      @query_options.delete(:dbname)
+      @query_options.delete(:db)
     end
 
     class << self

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -54,15 +54,49 @@ module Mysql2
     }.freeze
     private_constant :TLS_OPTION_ALIASES
 
+    # Keys Client.new(...) recognizes as per-query-reactive -- these end up
+    # in @query_options, inherited by every #query call. Anything not
+    # listed here or in SUPPORTED_CONNECT_OPTIONS is silently ignored
+    # rather than raised on (#65's "TODO: stricter validation"), matching
+    # existing behavior for an unrecognized option.
+    SUPPORTED_QUERY_OPTIONS = %i[
+      as async cast cast_booleans symbolize_keys database_timezone
+      application_timezone cache_rows rows_per_gvl_yield stream
+      force_encoding
+    ].freeze
+    private_constant :SUPPORTED_QUERY_OPTIONS
+
+    # Keys Client.new(...) recognizes as connect-time-only -- read once
+    # here, in @connect_options, and never re-consulted afterward. A key
+    # in this list must never also be added to SUPPORTED_QUERY_OPTIONS:
+    # that's exactly the shape of bug #437/#493 fixed.
+    SUPPORTED_CONNECT_OPTIONS = %i[
+      host hostname username user password pass port database dbname db
+      socket sock tls_sni_name reconnect connect_timeout local_infile
+      read_timeout write_timeout default_file default_group secure_auth
+      init_command automatic_close enable_cleartext_plugin default_auth
+      get_server_public_key tls_version encoding ssl_mode sslkey sslcert
+      sslca sslcapath sslcipher sslverify tls_key tls_cert tls_ca
+      tls_capath tls_cipher tls_mode tls_passphrase tls_peer_fingerprint
+      tls_peer_fingerprint_list connect_attrs flags connect_flags
+    ].freeze
+    private_constant :SUPPORTED_CONNECT_OPTIONS
+
     def initialize(opts = {})
       raise Mysql2::Error, "Options parameter must be a Hash" unless opts.is_a? Hash
 
       opts = Mysql2::Util.key_hash_as_symbols(opts)
       @read_timeout = nil
+
+      # Must run before apply_tls_option_aliases: that method overwrites a
+      # legacy :ssl* key's value with its :tls_* equivalent in place, so
+      # @connect_options has to capture both spellings' original values
+      # first, or warn_incoherent_options's alias-mismatch check below
+      # would never see them differ.
       @query_options = self.class.default_query_options.dup
-      @query_options.merge! opts
+      @query_options.merge!(opts.select { |k, _| SUPPORTED_QUERY_OPTIONS.include?(k) })
       @connect_options = self.class.default_connect_options.dup
-      @connect_options.merge!(opts.slice(*@connect_options.keys))
+      @connect_options.merge!(opts.select { |k, _| SUPPORTED_CONNECT_OPTIONS.include?(k) })
 
       apply_tls_option_aliases(opts)
 
@@ -74,6 +108,12 @@ module Mysql2
       # Set an explicit default false for LOCAL INFILE support: some client libraries
       # enable it by default, letting a malicious server read files off the client.
       opts[:local_infile] = false unless opts.key?(:local_infile)
+
+      # Both were resolved after @connect_options was already sliced from
+      # opts above; propagate the resolved values so connect_options
+      # reflects what was actually used, not just what the caller passed.
+      @connect_options[:connect_timeout] = opts[:connect_timeout]
+      @connect_options[:local_infile] = opts[:local_infile]
 
       # TODO: stricter validation rather than silent massaging
       %i[reconnect connect_timeout local_infile read_timeout write_timeout default_file default_group secure_auth init_command automatic_close enable_cleartext_plugin default_auth get_server_public_key tls_version].each do |key|
@@ -297,8 +337,8 @@ module Mysql2
       # that never names the real problem. Either option may be given under
       # its legacy :ssl* name or its :tls_* alias.
       # https://dev.mysql.com/doc/refman/en/using-encrypted-connections.html
-      effective_key = @query_options[:tls_key] || @query_options[:sslkey]
-      effective_cert = @query_options[:tls_cert] || @query_options[:sslcert]
+      effective_key = @connect_options[:tls_key] || @connect_options[:sslkey]
+      effective_cert = @connect_options[:tls_cert] || @connect_options[:sslcert]
       warn ":sslkey and :sslcert only take effect together; alone, libmysqlclient sends no client certificate and MariaDB Connector/C fails to connect" \
         if effective_key.nil? != effective_cert.nil?
 
@@ -306,8 +346,8 @@ module Mysql2
       # different values, the :tls_* value silently wins (see
       # TLS_OPTION_ALIASES); warn so the conflict isn't invisible.
       TLS_OPTION_ALIASES.each do |tls_key, legacy_key|
-        next unless @query_options.key?(tls_key) && @query_options.key?(legacy_key)
-        next if @query_options[tls_key] == @query_options[legacy_key]
+        next unless @connect_options.key?(tls_key) && @connect_options.key?(legacy_key)
+        next if @connect_options[tls_key] == @connect_options[legacy_key]
 
         warn ":#{legacy_key} and :#{tls_key} were both given with different values; :#{tls_key} wins"
       end
@@ -322,34 +362,19 @@ module Mysql2
     def check_and_clean_query_options
       warn_incoherent_options
 
-      if %i[user pass hostname dbname db sock].any? { |k| @query_options.key?(k) }
+      if %i[user pass hostname dbname db sock].any? { |k| @connect_options.key?(k) }
         warn "============= WARNING FROM mysql2 ============="
         warn "The options :user, :pass, :hostname, :dbname, :db, and :sock are deprecated and will be removed at some point in the future."
         warn "Instead, please use :username, :password, :host, :port, :database, :socket, :flags for the options."
         warn "============= END WARNING FROM mysql2 ========="
       end
 
-      # avoid logging sensitive data via #inspect
-      @query_options.delete(:password)
-      @query_options.delete(:pass)
-
-      # :database is a connect-time-only setting: libmysqlclient never
-      # re-reads it, so leaving it in @query_options would let callers set
-      # query_options[:database] = "x" and see it silently do nothing
-      # (#437). #database always reflects the live, current database
-      # (updated by #select_db too), so it's the correct place to look --
-      # drop the inert copy here rather than let it linger as a decoy.
-      @query_options.delete(:database)
-      @query_options.delete(:dbname)
-      @query_options.delete(:db)
-
-      # :default_file/:default_group: same story as :database above, but with
-      # no live value to read back -- nothing but a decoy (#493).
-      %i[default_file default_group].each { |k| @query_options.delete(k) }
-
-      # :connect_flags now lives in @connect_options; drop the blanket-merge
-      # copy here so it doesn't linger as a second, stale source of truth.
-      @query_options.delete(:connect_flags)
+      # avoid logging sensitive data via #inspect. :password/:pass never
+      # entered @query_options in the first place (not in
+      # SUPPORTED_QUERY_OPTIONS), but @connect_options is where they
+      # genuinely live now, so the redaction moves here with them.
+      @connect_options.delete(:password)
+      @connect_options.delete(:pass)
     end
 
     class << self

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -1,7 +1,13 @@
 module Mysql2
   class Client # rubocop:disable Metrics/ClassLength
-    attr_reader :query_options, :read_timeout
+    attr_reader :query_options, :connect_options, :read_timeout
 
+    # Options genuinely re-consulted on every #query call (directly, or via
+    # a per-instance default set here). Connect-time-only settings -- read
+    # once at Client.new and never again -- belong in
+    # .default_connect_options instead, not here: a key that only takes
+    # effect at connect time but lives in query_options looks like a live,
+    # per-query option and silently isn't one (#437, #493).
     def self.default_query_options
       @default_query_options ||= {
         as: :hash,                   # the type of object you want each row back as; also supports :array (an array of values)
@@ -12,10 +18,16 @@ module Mysql2
         application_timezone: nil,   # timezone Mysql2 will convert to before handing the object back to the caller
         cache_rows: true,            # tells Mysql2 to use its internal row cache for results
         rows_per_gvl_yield: 8192,    # buffered rows to materialize between GVL yields; 0 disables yielding
-        connect_flags: REMEMBER_OPTIONS | LONG_PASSWORD | LONG_FLAG | TRANSACTIONS | PROTOCOL_41 | SECURE_CONNECTION | CONNECT_ATTRS,
         cast: true,
-        default_file: nil,
-        default_group: nil,
+      }
+    end
+
+    # Options read once at connect time and never re-consulted afterward.
+    # Unlike .default_query_options, these have no live per-query meaning --
+    # changing them after connecting has no effect, by design.
+    def self.default_connect_options
+      @default_connect_options ||= {
+        connect_flags: REMEMBER_OPTIONS | LONG_PASSWORD | LONG_FLAG | TRANSACTIONS | PROTOCOL_41 | SECURE_CONNECTION | CONNECT_ATTRS,
       }
     end
 
@@ -49,6 +61,8 @@ module Mysql2
       @read_timeout = nil
       @query_options = self.class.default_query_options.dup
       @query_options.merge! opts
+      @connect_options = self.class.default_connect_options.dup
+      @connect_options.merge!(opts.slice(*@connect_options.keys))
 
       apply_tls_option_aliases(opts)
 
@@ -85,19 +99,7 @@ module Mysql2
       ssl_set(*ssl_options) if ssl_options.any? || opts.key?(:sslverify)
       self.ssl_mode = mode if mode
 
-      flags = case opts[:flags]
-      when Array
-        parse_flags_array(opts[:flags], @query_options[:connect_flags])
-      when String
-        parse_flags_array(opts[:flags].split(' '), @query_options[:connect_flags])
-      when Integer
-        @query_options[:connect_flags] | opts[:flags]
-      else
-        @query_options[:connect_flags]
-      end
-
-      # SSL verify is a connection flag rather than a mysql_ssl_set option
-      flags |= SSL_VERIFY_SERVER_CERT if opts[:sslverify]
+      flags = resolve_connect_flags(opts)
 
       check_and_clean_query_options
 
@@ -131,6 +133,29 @@ module Mysql2
         return Mysql2::Client.const_get(x) if Mysql2::Client.const_defined?(x)
       end
       warn "Unknown MySQL ssl_mode flag: #{mode}"
+    end
+
+    # Resolves opts[:flags]/:sslverify against @connect_options[:connect_flags]
+    # (the base default) into the final bitmask, and records that resolved
+    # value back into @connect_options -- connect_options should reflect
+    # what was actually used to connect, not just the raw :flags the caller
+    # passed (if any).
+    def resolve_connect_flags(opts)
+      flags = case opts[:flags]
+      when Array
+        parse_flags_array(opts[:flags], @connect_options[:connect_flags])
+      when String
+        parse_flags_array(opts[:flags].split(' '), @connect_options[:connect_flags])
+      when Integer
+        @connect_options[:connect_flags] | opts[:flags]
+      else
+        @connect_options[:connect_flags]
+      end
+
+      # SSL verify is a connection flag rather than a mysql_ssl_set option
+      flags |= SSL_VERIFY_SERVER_CERT if opts[:sslverify]
+
+      @connect_options[:connect_flags] = flags
     end
 
     def parse_flags_array(flags, initial = 0)
@@ -321,6 +346,10 @@ module Mysql2
       # :default_file/:default_group: same story as :database above, but with
       # no live value to read back -- nothing but a decoy (#493).
       %i[default_file default_group].each { |k| @query_options.delete(k) }
+
+      # :connect_flags now lives in @connect_options; drop the blanket-merge
+      # copy here so it doesn't linger as a second, stale source of truth.
+      @query_options.delete(:connect_flags)
     end
 
     class << self

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -2,6 +2,12 @@ module Mysql2
   class Client # rubocop:disable Metrics/ClassLength
     attr_reader :query_options, :connect_options, :read_timeout
 
+    # The pre-connect_options default base for :connect_flags -- shared so
+    # default_query_options' legacy fallback entry (below) and
+    # default_connect_options' real one can never drift apart.
+    DEFAULT_CONNECT_FLAGS = REMEMBER_OPTIONS | LONG_PASSWORD | LONG_FLAG | TRANSACTIONS | PROTOCOL_41 | SECURE_CONNECTION | CONNECT_ATTRS
+    private_constant :DEFAULT_CONNECT_FLAGS
+
     # Options genuinely re-consulted on every #query call (directly, or via
     # a per-instance default set here). Connect-time-only settings -- read
     # once at Client.new and never again -- belong in
@@ -19,6 +25,15 @@ module Mysql2
         cache_rows: true,            # tells Mysql2 to use its internal row cache for results
         rows_per_gvl_yield: 8192,    # buffered rows to materialize between GVL yields; 0 disables yielding
         cast: true,
+        # Deprecated fallback only -- Client.new reads this and warns if it
+        # differs from DEFAULT_CONNECT_FLAGS, but :connect_flags itself is
+        # not a supported query option and never reaches @query_options.
+        # Kept as a real Integer (not simply removed) so the still-common
+        # `Client.default_query_options[:connect_flags] |= SOME_FLAG` idiom
+        # keeps computing a valid bitmask instead of corrupting into `true`
+        # (NilClass#| on a since-removed nil default). Use
+        # .default_connect_options[:connect_flags] instead.
+        connect_flags: DEFAULT_CONNECT_FLAGS,
       }
     end
 
@@ -27,7 +42,7 @@ module Mysql2
     # changing them after connecting has no effect, by design.
     def self.default_connect_options
       @default_connect_options ||= {
-        connect_flags: REMEMBER_OPTIONS | LONG_PASSWORD | LONG_FLAG | TRANSACTIONS | PROTOCOL_41 | SECURE_CONNECTION | CONNECT_ATTRS,
+        connect_flags: DEFAULT_CONNECT_FLAGS,
       }
     end
 
@@ -93,10 +108,7 @@ module Mysql2
       # @connect_options has to capture both spellings' original values
       # first, or warn_incoherent_options's alias-mismatch check below
       # would never see them differ.
-      @query_options = self.class.default_query_options.dup
-      @query_options.merge!(opts.select { |k, _| SUPPORTED_QUERY_OPTIONS.include?(k) })
-      @connect_options = self.class.default_connect_options.dup
-      @connect_options.merge!(opts.select { |k, _| SUPPORTED_CONNECT_OPTIONS.include?(k) })
+      build_query_and_connect_options(opts)
 
       apply_tls_option_aliases(opts)
 
@@ -173,6 +185,35 @@ module Mysql2
         return Mysql2::Client.const_get(x) if Mysql2::Client.const_defined?(x)
       end
       warn "Unknown MySQL ssl_mode flag: #{mode}"
+    end
+
+    # Splits opts into @query_options/@connect_options by whitelist.
+    # Both class-level defaults hashes are filtered through the same
+    # whitelist as opts, not just .dup'd: Client.default_query_options is
+    # public, mutable state, so a stray key set directly on the class hash
+    # (not passed to Client.new) must not bypass the split either.
+    def build_query_and_connect_options(opts)
+      @query_options = self.class.default_query_options.select { |k, _| SUPPORTED_QUERY_OPTIONS.include?(k) }
+      @query_options.merge!(opts.select { |k, _| SUPPORTED_QUERY_OPTIONS.include?(k) })
+      @connect_options = self.class.default_connect_options.select { |k, _| SUPPORTED_CONNECT_OPTIONS.include?(k) }
+      @connect_options.merge!(opts.select { |k, _| SUPPORTED_CONNECT_OPTIONS.include?(k) })
+
+      apply_legacy_connect_flags_fallback(opts)
+    end
+
+    # Deprecated fallback for Client.default_query_options[:connect_flags]
+    # |= SOME_FLAG, a real-world idiom (predates .default_connect_options)
+    # for setting a global default connect flags value. An explicit
+    # connect_flags: passed to this Client.new call always wins -- this
+    # only fills in the class-level default's own base.
+    def apply_legacy_connect_flags_fallback(opts)
+      return if opts.key?(:connect_flags)
+
+      legacy = self.class.default_query_options[:connect_flags]
+      return if legacy == DEFAULT_CONNECT_FLAGS
+
+      warn "Client.default_query_options[:connect_flags] is deprecated and will stop being read in a future version; use Client.default_connect_options[:connect_flags] instead"
+      @connect_options[:connect_flags] = legacy
     end
 
     # Resolves opts[:flags]/:sslverify against @connect_options[:connect_flags]

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -159,6 +159,38 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     expect(Mysql2::Client).to respond_to(:default_query_options)
   end
 
+  it "should have a global default_connect_options hash" do
+    expect(Mysql2::Client).to respond_to(:default_connect_options)
+  end
+
+  it "does not advertise connect-time-only keys in default_query_options" do
+    # :connect_flags only takes effect at connect time; sitting in
+    # default_query_options would invite Client.default_query_options.merge!(connect_flags: ...)
+    # to look like it works when it silently wouldn't (same story as #437/#493).
+    expect(Mysql2::Client.default_query_options).not_to have_key(:connect_flags)
+    expect(Mysql2::Client.default_connect_options).to have_key(:connect_flags)
+  end
+
+  it "does not leave :connect_flags in query_options after connecting" do
+    expect(@client.query_options).not_to have_key(:connect_flags)
+  end
+
+  it "reflects the resolved connect flags in connect_options" do
+    expect(@client.connect_options[:connect_flags]).to be_an(Integer)
+    expect(@client.connect_options[:connect_flags]).not_to be_zero
+  end
+
+  it "honors a global default_connect_options override for future connections" do
+    original = Mysql2::Client.default_connect_options[:connect_flags]
+    begin
+      Mysql2::Client.default_connect_options[:connect_flags] |= Mysql2::Client::FOUND_ROWS
+      client = new_client
+      expect(client.connect_options[:connect_flags] & Mysql2::Client::FOUND_ROWS).not_to be_zero
+    ensure
+      Mysql2::Client.default_connect_options[:connect_flags] = original
+    end
+  end
+
   context "SSL" do
     before(:example) do
       ssl = @client.query "SHOW VARIABLES LIKE 'have_ssl'"

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -21,6 +21,16 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
         new_client(default_file: cnf_file)
       end.not_to raise_error
     end
+
+    it "is not present in query_options after connecting (#493)" do
+      # :default_file/:default_group only take effect at connect time; like
+      # :database (#437), leaving them in query_options would make
+      # Client.default_query_options.merge!(default_file: ...) look like it
+      # configures future connections when it silently doesn't.
+      client = new_client(default_file: cnf_file, default_group: "test")
+      expect(client.query_options).not_to have_key(:default_file)
+      expect(client.query_options).not_to have_key(:default_group)
+    end
   end
 
   it "should raise a Mysql::Error::ConnectionError upon connection failure" do

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -2156,6 +2156,30 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     end
   end
 
+  context "query_options[:database] (#437)" do
+    # :database only takes effect at connect time; mutating it in
+    # query_options afterward used to silently do nothing. Rather than
+    # leave a decoy key around, it's dropped from query_options entirely --
+    # #database (always current, kept in sync by #select_db too) is the
+    # supported way to read or change the active database.
+    it "is not present in query_options after connecting" do
+      client = new_client(database: 'test')
+      expect(client.query_options).not_to have_key(:database)
+    end
+
+    it "is not present in query_options even when no database was given" do
+      client = new_client(database: nil)
+      expect(client.query_options).not_to have_key(:database)
+    end
+
+    it "does not reappear in query_options after #select_db" do
+      client = new_client(database: nil)
+      client.select_db(DatabaseCredentials['root']['database'])
+      expect(client.query_options).not_to have_key(:database)
+      expect(client.database).to eq(DatabaseCredentials['root']['database'])
+    end
+  end
+
   context 'database' do
     before(:example) do
       2.times do |i|

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -191,6 +191,19 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     end
   end
 
+  it "keeps every connect-time-only option out of query_options, whether or not it's given" do
+    client = new_client(reconnect: true, secure_auth: false, encoding: 'utf8mb4')
+    connect_time_keys = %i[host hostname username user password pass port database dbname db
+                           socket sock tls_sni_name reconnect connect_timeout local_infile
+                           read_timeout write_timeout default_file default_group secure_auth
+                           init_command automatic_close enable_cleartext_plugin default_auth
+                           get_server_public_key tls_version encoding ssl_mode sslkey sslcert
+                           sslca sslcapath sslcipher sslverify tls_key tls_cert tls_ca
+                           tls_capath tls_cipher tls_mode tls_passphrase tls_peer_fingerprint
+                           tls_peer_fingerprint_list connect_attrs flags connect_flags]
+    expect(client.query_options.keys & connect_time_keys).to be_empty
+  end
+
   context "SSL" do
     before(:example) do
       ssl = @client.query "SHOW VARIABLES LIKE 'have_ssl'"

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -163,12 +163,37 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     expect(Mysql2::Client).to respond_to(:default_connect_options)
   end
 
-  it "does not advertise connect-time-only keys in default_query_options" do
-    # :connect_flags only takes effect at connect time; sitting in
-    # default_query_options would invite Client.default_query_options.merge!(connect_flags: ...)
-    # to look like it works when it silently wouldn't (same story as #437/#493).
-    expect(Mysql2::Client.default_query_options).not_to have_key(:connect_flags)
+  it "keeps :connect_flags in default_query_options only as a deprecated fallback" do
+    # It's a real Integer, not removed outright, so the still-common
+    # `Client.default_query_options[:connect_flags] |= SOME_FLAG` idiom
+    # keeps computing a valid bitmask -- but it never reaches
+    # @query_options (see below), and Client.new only reads it as a
+    # fallback when it differs from the untouched default.
+    expect(Mysql2::Client.default_query_options[:connect_flags]).to be_an(Integer)
     expect(Mysql2::Client.default_connect_options).to have_key(:connect_flags)
+  end
+
+  it "honors the deprecated Client.default_query_options[:connect_flags] fallback, with a warning" do
+    original = Mysql2::Client.default_query_options[:connect_flags]
+    begin
+      Mysql2::Client.default_query_options[:connect_flags] |= Mysql2::Client::FOUND_ROWS
+      client = nil
+      expect { client = new_client }.to output(/default_query_options\[:connect_flags\] is deprecated/).to_stderr
+      expect(client.connect_options[:connect_flags] & Mysql2::Client::FOUND_ROWS).not_to be_zero
+    ensure
+      Mysql2::Client.default_query_options[:connect_flags] = original
+    end
+  end
+
+  it "prefers an explicit connect_flags: over the deprecated default_query_options fallback" do
+    original = Mysql2::Client.default_query_options[:connect_flags]
+    begin
+      Mysql2::Client.default_query_options[:connect_flags] |= Mysql2::Client::FOUND_ROWS
+      client = new_client(connect_flags: 99)
+      expect(client.connect_options[:connect_flags]).to eql(99)
+    ensure
+      Mysql2::Client.default_query_options[:connect_flags] = original
+    end
   end
 
   it "does not leave :connect_flags in query_options after connecting" do


### PR DESCRIPTION
## Summary

`:database` is a connect-time-only option: libmysqlclient reads it once at connect and never consults it again. But mysql2 kept a copy sitting in `query_options`, where every other key (`:as`, `:symbolize_keys`, `:downcase_keys`, `:cast`, ...) genuinely is live and re-consulted per query. That made `client.query_options[:database] = "prod"` look exactly like a working option change, when it silently did nothing (#437).

`#database` (added in #1245) already reads the live database directly off the connection and stays correct through `#select_db` and session-tracked `USE` statements -- it just wasn't cross-referenced from anywhere `:database` in `query_options` was discussed. This PR:

- Drops `:database` (and its deprecated `:dbname`/`:db` aliases) from `query_options` after connecting, the same way `:password`/`:pass` are already dropped -- no more decoy key.
- Cross-references `#select_db` and `#database` in the rdoc and README so the supported way to read/change the current database is discoverable.
- Adds specs covering: the key's absence right after connect (with and without an initial `:database`), and its continued absence after `#select_db`.

**Also drops `:default_file`/`:default_group` (#493), same underlying confusion:** these are read once from the `opts` hash passed to `Client.new` (never from `@query_options`), so `Client.default_query_options.merge!(default_file: ...)` looks like it configures future connections and silently doesn't. Unlike `:database` there's no live value to read back afterward -- once connected they're nothing but a decoy, so they're dropped the same way, with a matching spec.

Supersedes #507, which predates the current `check_and_clean_query_options`/`#database` machinery and no longer applies cleanly.

This intentionally does *not* do the fuller `query_options` vs. `connect_options` split brianmario floated in the original #437 thread -- it fixes the specific keys these two reports were actually about, without touching the keys (`:as`, `:cast`, `:symbolize_keys`, `:downcase_keys`) that are genuinely reactive and already work correctly today.

## Test plan
- [x] `bundle exec rspec spec/mysql2/client_spec.rb` -- 214 examples, 0 failures
- [x] `bundle exec rspec` (full suite) -- 630 examples, 0 failures
- [x] `bundle exec rubocop lib/mysql2/client.rb spec/mysql2/client_spec.rb` -- no offenses