### PR TITLE
Represent TIME as a duration-anchored Time, not a broken time-of-day (#719)

### DIFF
--- a/README.md
+++ b/README.md
@@ -717,6 +717,15 @@ Then, if `:application_timezone` is set to say - `:local` - Mysql2 will then con
 
 Both options only allow two values - `:local` or `:utc` - with the exception that `:application_timezone` can be [and defaults to] nil
 
+A `TIME` column is a signed duration in MySQL, not a time-of-day -- it ranges
+from `-838:59:59` to `838:59:59` (elapsed time, or an interval between two
+events). Mysql2 represents it as a `Time` offset from a fixed placeholder
+date (`2000-01-01`, in whichever timezone `:database_timezone` names),
+rolling that date backward or forward as the duration requires: `24:00:01`
+becomes `2000-01-02 00:00:01`, `-01:00:00` becomes `1999-12-31 23:00:00`.
+Values within a single day (`00:00:00` to `23:59:59`) land on the
+placeholder date unchanged.
+
 ### Casting "boolean" columns
 
 You can now tell Mysql2 to cast `tinyint(1)` fields to boolean values in Ruby with the `:cast_booleans` option.

--- a/README.md
+++ b/README.md
@@ -726,6 +726,9 @@ becomes `2000-01-02 00:00:01`, `-01:00:00` becomes `1999-12-31 23:00:00`.
 Values within a single day (`00:00:00` to `23:59:59`) land on the
 placeholder date unchanged.
 
+Both plain `TIME` (whole-second precision) and `TIME(N)` up to `TIME(6)`
+(microsecond precision) are supported.
+
 ### Casting "boolean" columns
 
 You can now tell Mysql2 to cast `tinyint(1)` fields to boolean values in Ruby with the `:cast_booleans` option.

--- a/README.md
+++ b/README.md
@@ -717,14 +717,11 @@ Then, if `:application_timezone` is set to say - `:local` - Mysql2 will then con
 
 Both options only allow two values - `:local` or `:utc` - with the exception that `:application_timezone` can be [and defaults to] nil
 
-A `TIME` column is a signed duration in MySQL, not a time-of-day -- it ranges
-from `-838:59:59` to `838:59:59` (elapsed time, or an interval between two
-events). Mysql2 represents it as a `Time` offset from a fixed placeholder
-date (`2000-01-01`, in whichever timezone `:database_timezone` names),
-rolling that date backward or forward as the duration requires: `24:00:01`
-becomes `2000-01-02 00:00:01`, `-01:00:00` becomes `1999-12-31 23:00:00`.
-Values within a single day (`00:00:00` to `23:59:59`) land on the
-placeholder date unchanged.
+A `TIME` column ranges from `-838:59:59` to `838:59:59`. Mysql2 represents
+it as a `Time` offset from a fixed placeholder date (`2000-01-01`, in
+`:utc` or `:local` per `:database_timezone`), rolling that date backward
+or forward as the duration requires: `24:00:01` becomes
+`2000-01-02 00:00:01`, `-01:00:00` becomes `1999-12-31 23:00:00`.
 
 Both plain `TIME` (whole-second precision) and `TIME(N)` up to `TIME(6)`
 (microsecond precision) are supported.

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -889,11 +889,10 @@ static VALUE mysql2_utc_time(unsigned int year, unsigned int month, unsigned int
 /* MySQL TIME is a signed duration of hour, minute, second, and
  * microseconds, ranging from -838:59:59.999999 to 838:59:59.999999, but
  * Ruby's Time constructor rejects an hour beyond 24 or a negative value.
- * We solve this by taking a Time anchored at 2000-01-01 00:00:00 and
- * adding or subtracting the value converted to seconds -- a plain Integer
- * when there are no microseconds (the common case, and measurably cheaper
- * than a Rational), or an exact Rational when there are, so no microsecond
- * is lost to float rounding. */
+ * We solve this by adding the signed duration to a Time anchored at
+ * 2000-01-01 00:00:00. Duration is converted to an Integer in seconds
+ * or a Rational in microseconds, depending on the precision of the
+ * field. */
 static VALUE mysql2_time_from_duration(VALUE db_timezone, int negative,
                                        unsigned int hour, unsigned int min, unsigned int sec,
                                        unsigned long usec) {

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -900,10 +900,8 @@ static VALUE mysql2_time_from_duration(VALUE db_timezone, int negative,
   int64_t total_sec = (int64_t)hour * 3600 + (int64_t)min * 60 + (int64_t)sec;
 
   /* :utc has no environment dependence, so the cached anchor is exact.
-   * :local isn't cacheable the same way: Time.local re-reads ENV['TZ'] on
-   * every call, so a cached anchor would freeze the process's timezone at
-   * whatever it was when this extension loaded, silently going wrong after
-   * any later ENV['TZ'] change. */
+   * :local can't be cached the same way: Time.local re-reads ENV['TZ']
+   * on every call. */
   anchor = (db_timezone == intern_utc) ? opt_time_anchor_utc
          : rb_funcall(rb_cTime, intern_local, 7, opt_time_year, opt_time_month, opt_time_day,
                       INT2FIX(0), INT2FIX(0), INT2FIX(0), INT2FIX(0));
@@ -2685,9 +2683,8 @@ void init_mysql2_result(void) {
   opt_time_day = INT2NUM(1);
   opt_utc_offset = INT2NUM(0);
 
-  /* mysql2_time_from_duration's :utc anchor, built once and reused -- safe
-   * only because :utc has no environment dependence; see the comment there
-   * on why :local can't be cached the same way. */
+  /* mysql2_time_from_duration's :utc anchor, cached here; :local is
+   * rebuilt per call there. */
   opt_time_anchor_utc = rb_funcall(rb_cTime, intern_utc, 7, opt_time_year, opt_time_month, opt_time_day,
                                    INT2FIX(0), INT2FIX(0), INT2FIX(0), INT2FIX(0));
   rb_global_variable(&opt_time_anchor_utc); /* never GC */

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -96,6 +96,7 @@ typedef struct {
 extern VALUE mMysql2, cMysql2Client, cMysql2Error;
 static VALUE cMysql2Result, cDateTime, cDate;
 static VALUE opt_decimal_zero, opt_float_zero, opt_time_year, opt_time_month, opt_time_day, opt_utc_offset;
+static VALUE opt_time_anchor_utc, opt_time_anchor_local;
 static ID intern_new, intern_utc, intern_local, intern_localtime, intern_local_offset,
   intern_civil, intern_new_offset, intern_merge, intern_BigDecimal, intern_Float,
   intern_query_options, intern_plus;
@@ -888,7 +889,9 @@ static VALUE mysql2_utc_time(unsigned int year, unsigned int month, unsigned int
 /* MySQL TIME is a signed duration of hour, minute, second, and
  * microseconds, ranging from -838:59:59.999999 to 838:59:59.999999, but
  * Ruby's Time constructor rejects an hour beyond 24 or a negative value.
- * We solve this by creating a Time anchored at 2000-01-01 00:00:00, then
+ * We solve this by taking a Time anchored at 2000-01-01 00:00:00 (built
+ * once at init -- see opt_time_anchor_utc/_local -- since Time#+ never
+ * mutates its receiver, so the same anchor is reused every call) and
  * adding or subtracting the value converted to seconds -- a plain Integer
  * when there are no microseconds (the common case, and measurably cheaper
  * than a Rational), or an exact Rational when there are, so no microsecond
@@ -899,8 +902,7 @@ static VALUE mysql2_time_from_duration(VALUE db_timezone, int negative,
   VALUE anchor, offset;
   int64_t total_sec = (int64_t)hour * 3600 + (int64_t)min * 60 + (int64_t)sec;
 
-  anchor = rb_funcall(rb_cTime, db_timezone, 7, opt_time_year, opt_time_month, opt_time_day,
-                      INT2FIX(0), INT2FIX(0), INT2FIX(0), INT2FIX(0));
+  anchor = (db_timezone == intern_utc) ? opt_time_anchor_utc : opt_time_anchor_local;
 
   if (usec == 0) {
     offset = LL2NUM(negative ? -total_sec : total_sec);
@@ -909,6 +911,7 @@ static VALUE mysql2_time_from_duration(VALUE db_timezone, int negative,
     if (negative) total_usec = -total_usec;
     offset = rb_rational_new(LL2NUM(total_usec), INT2FIX(1000000));
   }
+  /* returns a newly-allocated object, anchor is not mutated */
   return rb_funcall(anchor, intern_plus, 1, offset);
 }
 
@@ -2679,6 +2682,16 @@ void init_mysql2_result(void) {
   opt_time_month = INT2NUM(1);
   opt_time_day = INT2NUM(1);
   opt_utc_offset = INT2NUM(0);
+
+  /* mysql2_time_from_duration's anchor (2000-01-01 00:00:00) is the same
+   * object every call for a given timezone -- Time#+ never mutates its
+   * receiver, so build each one once instead of on every TIME cast. */
+  opt_time_anchor_utc = rb_funcall(rb_cTime, intern_utc, 7, opt_time_year, opt_time_month, opt_time_day,
+                                   INT2FIX(0), INT2FIX(0), INT2FIX(0), INT2FIX(0));
+  rb_global_variable(&opt_time_anchor_utc); /* never GC */
+  opt_time_anchor_local = rb_funcall(rb_cTime, intern_local, 7, opt_time_year, opt_time_month, opt_time_day,
+                                     INT2FIX(0), INT2FIX(0), INT2FIX(0), INT2FIX(0));
+  rb_global_variable(&opt_time_anchor_local); /* never GC */
 
   binaryEncoding = rb_enc_find("binary");
 }

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -885,34 +885,30 @@ static VALUE mysql2_utc_time(unsigned int year, unsigned int month, unsigned int
   ((tz) == intern_utc && (hour) < 24 && (min) < 60 && (sec) < 60)
 #endif
 
-/* MySQL's TIME is a signed duration, not a time-of-day: it ranges from
- * -838:59:59 to 838:59:59 (elapsed time or an interval between two events,
- * per MySQL's own docs), so constructing it directly as Time.utc/local(...,
- * hour, min, sec, usec) breaks the moment hour reaches 24 or the value is
- * negative -- Time's own constructor rejects out-of-range components (#719).
- *
- * Instead, anchor a Time at year/month/day with all-zero wall-clock
- * components (always valid, never raises) and add the signed duration as an
- * exact Rational offset in seconds. Time#+ operates on the underlying
- * continuous instant, not on calendar fields, so this is immune to
- * leap-year layout (a day is always 86400 seconds, leap year or not) and
- * exact to the microsecond (Rational, never a float). Under :local, a
- * duration crossing a DST boundary is displayed with the wall-clock shift
- * DST implies -- the same behavior any Time + seconds arithmetic in Ruby
- * already has, not something this introduces. The common in-range case
- * (0 <= hour < 24) produces byte-identical output to direct construction. */
+/* MySQL TIME is a signed duration of hour, minute, second, and
+ * microseconds, ranging from -838:59:59.999999 to 838:59:59.999999, but
+ * Ruby's Time constructor rejects an hour beyond 24 or a negative value.
+ * We solve this by creating a Time anchored at 2000-01-01 00:00:00, then
+ * adding or subtracting the value converted to seconds -- a plain Integer
+ * when there are no microseconds (the common case, and measurably cheaper
+ * than a Rational), or an exact Rational when there are, so no microsecond
+ * is lost to float rounding. */
 static VALUE mysql2_time_from_duration(VALUE db_timezone, int negative,
                                        unsigned int hour, unsigned int min, unsigned int sec,
                                        unsigned long usec) {
   VALUE anchor, offset;
-  int64_t total_usec = (int64_t)hour * 3600000000LL + (int64_t)min * 60000000LL +
-                        (int64_t)sec * 1000000LL + (int64_t)usec;
-
-  if (negative) total_usec = -total_usec;
+  int64_t total_sec = (int64_t)hour * 3600 + (int64_t)min * 60 + (int64_t)sec;
 
   anchor = rb_funcall(rb_cTime, db_timezone, 7, opt_time_year, opt_time_month, opt_time_day,
                       INT2FIX(0), INT2FIX(0), INT2FIX(0), INT2FIX(0));
-  offset = rb_rational_new(LL2NUM(total_usec), INT2FIX(1000000));
+
+  if (usec == 0) {
+    offset = LL2NUM(negative ? -total_sec : total_sec);
+  } else {
+    int64_t total_usec = total_sec * 1000000LL + (int64_t)usec;
+    if (negative) total_usec = -total_usec;
+    offset = rb_rational_new(LL2NUM(total_usec), INT2FIX(1000000));
+  }
   return rb_funcall(anchor, intern_plus, 1, offset);
 }
 

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -96,7 +96,7 @@ typedef struct {
 extern VALUE mMysql2, cMysql2Client, cMysql2Error;
 static VALUE cMysql2Result, cDateTime, cDate;
 static VALUE opt_decimal_zero, opt_float_zero, opt_time_year, opt_time_month, opt_time_day, opt_utc_offset;
-static VALUE opt_time_anchor_utc, opt_time_anchor_local;
+static VALUE opt_time_anchor_utc;
 static ID intern_new, intern_utc, intern_local, intern_localtime, intern_local_offset,
   intern_civil, intern_new_offset, intern_merge, intern_BigDecimal, intern_Float,
   intern_query_options, intern_plus;
@@ -899,7 +899,14 @@ static VALUE mysql2_time_from_duration(VALUE db_timezone, int negative,
   VALUE anchor, offset;
   int64_t total_sec = (int64_t)hour * 3600 + (int64_t)min * 60 + (int64_t)sec;
 
-  anchor = (db_timezone == intern_utc) ? opt_time_anchor_utc : opt_time_anchor_local;
+  /* :utc has no environment dependence, so the cached anchor is exact.
+   * :local isn't cacheable the same way: Time.local re-reads ENV['TZ'] on
+   * every call, so a cached anchor would freeze the process's timezone at
+   * whatever it was when this extension loaded, silently going wrong after
+   * any later ENV['TZ'] change. */
+  anchor = (db_timezone == intern_utc) ? opt_time_anchor_utc
+         : rb_funcall(rb_cTime, intern_local, 7, opt_time_year, opt_time_month, opt_time_day,
+                      INT2FIX(0), INT2FIX(0), INT2FIX(0), INT2FIX(0));
 
   if (usec == 0) {
     offset = LL2NUM(negative ? -total_sec : total_sec);
@@ -2678,13 +2685,12 @@ void init_mysql2_result(void) {
   opt_time_day = INT2NUM(1);
   opt_utc_offset = INT2NUM(0);
 
-  /* mysql2_time_from_duration's anchor, built once per timezone and reused. */
+  /* mysql2_time_from_duration's :utc anchor, built once and reused -- safe
+   * only because :utc has no environment dependence; see the comment there
+   * on why :local can't be cached the same way. */
   opt_time_anchor_utc = rb_funcall(rb_cTime, intern_utc, 7, opt_time_year, opt_time_month, opt_time_day,
                                    INT2FIX(0), INT2FIX(0), INT2FIX(0), INT2FIX(0));
   rb_global_variable(&opt_time_anchor_utc); /* never GC */
-  opt_time_anchor_local = rb_funcall(rb_cTime, intern_local, 7, opt_time_year, opt_time_month, opt_time_day,
-                                     INT2FIX(0), INT2FIX(0), INT2FIX(0), INT2FIX(0));
-  rb_global_variable(&opt_time_anchor_local); /* never GC */
 
   binaryEncoding = rb_enc_find("binary");
 }

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -889,9 +889,7 @@ static VALUE mysql2_utc_time(unsigned int year, unsigned int month, unsigned int
 /* MySQL TIME is a signed duration of hour, minute, second, and
  * microseconds, ranging from -838:59:59.999999 to 838:59:59.999999, but
  * Ruby's Time constructor rejects an hour beyond 24 or a negative value.
- * We solve this by taking a Time anchored at 2000-01-01 00:00:00 (built
- * once at init -- see opt_time_anchor_utc/_local -- since Time#+ never
- * mutates its receiver, so the same anchor is reused every call) and
+ * We solve this by taking a Time anchored at 2000-01-01 00:00:00 and
  * adding or subtracting the value converted to seconds -- a plain Integer
  * when there are no microseconds (the common case, and measurably cheaper
  * than a Rational), or an exact Rational when there are, so no microsecond
@@ -2683,9 +2681,7 @@ void init_mysql2_result(void) {
   opt_time_day = INT2NUM(1);
   opt_utc_offset = INT2NUM(0);
 
-  /* mysql2_time_from_duration's anchor (2000-01-01 00:00:00) is the same
-   * object every call for a given timezone -- Time#+ never mutates its
-   * receiver, so build each one once instead of on every TIME cast. */
+  /* mysql2_time_from_duration's anchor, built once per timezone and reused. */
   opt_time_anchor_utc = rb_funcall(rb_cTime, intern_utc, 7, opt_time_year, opt_time_month, opt_time_day,
                                    INT2FIX(0), INT2FIX(0), INT2FIX(0), INT2FIX(0));
   rb_global_variable(&opt_time_anchor_utc); /* never GC */

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -1508,9 +1508,7 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
           break;
         case MYSQL_TYPE_TIME:         // MYSQL_TIME
           ts = (MYSQL_TIME*)result_buffer->buffer;
-          /* ts->neg carries the sign for MySQL's TIME duration range
-           * (-838:59:59 to 838:59:59); hour/minute/second/second_part are
-           * always its unsigned magnitude (#719). */
+          /* ts->neg is the sign; hour/minute/second/second_part are the unsigned magnitude. */
           val = mysql2_time_from_duration(args->db_timezone, ts->neg, ts->hour, ts->minute, ts->second, ts->second_part);
           if (!NIL_P(args->app_timezone)) {
             if (args->app_timezone == intern_local) {

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -98,7 +98,7 @@ static VALUE cMysql2Result, cDateTime, cDate;
 static VALUE opt_decimal_zero, opt_float_zero, opt_time_year, opt_time_month, opt_utc_offset;
 static ID intern_new, intern_utc, intern_local, intern_localtime, intern_local_offset,
   intern_civil, intern_new_offset, intern_merge, intern_BigDecimal, intern_Float,
-  intern_query_options;
+  intern_query_options, intern_plus;
 static VALUE sym_symbolize_keys, sym_as, sym_array, sym_database_timezone,
   sym_application_timezone, sym_local, sym_utc, sym_cast_booleans,
   sym_cache_rows, sym_cast, sym_fast, sym_stream, sym_name, sym_rows_per_gvl_yield,
@@ -885,6 +885,37 @@ static VALUE mysql2_utc_time(unsigned int year, unsigned int month, unsigned int
   ((tz) == intern_utc && (hour) < 24 && (min) < 60 && (sec) < 60)
 #endif
 
+/* MySQL's TIME is a signed duration, not a time-of-day: it ranges from
+ * -838:59:59 to 838:59:59 (elapsed time or an interval between two events,
+ * per MySQL's own docs), so constructing it directly as Time.utc/local(...,
+ * hour, min, sec, usec) breaks the moment hour reaches 24 or the value is
+ * negative -- Time's own constructor rejects out-of-range components (#719).
+ *
+ * Instead, anchor a Time at year/month/day with all-zero wall-clock
+ * components (always valid, never raises) and add the signed duration as an
+ * exact Rational offset in seconds. Time#+ operates on the underlying
+ * continuous instant, not on calendar fields, so this is immune to
+ * leap-year layout (a day is always 86400 seconds, leap year or not) and
+ * exact to the microsecond (Rational, never a float). Under :local, a
+ * duration crossing a DST boundary is displayed with the wall-clock shift
+ * DST implies -- the same behavior any Time + seconds arithmetic in Ruby
+ * already has, not something this introduces. The common in-range case
+ * (0 <= hour < 24) produces byte-identical output to direct construction. */
+static VALUE mysql2_time_from_duration(VALUE db_timezone, int negative,
+                                       unsigned int hour, unsigned int min, unsigned int sec,
+                                       unsigned long usec) {
+  VALUE anchor, offset;
+  int64_t total_usec = (int64_t)hour * 3600000000LL + (int64_t)min * 60000000LL +
+                        (int64_t)sec * 1000000LL + (int64_t)usec;
+
+  if (negative) total_usec = -total_usec;
+
+  anchor = rb_funcall(rb_cTime, db_timezone, 7, opt_time_year, opt_time_month, opt_time_month,
+                      INT2FIX(0), INT2FIX(0), INT2FIX(0), INT2FIX(0));
+  offset = rb_rational_new(LL2NUM(total_usec), INT2FIX(1000000));
+  return rb_funcall(anchor, intern_plus, 1, offset);
+}
+
 /* Read exactly n decimal digits. Returns 0 (leaving *out untouched) on any
  * non-digit, so callers fall back to the general parser. */
 static inline int mysql2_read_uint(const char *p, int n, unsigned int *out) {
@@ -1481,7 +1512,10 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
           break;
         case MYSQL_TYPE_TIME:         // MYSQL_TIME
           ts = (MYSQL_TIME*)result_buffer->buffer;
-          val = rb_funcall(rb_cTime, args->db_timezone, 7, opt_time_year, opt_time_month, opt_time_month, UINT2NUM(ts->hour), UINT2NUM(ts->minute), UINT2NUM(ts->second), ULONG2NUM(ts->second_part));
+          /* ts->neg carries the sign for MySQL's TIME duration range
+           * (-838:59:59 to 838:59:59); hour/minute/second/second_part are
+           * always its unsigned magnitude (#719). */
+          val = mysql2_time_from_duration(args->db_timezone, ts->neg, ts->hour, ts->minute, ts->second, ts->second_part);
           if (!NIL_P(args->app_timezone)) {
             if (args->app_timezone == intern_local) {
               val = rb_funcall(val, intern_localtime, 0);
@@ -1745,7 +1779,8 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
           break;
         }
         case MYSQL_TYPE_TIME: {     /* TIME field */
-          int tokens;
+          int tokens, negative;
+          const char *time_str = row[i];
           unsigned int hour=0, min=0, sec=0, msec=0;
           char msec_char[7] = {'0','0','0','0','0','0','\0'};
 
@@ -1755,13 +1790,18 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
             break;
           }
 
-          tokens = sscanf(row[i], "%2u:%2u:%2u.%6s", &hour, &min, &sec, msec_char);
+          negative = (time_str[0] == '-');
+          if (negative) time_str++;
+
+          /* %3u: MySQL's TIME hour ranges up to 838, one digit wider than a
+           * time-of-day's 0-23 (#719). */
+          tokens = sscanf(time_str, "%3u:%2u:%2u.%6s", &hour, &min, &sec, msec_char);
           if (tokens < 3) {
             val = Qnil;
             break;
           }
           msec = msec_char_to_uint(msec_char, sizeof(msec_char));
-          val = rb_funcall(rb_cTime, args->db_timezone, 7, opt_time_year, opt_time_month, opt_time_month, UINT2NUM(hour), UINT2NUM(min), UINT2NUM(sec), UINT2NUM(msec));
+          val = mysql2_time_from_duration(args->db_timezone, negative, hour, min, sec, msec);
           if (!NIL_P(args->app_timezone)) {
             if (args->app_timezone == intern_local) {
               val = rb_funcall(val, intern_localtime, 0);
@@ -2614,6 +2654,7 @@ void init_mysql2_result(void) {
   intern_BigDecimal   = rb_intern("BigDecimal");
   intern_Float        = rb_intern("Float");
   intern_query_options = rb_intern("@query_options");
+  intern_plus         = rb_intern("+");
 
   sym_symbolize_keys  = ID2SYM(rb_intern("symbolize_keys"));
   sym_as              = ID2SYM(rb_intern("as"));

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -95,7 +95,7 @@ typedef struct {
 
 extern VALUE mMysql2, cMysql2Client, cMysql2Error;
 static VALUE cMysql2Result, cDateTime, cDate;
-static VALUE opt_decimal_zero, opt_float_zero, opt_time_year, opt_time_month, opt_utc_offset;
+static VALUE opt_decimal_zero, opt_float_zero, opt_time_year, opt_time_month, opt_time_day, opt_utc_offset;
 static ID intern_new, intern_utc, intern_local, intern_localtime, intern_local_offset,
   intern_civil, intern_new_offset, intern_merge, intern_BigDecimal, intern_Float,
   intern_query_options, intern_plus;
@@ -910,7 +910,7 @@ static VALUE mysql2_time_from_duration(VALUE db_timezone, int negative,
 
   if (negative) total_usec = -total_usec;
 
-  anchor = rb_funcall(rb_cTime, db_timezone, 7, opt_time_year, opt_time_month, opt_time_month,
+  anchor = rb_funcall(rb_cTime, db_timezone, 7, opt_time_year, opt_time_month, opt_time_day,
                       INT2FIX(0), INT2FIX(0), INT2FIX(0), INT2FIX(0));
   offset = rb_rational_new(LL2NUM(total_usec), INT2FIX(1000000));
   return rb_funcall(anchor, intern_plus, 1, offset);
@@ -2681,6 +2681,7 @@ void init_mysql2_result(void) {
   rb_global_variable(&opt_float_zero);
   opt_time_year = INT2NUM(2000);
   opt_time_month = INT2NUM(1);
+  opt_time_day = INT2NUM(1);
   opt_utc_offset = INT2NUM(0);
 
   binaryEncoding = rb_enc_find("binary");

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -1230,6 +1230,40 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
       expect(test_result['time_test'].strftime("%Y-%m-%d %H:%M:%S")).to eql('2000-01-01 11:44:00')
     end
 
+    context "a TIME value outside a single day (#719)" do
+      # MySQL's TIME is a signed duration (-838:59:59 to 838:59:59), not a
+      # time-of-day -- a negative value or an hour >= 24 used to silently
+      # return nil, or raise ArgumentError, depending on the exact value.
+      # These are represented as a Time offset from the same 2000-01-01
+      # anchor an in-range TIME already uses, rolling the placeholder date
+      # backward or forward as the duration requires.
+      before(:context) do
+        new_client do |client|
+          client.query("DROP TABLE IF EXISTS mysql2_time_duration_test")
+          client.query("CREATE TABLE mysql2_time_duration_test (t TIME(6))")
+          %w[24:00:00 24:00:01 -01:00:00 838:59:59 -838:59:59 12:34:56.25].each do |t|
+            client.query("INSERT INTO mysql2_time_duration_test VALUES ('#{t}')")
+          end
+        end
+      end
+
+      after(:context) do
+        new_client { |client| client.query("DROP TABLE IF EXISTS mysql2_time_duration_test") }
+      end
+
+      it "represents each value as the expected duration-anchored Time" do
+        rows = @client.query("SELECT t FROM mysql2_time_duration_test ORDER BY t").map { |r| r['t'] }
+        expect(rows.map { |t| t.strftime('%Y-%m-%d %H:%M:%S.%6N') }).to eql([
+                                                                              '1999-11-27 01:00:01.000000', # -838:59:59
+                                                                              '1999-12-31 23:00:00.000000', # -01:00:00
+                                                                              '2000-01-01 12:34:56.250000', # 12:34:56.25
+                                                                              '2000-01-02 00:00:00.000000', # 24:00:00
+                                                                              '2000-01-02 00:00:01.000000', # 24:00:01
+                                                                              '2000-02-04 22:59:59.000000', # 838:59:59
+                                                                            ])
+      end
+    end
+
     it "should return Date for a DATE value" do
       expect(test_result['date_test']).to be_an_instance_of(Date)
       expect(test_result['date_test'].strftime("%Y-%m-%d")).to eql('2010-04-04')
@@ -1934,9 +1968,6 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
     end
 
     it "re-elects bind types when a later #each switches cast mode mid-stream" do
-      # No temporal columns: the full-cast side of the switch would trip the
-      # pre-existing stmt-path limitation that a TIME outside 00..23 hours
-      # raises in Time.local.
       statement = @client.prepare("SELECT row_id, int_min_col FROM mysql2_cast_false_test ORDER BY row_id")
 
       result = statement.execute(cast: false, stream: true, cache_rows: false)
@@ -2236,9 +2267,6 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
     end
 
     it "does not treat unrecognized truthy :cast values as :fast on prepared statements" do
-      # No TIME column: under the full cast this select gets, the
-      # pre-existing stmt-path limitation that a TIME outside 00..23 hours
-      # raises in Time.local would trip on time_col.
       row = @client.prepare("SELECT decimal_col, date_col FROM mysql2_cast_fast_test WHERE row_id = 1").execute(cast: :bogus).first
       expect(row['decimal_col']).to eql(BigDecimal("10.3"))
       expect(row['date_col']).to eql(Date.new(2010, 4, 4))

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -1264,6 +1264,37 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
       end
     end
 
+    context "a TIME column declared with fewer than 6 fractional digits" do
+      # MySQL sends exactly the declared precision on the wire (TIME(4)
+      # sends "12:34:56.1234", not zero-padded to 6 digits) -- this pins
+      # that mysql2 still expands it to the right number of microseconds,
+      # matching between protocols.
+      before(:context) do
+        new_client do |client|
+          client.query("DROP TABLE IF EXISTS mysql2_time_precision_test")
+          client.query("CREATE TABLE mysql2_time_precision_test (t TIME(4))")
+          %w[12:34:56.1234 -01:00:00.5].each do |t|
+            client.query("INSERT INTO mysql2_time_precision_test VALUES ('#{t}')")
+          end
+        end
+      end
+
+      after(:context) do
+        new_client { |client| client.query("DROP TABLE IF EXISTS mysql2_time_precision_test") }
+      end
+
+      it "expands the declared precision to the correct microseconds, matching between protocols" do
+        text = @client.query("SELECT t FROM mysql2_time_precision_test ORDER BY t").map { |r| r['t'] }
+        stmt = @client.prepare("SELECT t FROM mysql2_time_precision_test ORDER BY t").execute.map { |r| r['t'] }
+
+        expect(text.map { |t| t.strftime('%Y-%m-%d %H:%M:%S.%6N') }).to eql([
+                                                                              '1999-12-31 22:59:59.500000', # -01:00:00.5
+                                                                              '2000-01-01 12:34:56.123400', # 12:34:56.1234
+                                                                            ])
+        expect(stmt).to eql(text)
+      end
+    end
+
     it "should return Date for a DATE value" do
       expect(test_result['date_test']).to be_an_instance_of(Date)
       expect(test_result['date_test'].strftime("%Y-%m-%d")).to eql('2010-04-04')

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -958,6 +958,31 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
       expect(test_result['time_test'].strftime("%Y-%m-%d %H:%M:%S")).to eql('2000-01-01 11:44:00')
     end
 
+    context "a TIME value outside a single day (#719)" do
+      # Binary-protocol TIME decoding used to ignore MYSQL_TIME.neg entirely,
+      # so a negative TIME silently came back with the wrong sign (positive
+      # instead of negative) rather than nil/raising like the text protocol.
+      before(:context) do
+        new_client do |client|
+          client.query("DROP TABLE IF EXISTS mysql2_time_duration_stmt_test")
+          client.query("CREATE TABLE mysql2_time_duration_stmt_test (t TIME(6))")
+          %w[24:00:00 24:00:01 -01:00:00 838:59:59 -838:59:59 12:34:56.25].each do |t|
+            client.query("INSERT INTO mysql2_time_duration_stmt_test VALUES ('#{t}')")
+          end
+        end
+      end
+
+      after(:context) do
+        new_client { |client| client.query("DROP TABLE IF EXISTS mysql2_time_duration_stmt_test") }
+      end
+
+      it "returns the same duration-anchored Time via a prepared statement as via a plain query" do
+        text = @client.query("SELECT t FROM mysql2_time_duration_stmt_test ORDER BY t").map { |r| r['t'] }
+        stmt = @client.prepare("SELECT t FROM mysql2_time_duration_stmt_test ORDER BY t").execute.map { |r| r['t'] }
+        expect(stmt).to eql(text)
+      end
+    end
+
     it "should return Date for a DATE value" do
       expect(test_result['date_test']).to be_an_instance_of(Date)
       expect(test_result['date_test'].strftime("%Y-%m-%d")).to eql('2010-04-04')


### PR DESCRIPTION
## Summary

MySQL's `TIME` is a signed duration (`-838:59:59` to `838:59:59`, per its own docs: "elapsed time or a time interval between two events"), not a time-of-day, but mysql2 built it with `Time.utc/local(..., hour, min, sec, usec)` directly using the raw components. Ruby's `Time` constructor rejects out-of-range components, so:

- Any `TIME` with a 3-digit hour or a negative value silently returned `nil` (the text-protocol `sscanf` couldn't parse a 3-digit hour or a leading `-`).
- Some in-range-looking values (e.g. `hour=24` with a nonzero second) raised `ArgumentError` outright, uncaught, mid-iteration.
- The binary protocol (prepared statements) was worse: it never read `MYSQL_TIME.neg` at all, so a negative `TIME` silently came back **positive** -- wrong data, not just missing data.

All three confirmed live before this fix, against a real `TIME` column and via prepared statements.

## Fix

`TIME` is now represented as a `Time` offset from the existing `2000-01-01` placeholder anchor this code already used, adding the signed duration as an exact `Rational` number of seconds via `Time#+` instead of constructing the `Time` directly with the raw (and potentially out-of-range) components.

`Time#+` operates on the underlying continuous instant, not calendar fields, so this is immune to leap-year layout (a day is always 86400 seconds) and exact to the microsecond (`Rational`, never a float -- no precision loss). Under `:local`, a duration crossing a DST boundary is displayed with whatever wall-clock shift DST implies, which is the same behavior any `Time + seconds` arithmetic in Ruby already has, not something this introduces.

The common in-range case (`0 <= hour < 24`) is unchanged: it produces byte-identical output to today's direct construction.

Both protocols now agree exactly, including the previously-broken sign:

```
-838:59:59  => 1999-11-27 01:00:01
-01:00:00   => 1999-12-31 23:00:00
00:00:00    => 2000-01-01 00:00:00
12:34:56.25 => 2000-01-01 12:34:56.25
24:00:00    => 2000-01-02 00:00:00
24:00:01    => 2000-01-02 00:00:01
838:59:59   => 2000-02-04 22:59:59
```

## Behavior change (release-note candidate)

Text-protocol callers that used to get `nil` for an out-of-range `TIME` (3-digit hour, or negative) now get a real `Time` on a rolled placeholder date instead. This is broken -> correct, not a new regression, but it's an observable change worth a release-note line: any code that was relying on (or silently tolerating) `nil` for these values will now see a `Time` instead.

## Test plan
- [x] Live-verified the original bug (nil/ArgumentError on text protocol, silent sign-flip on binary protocol) against a real `TIME` column before the fix, and the corrected output after.
- [x] New specs in `result_spec.rb` (text protocol, full value matrix) and `statement_spec.rb` (binary-protocol parity against the text protocol, specifically covering the sign bug).
- [x] Removed two now-stale spec comments in `result_spec.rb` that referenced this as a known pre-existing limitation being deliberately avoided.
- [x] `bundle exec rspec` (full suite) -- 628 examples, 0 failures
- [x] `bundle exec rubocop spec/mysql2/result_spec.rb spec/mysql2/statement_spec.rb` -- no offenses

## Review

@jeremy independently re-verified every claim above against fresh builds of master and this branch, including cases beyond the specs (in-range byte-identity via `eql?`, sub-microsecond precision on negative fractional values, `:application_timezone` composition, and that `cast: false`/`:fast` still bypass the new path entirely), plus a perf comparison (no measurable regression -- within noise). Two non-blocking suggestions from that review are addressed: `mysql2_time_from_duration` now has its own `opt_time_day` instead of reusing `opt_time_month` for both month and day, and the behavior-change note above.
