### PR TITLE
Expose Client#socket on Windows via rb_w32_wrap_io_handle (#647)

### DIFF
--- a/README.md
+++ b/README.md
@@ -829,8 +829,6 @@ Prepared statements honor `:cast => false` and `:cast => :fast` too: result colu
 
 ### Async
 
-NOTE: Not supported on Windows.
-
 `Mysql2::Client` takes advantage of the MySQL C API's (undocumented) non-blocking function mysql_send_query for *all* queries.
 But, in order to take full advantage of it in your Ruby code, you can do:
 
@@ -849,6 +847,10 @@ result = client.async_result
 NOTE: Because of the way MySQL's query API works, this method will block until the result is ready.
 So if you really need things to stay async, it's best to just monitor the socket with something like EventMachine.
 If you need multiple query concurrency take a look at using a connection pool.
+
+`Client#socket` (used for the `IO.select`/EventMachine monitoring above) works
+on Windows too: the native `SOCKET` is wrapped as a CRT file descriptor via
+`rb_w32_wrap_io_handle`, present since Ruby 2.0.
 
 ### Query timing
 

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -11,6 +11,9 @@
 #ifndef _MSC_VER
 #include <unistd.h>
 #endif
+#ifdef _WIN32
+#include <windows.h>
+#endif
 #include <fcntl.h>
 #include "wait_for_single_fd.h"
 
@@ -894,6 +897,10 @@ static VALUE allocate(VALUE klass) {
   wrapper->pending_stmt_close_count = 0;
   wrapper->pending_result_frees = NULL;
   wrapper->pending_result_free_count = 0;
+#ifdef _WIN32
+  wrapper->wrapped_native_fd = -1;
+  wrapper->wrapped_ruby_fd = -1;
+#endif
 
   return obj;
 }
@@ -1291,6 +1298,9 @@ static VALUE rb_mysql_client_close(VALUE self) {
   mysql2_drop_pending_stmt_closes(wrapper);
 
   if (wrapper->client) {
+#if defined(_WIN32) && defined(HAVE_RB_W32_WRAP_IO_HANDLE)
+    mysql2_win32_unwrap_socket(wrapper);
+#endif
     rb_thread_call_without_gvl(nogvl_close, wrapper, RUBY_UBF_IO, 0);
   }
 
@@ -1340,6 +1350,9 @@ static VALUE rb_mysql_client_discard(VALUE self) {
      * share sockets across fork() here anyway. Close the socket outright
      * without a QUIT, same as disconnect_and_mark_inactive. */
     if (CONNECTED(wrapper)) {
+#ifdef HAVE_RB_W32_WRAP_IO_HANDLE
+      mysql2_win32_unwrap_socket(wrapper);
+#endif
       close(wrapper->client->net.fd);
       wrapper->client->net.fd = -1;
     }
@@ -2066,9 +2079,53 @@ static VALUE rb_mysql_client_socket(VALUE self) {
   return INT2NUM(wrapper->client->net.fd);
 }
 #else
-static VALUE rb_mysql_client_socket(RB_MYSQL_UNUSED VALUE self) {
-  rb_raise(cMysql2Error, "Raw access to the mysql file descriptor isn't supported on Windows");
+#ifdef HAVE_RB_W32_WRAP_IO_HANDLE
+/* A native SOCKET isn't a CRT file descriptor, so it has to be registered
+ * with rb_w32_wrap_io_handle() before Ruby's IO layer (IO.for_fd,
+ * IO.select, rb_wait_for_single_fd) can use it -- the same technique
+ * ruby-pg's Connection#socket_io has shipped since 2013. Memoized on the
+ * wrapper (wrapped_native_fd/wrapped_ruby_fd) rather than re-wrapped on
+ * every call: each wrap consumes a slot in the CRT's fd table, and never
+ * releasing a stale one would leak that table over repeated calls. Only
+ * re-wraps if the underlying net.fd has actually changed since the last
+ * call, which covers libmysqlclient's own internal reconnect swapping the
+ * socket out without mysql2 ever seeing nogvl_close run. */
+static VALUE rb_mysql_client_socket(VALUE self) {
+  int native_fd;
+  GET_CLIENT(self);
+  REQUIRE_CONNECTED(wrapper);
+
+  native_fd = (int)wrapper->client->net.fd;
+  if (wrapper->wrapped_native_fd != native_fd) {
+    if (wrapper->wrapped_ruby_fd != -1) {
+      rb_w32_unwrap_io_handle(wrapper->wrapped_ruby_fd);
+    }
+    wrapper->wrapped_ruby_fd = rb_w32_wrap_io_handle((HANDLE)(intptr_t)native_fd, O_RDWR | O_BINARY);
+    wrapper->wrapped_native_fd = native_fd;
+  }
+  return INT2NUM(wrapper->wrapped_ruby_fd);
 }
+
+/* Releases the CRT fd table slot claimed by rb_mysql_client_socket above,
+ * if any. Must run with the GVL held, before the underlying net.fd it
+ * wraps becomes invalid -- callers are the ordinary Ruby-level #close/
+ * #discard! paths, never a dfree/GC-sweep callback (rb_w32_unwrap_io_handle
+ * is not documented safe there, so an unwrap during GC finalization is
+ * skipped rather than risked; the CRT slot is leaked in that case, same
+ * tradeoff decr_mysql2_client already accepts for other per-connection
+ * client-side resources it can't safely reclaim during a sweep). */
+static void mysql2_win32_unwrap_socket(mysql_client_wrapper *wrapper) {
+  if (wrapper->wrapped_ruby_fd != -1) {
+    rb_w32_unwrap_io_handle(wrapper->wrapped_ruby_fd);
+    wrapper->wrapped_ruby_fd = -1;
+    wrapper->wrapped_native_fd = -1;
+  }
+}
+#else
+static VALUE rb_mysql_client_socket(RB_MYSQL_UNUSED VALUE self) {
+  rb_raise(cMysql2Error, "Raw access to the mysql file descriptor requires Ruby 2.0+ (rb_w32_wrap_io_handle) on Windows");
+}
+#endif
 #endif
 
 /* call-seq:

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -30,6 +30,12 @@ static ID intern_brackets, intern_merge, intern_merge_bang, intern_new_with_args
     rb_raise(cMysql2Error, "MySQL client is not initialized"); \
   }
 
+#if defined(_WIN32) && defined(HAVE_RB_W32_WRAP_IO_HANDLE)
+/* Defined below, alongside rb_mysql_client_socket; needed here by the
+ * #close/#discard! call sites further up the file. */
+static void mysql2_win32_unwrap_socket(mysql_client_wrapper *wrapper);
+#endif
+
 #if defined(HAVE_MYSQL_NET_VIO) || defined(HAVE_ST_NET_VIO)
   #define CONNECTED(wrapper) (wrapper->client->net.vio != NULL && wrapper->client->net.fd != -1)
 #elif defined(HAVE_MYSQL_NET_PVIO) || defined(HAVE_ST_NET_PVIO)

--- a/ext/mysql2/client.h
+++ b/ext/mysql2/client.h
@@ -92,6 +92,18 @@ typedef struct {
   unsigned long pending_stmt_close_count; /* O(1) mirror of the list above, for Client#pending_prepared_statement_closes */
   mysql2_pending_result_free *pending_result_frees;
   unsigned long pending_result_free_count;
+#ifdef _WIN32
+  /* Client#socket on Windows: a native SOCKET isn't a CRT file descriptor,
+   * so it has to be registered with rb_w32_wrap_io_handle() before Ruby can
+   * see it as one. wrapped_native_fd is the raw net.fd value last wrapped
+   * (-1 if never); wrapped_ruby_fd is the CRT fd rb_w32_wrap_io_handle
+   * returned for it (-1 if unwrapped or never wrapped). Re-wrapping is only
+   * needed if the two drift apart -- e.g. after libmysqlclient's own
+   * internal reconnect swaps the underlying socket without mysql2 ever
+   * seeing nogvl_close run. */
+  int wrapped_native_fd;
+  int wrapped_ruby_fd;
+#endif
 } mysql_client_wrapper;
 
 extern const rb_data_type_t rb_mysql_client_type;

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -55,6 +55,11 @@ have_func('rb_time_timespec_new', 'ruby.h')
 # Monotonic clock for Result#query_time (gettimeofday fallback otherwise)
 have_func('clock_gettime', 'time.h')
 
+# 2.0+ on Windows: lets Client#socket wrap a native SOCKET as a CRT file
+# descriptor there too, the same technique ruby-pg's Connection#socket_io
+# has used since 2013 (github.com/ged/ruby-pg@84a1bb7fa40b590014dd0258).
+have_func('rb_w32_wrap_io_handle') if RUBY_PLATFORM =~ /mingw|mswin/
+
 ### Find OpenSSL library
 
 # User-specified OpenSSL if explicitly specified

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -1733,10 +1733,27 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
   end
 
   if RUBY_PLATFORM =~ /mingw|mswin/
-    it "#socket should raise as it's not supported" do
+    # rb_w32_wrap_io_handle wraps the native SOCKET as a CRT file descriptor
+    # (#647), the same technique ruby-pg's Connection#socket_io has used
+    # since 2013. Present on any Ruby this project's CI actually tests.
+    it "#socket should return a Fixnum (file descriptor from C)" do
+      expect(@client.socket).to be_an_instance_of(0.class)
+    end
+
+    it "#socket should require an open connection" do
+      @client.close
       expect do
         @client.socket
-      end.to raise_error(Mysql2::Error, /Raw access to the mysql file descriptor isn't supported on Windows/)
+      end.to raise_error(Mysql2::Error)
+    end
+
+    it "#socket should return the same wrapped fd across repeated calls" do
+      expect(@client.socket).to eql(@client.socket)
+    end
+
+    it "#socket should be usable with IO.for_fd" do
+      io_wrapper = IO.for_fd(@client.socket, autoclose: false)
+      expect(IO.select([io_wrapper], nil, nil, 0)).to be_nil # nothing to read yet
     end
   end
 


### PR DESCRIPTION
## Summary

A native Windows `SOCKET` isn't a CRT file descriptor, so `Client#socket` has always just raised there ("Raw access to the mysql file descriptor isn't supported on Windows") -- no way to `IO.select`/EventMachine-monitor a connection for async use on Windows, the only platform where the README's own "Async" section's documented pattern didn't work.

## Fix

`rb_w32_wrap_io_handle` (present on Ruby 2.0+) registers a native `SOCKET`/`HANDLE` as a real CRT file descriptor, exactly the technique [ruby-pg's `Connection#socket_io` has shipped since 2013](https://github.com/ged/ruby-pg/commit/84a1bb7fa40b590014dd0258c973b7b1b5865c48) (this issue itself links that precedent). `Client#socket` now wraps and returns that fd on Windows, matching its existing non-Windows contract (a plain Integer usable with `IO.for_fd`/`IO.select`).

The wrap is memoized on the connection (`wrapped_native_fd`/`wrapped_ruby_fd` on the wrapper struct) rather than re-wrapped on every call -- each wrap consumes a CRT fd-table slot, and re-wrapping on every call without releasing the old one would leak that table. It only re-wraps if the underlying native fd has actually changed since the last call, which covers libmysqlclient's own internal reconnect swapping the socket out from under a live connection without `Client#close` ever running. The wrap is released in both `#close` and `#discard!`, before the underlying native socket is actually invalidated -- deliberately *not* attempted from the GC/dfree path, since `rb_w32_unwrap_io_handle` isn't documented safe during a GC sweep; that leaks the CRT slot in the (already-suboptimal) case of a connection collected while still open, the same tradeoff `decr_mysql2_client` already accepts for other per-connection resources it can't safely reclaim during a sweep.

Builds against a Ruby without `rb_w32_wrap_io_handle` keep today's raise, now naming the actual requirement instead of a bare "not supported".

## Verification

I don't have a Windows environment to test this against locally, so this PR leaned on `build-windows.yml`'s CI matrix (windows-2022/windows-2025, full spec suite against a real MySQL server) to actually verify it -- and it has: both Windows legs, windows-cross, and both windows-precompiled jobs all passed clean.

## Test plan
- [x] macOS: `bundle exec rspec` (full suite) -- 626 examples, 0 failures (unaffected -- all new specs are Windows-gated)
- [x] macOS: `bundle exec rubocop` -- no offenses
- [x] Windows CI (this PR): passed -- new specs cover `#socket` returning a Fixnum, requiring an open connection, memoizing across repeated calls, and usability with `IO.for_fd`/`IO.select`