### PR TITLE
Support :read_timeout on Mysql2::EM::Client, and discard on timeout

### DIFF
--- a/lib/mysql2/em.rb
+++ b/lib/mysql2/em.rb
@@ -37,12 +37,50 @@ module Mysql2
         super(*args)
       end
 
+      def discard!(*args)
+        @watch.detach if @watch && @watch.watching?
+
+        super(*args)
+      end
+
       def query(sql, opts = {})
         if ::EM.reactor_running?
           super(sql, opts.merge(async: true))
           deferable = ::EM::DefaultDeferrable.new
           @watch = ::EM.watch(socket, Watcher, self, deferable)
           @watch.notify_readable = true
+
+          # :read_timeout has no effect on the synchronous wait mysql2 does
+          # for a normal query (there is none here -- the whole point of
+          # the async: true send above is that nothing blocks waiting for
+          # the server), so it's applied here instead, as a timer on the
+          # deferable.
+          if @read_timeout
+            timeout_error = Mysql2::Error::TimeoutError.new(
+              "Timeout waiting for a response from the last query. (waited #{@read_timeout} seconds)",
+            )
+            deferable.timeout(@read_timeout, timeout_error)
+            deferable.errback do |err|
+              # Only for the timeout above, identified by object identity --
+              # not any other failure. A real query error already reaches
+              # here via Watcher#notify_readable, which detaches @watch and
+              # fails the deferable with the actual exception; that path
+              # completed a full round trip and leaves the connection fine
+              # to reuse, same as a synchronous query error. A timeout is
+              # different: the async read this method started never
+              # completed, @watch is still registered, and a response may
+              # still arrive late and be read as the reply to whatever
+              # query runs next on this connection. Discard the connection
+              # outright (which also detaches the now-orphaned watch, see
+              # the override above) -- same reasoning as the synchronous
+              # read_timeout path sacrificing the connection, and discard!
+              # rather than close because sending a real QUIT on a
+              # connection with an unread response in flight isn't safe
+              # either.
+              discard! if err.equal?(timeout_error)
+            end
+          end
+
           deferable
         else
           super(sql, opts)

--- a/spec/em/em_spec.rb
+++ b/spec/em/em_spec.rb
@@ -109,6 +109,59 @@ begin
       end
     end
 
+    context ':read_timeout' do
+      it "fails the deferable with Mysql2::Error::TimeoutError when the server doesn't respond in time" do
+        errors = []
+        EM.run do
+          client = Mysql2::EM::Client.new DatabaseCredentials['root'].merge(read_timeout: 1)
+          defer = client.query "SELECT SLEEP(3)"
+          defer.callback do
+            # This _shouldn't_ be run, but it is needed to prevent the specs
+            # from freezing if this test fails.
+            EM.stop_event_loop
+          end
+          defer.errback do |err|
+            errors << err
+            EM.stop_event_loop
+          end
+        end
+        expect(errors.length).to eq(1)
+        expect(errors.first).to be_a(Mysql2::Error::TimeoutError)
+      end
+
+      it "discards the connection after a timeout, rather than leaving a pending response to desync the next query" do
+        client = Mysql2::EM::Client.new DatabaseCredentials['root'].merge(read_timeout: 1)
+        EM.run do
+          defer = client.query "SELECT SLEEP(3)"
+          defer.errback { EM.stop_event_loop }
+          defer.callback { EM.stop_event_loop }
+        end
+        expect(client.closed?).to be true
+      end
+
+      it "leaves the connection usable after a real query error (not a timeout)" do
+        client = Mysql2::EM::Client.new DatabaseCredentials['root'].merge(read_timeout: 5)
+        errors = []
+        results = []
+        EM.run do
+          defer = client.query "SELECT * FROM this_table_does_not_exist"
+          defer.errback do |err|
+            errors << err
+            defer2 = client.query "SELECT 1 AS one"
+            defer2.callback do |result|
+              results << result.first
+              client.close
+              EM.stop_event_loop
+            end
+          end
+          defer.callback { EM.stop_event_loop }
+        end
+        expect(errors.length).to eq(1)
+        expect(errors.first).not_to be_a(Mysql2::Error::TimeoutError)
+        expect(results).to eq([{ "one" => 1 }])
+      end
+    end
+
     it "should not raise error when closing client with no query running" do
       callbacks_run = []
       EM.run do


### PR DESCRIPTION
Adopts the approach from #971 (2018, never merged): `read_timeout` was silently ignored on the async EventMachine path, since it's only checked by the synchronous wait mysql2 does for a normal query -- and there is no such wait here, that's the whole point of sending the query with `async: true`. This applies it as an `EM::Deferrable#timeout` instead, same core idea as #971.

Differs from #971 in two ways:

- Raises `Mysql2::Error::TimeoutError`, not a bespoke `Mysql2::EM::ReadTimeout`, so it's consistent with the synchronous path and catchable the same way regardless of which one a query happened to run through.

- **Discards the connection when the timeout fires, which #971 never did.** Firing the deferable's errback only tells the caller the query failed -- it does nothing to the connection itself. The async read is still pending at the C level and `@watch` is still registered with the reactor, so if the server's response arrives late, it lands as the reply to whatever query runs next on this connection: a silent protocol desync. The synchronous path avoids this by sacrificing the connection on a plain `read_timeout` (absent `kill_on_timeout`); there's no EM-equivalent escalation, so the same sacrifice happens here, via `discard!` rather than `close` -- a real QUIT isn't safe to send while a stale response may still be in flight. The `discard!` call is gated by comparing the failed deferable's error against the exact `timeout_error` instance passed to `EM::Deferrable#timeout` (object identity, not class), so a real query error -- which already reaches the errback via `Watcher#notify_readable`, having completed a full round trip -- is left alone and the connection stays usable, same as before this change.

Also adds a `discard!` override alongside the existing `close` override, for the same reason `close` needs one: a caller invoking either directly while `@watch` is still registered needs it detached first.

## Scope

Intentionally minimal and self-contained to `lib/mysql2/em.rb` -- no changes to the synchronous path or the C extension.

## Testing

Full spec suite (629 examples) and rubocop pass clean. New specs cover:
- Timeout actually raises `Mysql2::Error::TimeoutError`.
- Connection is `closed?` after a timeout fires.
- A real (non-timeout) query error leaves the connection usable, same as before this change.

Fixes #971