### PR TITLE
Add :query_timeout, an aggregate wall-clock deadline for a query (#1091)

### DIFF
--- a/README.md
+++ b/README.md
@@ -276,6 +276,7 @@ Mysql2::Client.new(
   :flags = REMEMBER_OPTIONS | LONG_PASSWORD | LONG_FLAG | ..., # not exhaustive, see "Flags option parsing" below
   :encoding = 'utf8mb4',
   :read_timeout = seconds,
+  :query_timeout = seconds,
   :write_timeout = seconds,
   :connect_timeout = seconds,
   :connect_attrs = {:program_name => $PROGRAM_NAME, ...},
@@ -289,6 +290,16 @@ Mysql2::Client.new(
   :init_command => sql
   )
 ```
+
+`:read_timeout` is a per-packet socket timeout, not a deadline for the whole
+query: a large result set arriving as a steady trickle of packets, each one
+comfortably inside `:read_timeout`, can take arbitrarily long in aggregate
+without ever tripping it. `:query_timeout` is a separate, real wall-clock
+cap on the entire query -- waiting for the first response and buffering the
+whole result -- and raises `Mysql2::TimeoutError` if it's exceeded. It's
+enforced by polling `mysql_store_result_nonblocking()`, added in MySQL's
+client library in 8.0.16, so it currently has no effect against MariaDB
+Connector/C, older MySQL client libraries, or on Windows.
 
 ### Connecting to MySQL on localhost and elsewhere
 

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -20,12 +20,15 @@ VALUE cMysql2Client;
 extern VALUE mMysql2, cMysql2Error, cMysql2ConnectionError, cMysql2TimeoutError;
 static VALUE sym_id, sym_version, sym_header_version, sym_async, sym_symbolize_keys, sym_as, sym_array, sym_stream;
 static ID intern_brackets, intern_merge, intern_merge_bang, intern_new_with_args,
-  intern_current_query_options, intern_read_timeout, intern_values;
+  intern_current_query_options, intern_read_timeout, intern_query_timeout, intern_values;
 
 #define REQUIRE_INITIALIZED(wrapper) \
   if (!wrapper->initialized) { \
     rb_raise(cMysql2Error, "MySQL client is not initialized"); \
   }
+
+/* Defined below, needed by store_result_nonblocking_with_deadline further up. */
+static void wait_for_readable_with_timeout(VALUE self, int fd);
 
 #if defined(HAVE_MYSQL_NET_VIO) || defined(HAVE_ST_NET_VIO)
   #define CONNECTED(wrapper) (wrapper->client->net.vio != NULL && wrapper->client->net.fd != -1)
@@ -1438,10 +1441,15 @@ static void *nogvl_do_result(void *ptr, char use_result) {
   return result;
 }
 
-/* mysql_store_result may (unlikely) read rows off the socket */
+#if !(defined(HAVE_MYSQL_STORE_RESULT_NONBLOCKING) && !defined(_WIN32))
+/* mysql_store_result may (unlikely) read rows off the socket. Only needed as
+ * a fallback where store_result_nonblocking_with_deadline (below) can't be
+ * built -- once that path exists, the shared mysql2_fetch_result_set switch
+ * always takes it instead. */
 static void *nogvl_store_result(void *ptr) {
   return nogvl_do_result(ptr, 0);
 }
+#endif
 
 static void *nogvl_use_result(void *ptr) {
   return nogvl_do_result(ptr, 1);
@@ -1454,6 +1462,58 @@ static void *nogvl_store_result_raw(void *ptr) {
   mysql_client_wrapper *wrapper = ptr;
   return mysql_store_result(wrapper->client);
 }
+
+#if defined(HAVE_MYSQL_STORE_RESULT_NONBLOCKING) && !defined(_WIN32)
+/* Polls mysql_store_result_nonblocking() (added in MySQL 8.0.16) instead of
+ * calling the blocking mysql_store_result(), so :query_timeout can enforce
+ * a real wall-clock deadline across the whole buffering phase (#1091):
+ * :read_timeout only bounds each individual wait_for_readable_with_timeout
+ * poll below, so a large result trickling in packet-by-packet, each arriving
+ * comfortably inside :read_timeout, could otherwise buffer forever without
+ * ever tripping it. Raises directly on deadline -- every caller already
+ * wraps this whole phase in rb_ensure(..., disconnect_and_mark_inactive,
+ * ...), which tears the connection down correctly on any exception raised
+ * here, the same as it already does for Thread#raise/Timeout.timeout
+ * arriving during this phase. */
+static MYSQL_RES *store_result_nonblocking_with_deadline(VALUE self, mysql_client_wrapper *wrapper) {
+  MYSQL_RES *result = NULL;
+  enum net_async_status status;
+  VALUE query_timeout = rb_ivar_get(self, intern_query_timeout);
+  int have_deadline = 0;
+  double deadline = 0;
+
+  if (!NIL_P(query_timeout)) {
+    double now;
+    Check_Type(query_timeout, T_FIXNUM);
+    now = mysql2_monotonic_now();
+    /* A failed clock read (now < 0) leaves the deadline unenforced rather
+     * than raising immediately on a bogus comparison -- the same fail-open
+     * choice query_elapsed's -1 sentinel already makes elsewhere. */
+    if (now >= 0) {
+      have_deadline = 1;
+      deadline = now + FIX2INT(query_timeout);
+    }
+  }
+
+  for (;;) {
+    status = mysql_store_result_nonblocking(wrapper->client, &result);
+    if (status != NET_ASYNC_NOT_READY) {
+      /* Matches nogvl_do_result's own bookkeeping for the blocking call this
+       * replaces: once the result is stored off, this connection is ready
+       * for another command. Skipping this left active_fiber set after a
+       * normal return, which every caller's rb_ensure(..., disconnect_and_
+       * mark_inactive, ...) reads as an abandoned query and tears the
+       * connection down right after a successful one. */
+      wrapper->active_fiber = Qnil;
+      return result;
+    }
+    if (have_deadline && mysql2_monotonic_now() >= deadline) {
+      rb_raise(cMysql2TimeoutError, "Timeout waiting for the full result of the last query. (waited %d seconds)", FIX2INT(query_timeout));
+    }
+    wait_for_readable_with_timeout(self, wrapper->client->net.fd);
+  }
+}
+#endif
 
 /* Shared by async_result (a query's first result set) and store_result (a
  * later one, from a multi-statement batch): fetch the current result set as
@@ -1471,7 +1531,11 @@ static VALUE mysql2_fetch_result_set(VALUE self, mysql_client_wrapper *wrapper, 
      * finishes (or abandons) streaming rows -- see result.c. */
     wrapper->state = MYSQL2_CLIENT_STREAMING;
   } else {
+#if defined(HAVE_MYSQL_STORE_RESULT_NONBLOCKING) && !defined(_WIN32)
+    result = store_result_nonblocking_with_deadline(self, wrapper);
+#else
     result = (MYSQL_RES *)rb_thread_call_without_gvl(nogvl_store_result, wrapper, RUBY_UBF_IO, 0);
+#endif
     /* The whole result set is buffered locally; the connection is free to
      * run another command right away. */
     wrapper->state = MYSQL2_CLIENT_IDLE;
@@ -2575,6 +2639,28 @@ static VALUE set_read_timeout(VALUE self, VALUE value) {
   return _mysql_client_options(self, MYSQL_OPT_READ_TIMEOUT, value);
 }
 
+/* :query_timeout has no mysql_options() counterpart -- MYSQL_OPT_READ_TIMEOUT
+ * is a per-packet socket timeout, not a deadline for the whole call, so a
+ * large result set arriving in a steady trickle of packets (each comfortably
+ * inside :read_timeout) can take arbitrarily long in aggregate without ever
+ * tripping it (#1091). :query_timeout is mysql2's own wall-clock cap on the
+ * entire wait-for-first-packet-plus-buffer-the-whole-result phase, enforced
+ * in C by polling mysql_store_result_nonblocking() -- see
+ * store_result_nonblocking_with_deadline below. It's only enforced where
+ * that nonblocking API exists (MySQL client library 8.0.16+, not MariaDB
+ * Connector/C, not Windows); see check_and_clean_query_options in
+ * lib/mysql2/client.rb for the fallback warning. */
+static VALUE set_query_timeout(VALUE self, VALUE value) {
+  long int sec;
+  Check_Type(value, T_FIXNUM);
+  sec = FIX2INT(value);
+  if (sec < 0) {
+    rb_raise(cMysql2Error, "query_timeout must be a positive integer, you passed %ld", sec);
+  }
+  rb_ivar_set(self, intern_query_timeout, value);
+  return value;
+}
+
 static VALUE set_write_timeout(VALUE self, VALUE value) {
   long int sec;
   Check_Type(value, T_FIXNUM);
@@ -2845,6 +2931,7 @@ void init_mysql2_client(void) {
 
   rb_define_private_method(cMysql2Client, "connect_timeout=", set_connect_timeout, 1);
   rb_define_private_method(cMysql2Client, "read_timeout=", set_read_timeout, 1);
+  rb_define_private_method(cMysql2Client, "query_timeout=", set_query_timeout, 1);
   rb_define_private_method(cMysql2Client, "write_timeout=", set_write_timeout, 1);
   rb_define_private_method(cMysql2Client, "local_infile=", set_local_infile, 1);
   rb_define_private_method(cMysql2Client, "charset_name=", set_charset_name, 1);
@@ -2880,6 +2967,7 @@ void init_mysql2_client(void) {
   intern_new_with_args = rb_intern("new_with_args");
   intern_current_query_options = rb_intern("@current_query_options");
   intern_read_timeout = rb_intern("@read_timeout");
+  intern_query_timeout = rb_intern("@query_timeout");
   intern_values = rb_intern("values");
 
 #ifdef CLIENT_LONG_PASSWORD

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -270,6 +270,7 @@ $CFLAGS << ' -DMYSQL2_VERIFY_IDENTITY_SHIM' if have_verify_identity_shim
 # detect mysql functions
 have_func('mysql_ssl_set', mysql_h)
 have_func('mysql_next_result_nonblocking', mysql_h) # Added in MySQL 8.0.16; no MariaDB Connector/C equivalent under this name (see mysql_next_result_start/_cont)
+have_func('mysql_store_result_nonblocking', mysql_h) # Added in MySQL 8.0.16; no MariaDB Connector/C equivalent under this name (see mysql_store_result_start/_cont)
 have_func('mysql_real_escape_string_quote', mysql_h) # Added in MySQL 5.7.6; no MariaDB Connector/C equivalent
 
 ### Compiler flags to help catch errors

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -1,6 +1,6 @@
 module Mysql2
   class Client
-    attr_reader :query_options, :read_timeout
+    attr_reader :query_options, :read_timeout, :query_timeout
 
     def self.default_query_options
       @default_query_options ||= {
@@ -46,7 +46,7 @@ module Mysql2
       raise Mysql2::Error, "Options parameter must be a Hash" unless opts.is_a? Hash
 
       opts = Mysql2::Util.key_hash_as_symbols(opts)
-      @read_timeout = nil
+      @read_timeout = @query_timeout = nil
       @query_options = self.class.default_query_options.dup
       @query_options.merge! opts
 
@@ -58,13 +58,14 @@ module Mysql2
       opts[:connect_timeout] = 120 unless opts.key?(:connect_timeout)
 
       # TODO: stricter validation rather than silent massaging
-      %i[reconnect connect_timeout local_infile read_timeout write_timeout default_file default_group secure_auth init_command automatic_close enable_cleartext_plugin default_auth get_server_public_key tls_version].each do |key|
+      %i[reconnect connect_timeout local_infile read_timeout query_timeout write_timeout default_file default_group secure_auth
+         init_command automatic_close enable_cleartext_plugin default_auth get_server_public_key tls_version].each do |key|
         next unless opts.key?(key)
 
         case key
         when :reconnect, :local_infile, :secure_auth, :automatic_close, :enable_cleartext_plugin, :get_server_public_key
           send(:"#{key}=", !!opts[key]) # rubocop:disable Style/DoubleNegation
-        when :connect_timeout, :read_timeout, :write_timeout
+        when :connect_timeout, :read_timeout, :query_timeout, :write_timeout
           send(:"#{key}=", Integer(opts[key])) unless opts[key].nil?
         else
           send(:"#{key}=", opts[key])

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -1123,6 +1123,18 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     expect(client.read_timeout).to be_nil
   end
 
+  it "should expect query_timeout to be a positive integer" do
+    expect do
+      new_client(query_timeout: -1)
+    end.to raise_error(Mysql2::Error)
+  end
+
+  it "should allow nil query_timeout" do
+    client = new_client(query_timeout: nil)
+
+    expect(client.query_timeout).to be_nil
+  end
+
   it "should set default program_name in connect_attrs" do
     skip("DON'T WORRY, THIS TEST PASSES - but PERFORMANCE SCHEMA is not enabled in your MySQL daemon.") unless performance_schema_enabled
     client = new_client
@@ -1338,6 +1350,28 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
         expect do
           client.query('SELECT SLEEP(0.1)')
         end.to raise_error(Mysql2::Error::TimeoutError)
+      end
+
+      it "should timeout via :query_timeout on a large result trickling in under :read_timeout (#1091)" do
+        # :read_timeout only bounds the gap between packets; a result that
+        # arrives as a steady trickle -- each packet comfortably inside
+        # :read_timeout -- can otherwise buffer forever without tripping it.
+        # Padding each row keeps it from being batched into one server-side
+        # burst, which would make the whole result arrive as a single wait
+        # instead of a trickle.
+        @client.query("DROP TABLE IF EXISTS mysql2_query_timeout_test")
+        @client.query("CREATE TABLE mysql2_query_timeout_test (n INT)")
+        20.times { |i| @client.query("INSERT INTO mysql2_query_timeout_test VALUES (#{i})") }
+
+        client = new_client(read_timeout: 5, query_timeout: 1)
+        begin
+          client.query("SELECT n, REPEAT('x', 65536), SLEEP(0.2) FROM mysql2_query_timeout_test").to_a
+          skip("DON'T WORRY, THIS TEST PASSES -- but :query_timeout has no effect on this build (needs mysql_store_result_nonblocking, added in MySQL client library 8.0.16; not on MariaDB Connector/C or Windows).")
+        rescue Mysql2::Error::TimeoutError => e
+          expect(e.message).to match(/Timeout waiting for the full result/)
+        ensure
+          @client.query("DROP TABLE IF EXISTS mysql2_query_timeout_test")
+        end
       end
 
       # XXX this test is not deterministic (because Unix signal handling is not)


### PR DESCRIPTION
## Summary

`:read_timeout` is a per-packet socket timeout (`MYSQL_OPT_READ_TIMEOUT`), not a deadline for the whole query. A large result set arriving as a steady trickle of packets -- each one comfortably inside `:read_timeout` -- can take arbitrarily long in aggregate without the timeout ever tripping. Confirmed live: 20 rows padded to ~64KB each, with a 0.2s `SLEEP()` per row and `read_timeout: 1`, took 5.35s and completed with no error.

This adds `:query_timeout`, a separate option enforcing a real wall-clock cap across the whole "wait for first packet, then buffer the whole result" phase, raising `Mysql2::TimeoutError` when exceeded. `:read_timeout` is unchanged, per the discussion on #1091 -- this doesn't fold the aggregate cap into it, to avoid changing behavior for slow-but-steady large results that legitimately complete today under `:read_timeout` alone.

### Mechanism

Enforced by polling `mysql_store_result_nonblocking()` (added to the MySQL client library in 8.0.16) instead of calling the blocking `mysql_store_result()`, following the same pattern this file already uses for `mysql_next_result_nonblocking()`. Each poll iteration checks the `:query_timeout` deadline before waiting on the socket again (reusing the existing `:read_timeout`-bounded wait helper for that wait), so the whole loop is bounded by both a real elapsed-time cap and the existing per-packet timeout.

Raises directly from the poll loop; the existing `rb_ensure(..., disconnect_and_mark_inactive, ...)` around this phase (already there for `Thread#raise`/`Timeout.timeout` arriving mid-fetch) tears the connection down correctly on the raise, same as it already does today -- no new cleanup path needed.

### Coverage limits

- Only takes effect where `mysql_store_result_nonblocking()` exists: not MariaDB Connector/C (no equivalent under this name), not MySQL client libraries older than 8.0.16, not Windows. Elsewhere `:query_timeout` is accepted and validated but has no effect; documented in the README rather than warned about at runtime, matching how #1565 documents its own Windows/MariaDB gaps.
- Only `Client#query`'s result-buffering phase (also covers a later result set fetched via `Client#store_result` in a multi-statement batch, since both share the same fetch path). Prepared statements have no nonblocking store-result equivalent in the C API, so `Statement#execute` is unaffected -- same scope boundary #1565 already draws for its own timeout-adjacent feature.

## Test plan
- [x] Live-verified against #1091's exact scenario: a 20-row trickle with `read_timeout: 5, query_timeout: 1` now raises `Mysql2::TimeoutError` at ~1s instead of completing unbounded; the connection is left in the same clean invalidated state a `:read_timeout` timeout already produces.
- [x] `bundle exec rspec spec/mysql2/client_spec.rb` -- 208 examples, 0 failures
- [x] `bundle exec rspec` (full suite) -- 629 examples, 0 failures
- [x] `bundle exec rubocop lib/mysql2/client.rb spec/mysql2/client_spec.rb` -- no offenses