### PR TITLE
Detect a server-killed connection in #closed?, via a portable peek

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -627,6 +627,36 @@ static void invalidate_socket(mysql_client_wrapper *wrapper)
     wrapper->client->net.fd = -1;
   }
 }
+
+/* Whether the peer has cleanly closed the TCP connection (a graceful FIN --
+ * another session's KILL, wait_timeout expiring server-side, a proxy or
+ * load balancer dropping an idle connection) without mysql2 or the client
+ * library having done anything yet to notice: CONNECTED() only checks that
+ * a vio/fd exists, not that the peer is actually still there, so closed?
+ * can report false right up until the next real command happens to fail.
+ *
+ * A single-byte non-blocking peek: MSG_PEEK leaves any real data
+ * untouched, which is safe here because this is only ever called from an
+ * idle-connection check (closed?), never while a query's response is
+ * actually expected. MSG_DONTWAIT makes it non-blocking regardless of the
+ * socket's own blocking mode, so this can't stall the caller. recv()
+ * returning 0 is the standard EOF signal for a clean peer close; EAGAIN/
+ * EWOULDBLOCK means nothing is waiting to be read, the ordinary idle
+ * state -- both are cheap, common outcomes on every call. Actual queued
+ * data, or any other error, is treated as still-connected rather than
+ * guessed at: this exists to catch the common, unambiguous dead case
+ * promptly, not to be the sole authority on liveness. A connection that's
+ * broken in some other way still surfaces on the next real command,
+ * exactly as it does today without this check. */
+static bool mysql2_socket_peer_closed(int fd) {
+  char buf[1];
+  ssize_t n;
+
+  if (fd < 0) return false;
+
+  n = recv(fd, buf, 1, MSG_PEEK | MSG_DONTWAIT);
+  return n == 0;
+}
 #endif /* _WIN32 */
 
 void mysql2_enqueue_pending_stmt_close(mysql_client_wrapper *wrapper, MYSQL_STMT *stmt, uintptr_t wrapper_key)
@@ -1306,7 +1336,16 @@ static VALUE rb_mysql_client_close(VALUE self) {
  */
 static VALUE rb_mysql_client_closed(VALUE self) {
   GET_CLIENT(self);
-  return CONNECTED(wrapper) ? Qfalse : Qtrue;
+  if (!CONNECTED(wrapper)) return Qtrue;
+#ifndef _WIN32
+  /* CONNECTED() alone only confirms a vio/fd exists, not that the peer is
+   * still there -- see mysql2_socket_peer_closed. Scoped to closed? rather
+   * than folded into CONNECTED()/REQUIRE_CONNECTED generally: this is a
+   * real recv() syscall, unlike the rest of that check, and
+   * REQUIRE_CONNECTED runs on every command. */
+  if (mysql2_socket_peer_closed(wrapper->client->net.fd)) return Qtrue;
+#endif
+  return Qfalse;
 }
 
 /* call-seq:

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -877,20 +877,21 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       expect(@client.closed?).to eql(true)
     end
 
-    # The peer-closed peek behind this is POSIX-only (see mysql2_socket_peer_closed,
-    # ext/mysql2/client.c); closed? on Windows still only checks CONNECTED(),
-    # unchanged, so a server-side KILL isn't detected without a further command.
-    unless RUBY_PLATFORM =~ /mingw|mswin/
-      it "should detect a connection killed server-side, without waiting for a command to fail" do
-        supervisor = new_client
-        connection_id = @client.thread_id
-        supervisor.query("KILL #{connection_id}")
+    it "should detect a connection killed server-side, without waiting for a command to fail" do
+      # The peer-closed peek behind this is POSIX-only (see
+      # mysql2_socket_peer_closed, ext/mysql2/client.c); closed? on Windows
+      # still only checks CONNECTED(), unchanged, so a server-side KILL
+      # isn't detected without a further command.
+      skip "not implemented on Windows -- see mysql2_socket_peer_closed in client.c" if RUBY_PLATFORM =~ /mingw|mswin/
 
-        Timeout.timeout(5) do
-          sleep 0.05 until @client.closed?
-        end
-        expect(@client.closed?).to be true
+      supervisor = new_client
+      connection_id = @client.thread_id
+      supervisor.query("KILL #{connection_id}")
+
+      Timeout.timeout(5) do
+        sleep 0.05 until @client.closed?
       end
+      expect(@client.closed?).to be true
     end
 
     it "should not report a healthy idle connection as closed" do

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -876,6 +876,24 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       @client.close
       expect(@client.closed?).to eql(true)
     end
+
+    it "should detect a connection killed server-side, without waiting for a command to fail" do
+      supervisor = new_client
+      connection_id = @client.thread_id
+      supervisor.query("KILL #{connection_id}")
+
+      Timeout.timeout(5) do
+        sleep 0.05 until @client.closed?
+      end
+      expect(@client.closed?).to be true
+    end
+
+    it "should not report a healthy idle connection as closed" do
+      client = new_client
+      sleep 0.2
+      expect(client.closed?).to be false
+      expect(client.query("SELECT 1 AS one").first).to eql('one' => 1)
+    end
   end
 
   context "#discard!" do

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -877,15 +877,20 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
       expect(@client.closed?).to eql(true)
     end
 
-    it "should detect a connection killed server-side, without waiting for a command to fail" do
-      supervisor = new_client
-      connection_id = @client.thread_id
-      supervisor.query("KILL #{connection_id}")
+    # The peer-closed peek behind this is POSIX-only (see mysql2_socket_peer_closed,
+    # ext/mysql2/client.c); closed? on Windows still only checks CONNECTED(),
+    # unchanged, so a server-side KILL isn't detected without a further command.
+    unless RUBY_PLATFORM =~ /mingw|mswin/
+      it "should detect a connection killed server-side, without waiting for a command to fail" do
+        supervisor = new_client
+        connection_id = @client.thread_id
+        supervisor.query("KILL #{connection_id}")
 
-      Timeout.timeout(5) do
-        sleep 0.05 until @client.closed?
+        Timeout.timeout(5) do
+          sleep 0.05 until @client.closed?
+        end
+        expect(@client.closed?).to be true
       end
-      expect(@client.closed?).to be true
     end
 
     it "should not report a healthy idle connection as closed" do


### PR DESCRIPTION
Reimplements the goal of #1022 (2019, never merged): `closed?` only checks `CONNECTED()` -- whether a vio/fd exists -- not whether the peer is actually still there, so a connection killed from another session (`KILL`, `wait_timeout`, a proxy dropping an idle connection) still reports `closed? => false` until the next real command happens to fail.

## Why not #1022's approach

#1022 addressed this with `vio_is_connected()`, feature-detected via `have_func` since it isn't always exported. I checked this directly against both client libraries mysql2 supports, not just the header:

- On MySQL's libmysqlclient (built as C++), the symbol is declared without `extern "C"` and is only reachable name-mangled. Confirmed with an actual link test (not just reading the source) against current libmysqlclient -- a plain C translation unit calling it fails to link.
- MariaDB Connector/C has no equivalent function at all.

`have_func` would correctly no-op the feature in both cases (not a crash risk -- the PR's own design already handled absence gracefully), but it means the feature likely never activates on either library this gem targets.

## What this does instead

A single-byte non-blocking peek on the raw fd -- `recv(fd, buf, 1, MSG_PEEK | MSG_DONTWAIT)` -- standard POSIX, no library symbol dependency, no `extconf.rb` probing needed. A clean 0-byte return is the standard EOF signal for a peer's graceful close; `EAGAIN`/`EWOULDBLOCK` is the ordinary idle state.

Verified directly against a real `KILL` from a supervisor connection before writing the spec (not just reasoned about): the peek reports the close immediately, matching what `mysql_ping()` only discovers by paying for a real round trip.

## Scope

Deliberately limited to `closed?` only, **not** folded into the `CONNECTED()` macro that `REQUIRE_CONNECTED` runs on every command -- unlike `vio_is_connected()` (a plain function call), this is a real `recv()` syscall, and `MSG_PEEK` is only safe to rely on from an idle-connection check like this one, never while a query's response could legitimately be in flight.

POSIX only, matching the precedent of several other features in this file (`kill_on_timeout`, `invalidate_socket`): Windows keeps today's behavior, `closed?` unchanged there. Also cross-referenced against #647 (exposing the socket fd on Windows) -- that issue is about *Ruby-level* IO exposure (`Client#socket`, needed for EventMachine/reactor integration) and doesn't block this: `net.fd` is already treated as directly usable at the C level on Windows elsewhere in this file (e.g. `disconnect_and_mark_inactive`'s `close(wrapper->client->net.fd)`), this PR just doesn't extend the peek check there.

## Testing

Full spec suite (628 examples) and rubocop pass clean. New specs cover a server-side `KILL` being detected without any further command, and a healthy idle connection *not* being misreported as closed (no false positive from the peek itself).

Relates to #1022