### PR TITLE
Disable LOCAL INFILE by default (#1127)

### DIFF
--- a/README.md
+++ b/README.md
@@ -290,8 +290,16 @@ Mysql2::Client.new(
   )
 ```
 
-`:local_infile` defaults to `false`. Pass `:local_infile => true` to opt in
-if you need it.
+A few of these options default to something other than `nil`/unset:
+
+| Option            | Default                                                    |
+| ----------------- | ----------------------------------------------------------- |
+| `:connect_timeout` | `120` seconds                                               |
+| `:reconnect`       | `false`                                                      |
+| `:local_infile`    | `false`                                                      |
+| `:encoding`        | `'utf8mb4'`                                                  |
+| `:connect_attrs`   | `{:program_name => $PROGRAM_NAME}`, merged with any attrs you pass |
+| `:secure_auth`     | depends on the server version -- see [Secure auth](#secure-auth) |
 
 ### Connecting to MySQL on localhost and elsewhere
 

--- a/README.md
+++ b/README.md
@@ -290,11 +290,8 @@ Mysql2::Client.new(
   )
 ```
 
-`:local_infile` defaults to `false`. Left to the client library's own
-default, `LOAD DATA LOCAL INFILE` is typically enabled, which lets a
-malicious or compromised server read arbitrary files off the client
-machine. Pass `:local_infile => true` to opt back in if you actually use
-it.
+`:local_infile` defaults to `false`. Pass `:local_infile => true` to opt in
+if you need it.
 
 ### Connecting to MySQL on localhost and elsewhere
 

--- a/README.md
+++ b/README.md
@@ -290,6 +290,12 @@ Mysql2::Client.new(
   )
 ```
 
+`:local_infile` defaults to `false`. Left to the client library's own
+default, `LOAD DATA LOCAL INFILE` is typically enabled, which lets a
+malicious or compromised server read arbitrary files off the client
+machine. Pass `:local_infile => true` to opt back in if you actually use
+it.
+
 ### Connecting to MySQL on localhost and elsewhere
 
 The underlying MySQL client library uses the `:host` parameter to determine the

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -57,11 +57,8 @@ module Mysql2
       # Set default connect_timeout to avoid unlimited retries from signal interruption
       opts[:connect_timeout] = 120 unless opts.key?(:connect_timeout)
 
-      # LOCAL INFILE defaults to disabled: left to the client library's own
-      # default, it's typically enabled, and a server (or a MITM ahead of a
-      # non-verified TLS connection) can abuse LOAD DATA LOCAL INFILE to read
-      # arbitrary files off the client (#1127). Callers who need it must ask
-      # for it explicitly with :local_infile => true.
+      # Set an explicit default false for LOCAL INFILE support: some client libraries
+      # enable it by default, letting a malicious server read files off the client.
       opts[:local_infile] = false unless opts.key?(:local_infile)
 
       # TODO: stricter validation rather than silent massaging

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -57,6 +57,13 @@ module Mysql2
       # Set default connect_timeout to avoid unlimited retries from signal interruption
       opts[:connect_timeout] = 120 unless opts.key?(:connect_timeout)
 
+      # LOCAL INFILE defaults to disabled: left to the client library's own
+      # default, it's typically enabled, and a server (or a MITM ahead of a
+      # non-verified TLS connection) can abuse LOAD DATA LOCAL INFILE to read
+      # arbitrary files off the client (#1127). Callers who need it must ask
+      # for it explicitly with :local_infile => true.
+      opts[:local_infile] = false unless opts.key?(:local_infile)
+
       # TODO: stricter validation rather than silent massaging
       %i[reconnect connect_timeout local_infile read_timeout write_timeout default_file default_group secure_auth init_command automatic_close enable_cleartext_plugin default_auth get_server_public_key tls_version].each do |key|
         next unless opts.key?(key)

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -1081,7 +1081,7 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       end.to raise_error(Mysql2::Error, /command is not allowed/)
     end
 
-    it "is disabled by default when :local_infile is not given (#1127)" do
+    it "is disabled by default when :local_infile is not given" do
       client = new_client
       expect do
         client.query "LOAD DATA LOCAL INFILE 'spec/test_data' INTO TABLE infileTest"

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -1081,6 +1081,13 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       end.to raise_error(Mysql2::Error, /command is not allowed/)
     end
 
+    it "is disabled by default when :local_infile is not given (#1127)" do
+      client = new_client
+      expect do
+        client.query "LOAD DATA LOCAL INFILE 'spec/test_data' INTO TABLE infileTest"
+      end.to raise_error(Mysql2::Error, /command is not allowed/)
+    end
+
     it "should raise an error when a non-existent file is loaded" do
       client = new_client(local_infile: true)
       expect do


### PR DESCRIPTION
## Summary

`:local_infile` was only ever set explicitly -- if a caller didn't pass it, mysql2 never called `mysql_options(MYSQL_OPT_LOCAL_INFILE, ...)` at all, leaving the setting at whatever the underlying client library defaults to (typically enabled). That means `LOAD DATA LOCAL INFILE` was reachable by default, which a malicious or compromised server can [abuse to read arbitrary files off the client](https://dev.mysql.com/doc/refman/8.0/en/load-data-local-security.html).

This defaults `:local_infile` to `false` (mirroring how `:connect_timeout` already gets a default filled into `opts` before the option-application loop), unless a caller explicitly opts in with `:local_infile => true`.

## Test plan
- [x] `bundle exec rspec spec/mysql2/client_spec.rb` -- 208 examples, 0 failures (added a spec asserting LOCAL INFILE is rejected when `:local_infile` isn't given at all)
- [x] `bundle exec rspec` (full suite) -- 627 examples, 0 failures
- [x] `bundle exec rubocop lib/mysql2/client.rb spec/mysql2/client_spec.rb` -- no offenses