### PR TITLE
Accept a callable :password, re-evaluated on every connect

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,7 +23,7 @@ Lint/MissingSuper:
 # Offense count: 2
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
 Metrics/AbcSize:
-  Max: 92
+  Max: 92.62
 
 # Offense count: 35
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
@@ -39,7 +39,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 195
+  Max: 198
 
 # Offense count: 3
 # Configuration parameters: AllowedMethods, AllowedPatterns.
@@ -49,7 +49,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 6
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
 Metrics/MethodLength:
-  Max: 54
+  Max: 55
 
 # Offense count: 2
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/README.md
+++ b/README.md
@@ -303,6 +303,55 @@ type of connection to make, with special interpretation you should be aware of:
 * An IPv4 or IPv6 address will result in a TCP connection.
 * Any other value will be looked up as a hostname for a TCP connection.
 
+### Rotating credentials with a callable password
+
+`:password` accepts anything that responds to `call` — a proc, lambda, or
+provider object. The callable is evaluated fresh for every physical connect,
+never cached by the driver, so short-lived credentials such as AWS RDS IAM
+tokens (15-minute lifetime) or Vault dynamic secrets are minted at the moment
+they're needed. It receives a `Mysql2::Client::PasswordContext` with `host`,
+`port`, `username`, and `attempt` (the physical connect attempt number,
+starting at 1), so one provider object can serve many clients:
+
+``` ruby
+provider = lambda do |ctx|
+  Aws::RDS::AuthTokenGenerator.new(credentials: aws_credentials) \
+    .auth_token(region: 'us-east-1', endpoint: "#{ctx.host}:#{ctx.port}", user_name: ctx.username)
+end
+
+client = Mysql2::Client.new(
+  host: 'mydb.cluster-abc123.us-east-1.rds.amazonaws.com',
+  username: 'iam_user',
+  password: provider,
+  enable_cleartext_plugin: true, # RDS IAM sends the token as a cleartext password
+  ssl_mode: :verify_identity,    # never send a cleartext token without TLS
+)
+```
+
+Caching is the provider's job, and the recommended pattern — the same one the
+AWS Advanced JDBC Wrapper implements — is: cache the token keyed by
+host/port/user with a TTL just under the token lifetime, and on an
+authentication failure force-refresh the token and retry the connect once.
+
+``` ruby
+begin
+  client = Mysql2::Client.new(options) # :password provider returns a cached token
+rescue Mysql2::Error => e
+  raise unless e.error_number == 1045 # ER_ACCESS_DENIED_ERROR: cached token may have expired
+
+  provider.refresh! # drop the cached token so the next evaluation mints a new one
+  client = Mysql2::Client.new(options)
+end
+```
+
+A callable `:password` cannot be combined with `reconnect: true` and raises
+`ArgumentError`: libmysqlclient's auto-reconnect re-authenticates inside the
+C library using the password it stored at connect time, so the callable can
+never intercept that path. Reconnect at the application layer instead, where
+constructing a new client evaluates the callable again.
+
+Like a static password, the callable never appears in `#inspect` output.
+
 ### Secure connections with SSL/TLS
 
 The mysql2 gem can configure the underlying MySQL/MariaDB client library to

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -42,10 +42,23 @@ module Mysql2
     }.freeze
     private_constant :TLS_OPTION_ALIASES
 
+    # Passed to a callable :password on every evaluation, so one provider
+    # object can serve many clients and implement its own caching and retry
+    # policy. +attempt+ counts physical connect attempts, starting at 1.
+    PasswordContext = Struct.new(:host, :port, :username, :attempt)
+
     def initialize(opts = {})
       raise Mysql2::Error, "Options parameter must be a Hash" unless opts.is_a? Hash
 
       opts = Mysql2::Util.key_hash_as_symbols(opts)
+
+      # libmysqlclient's auto-reconnect re-authenticates inside the C library
+      # using the password it stored at connect time, so a callable :password
+      # can never intercept that path and rotated credentials would silently
+      # go stale. Refuse the combination.
+      raise ArgumentError, "callable :password is incompatible with reconnect: true; auto-reconnect re-authenticates with the connect-time password, never the callable" \
+        if (opts[:password] || opts[:pass]).respond_to?(:call) && opts[:reconnect]
+
       @read_timeout = nil
       @query_options = self.class.default_query_options.dup
       @query_options.merge! opts
@@ -107,12 +120,12 @@ module Mysql2
 
       # Correct the data types before passing these values down to the C level
       user = user.to_s unless user.nil?
-      pass = pass.to_s unless pass.nil?
       host = host.to_s unless host.nil?
       port = port.to_i unless port.nil?
       database = database.to_s unless database.nil?
       socket = socket.to_s unless socket.nil?
       tls_sni_name = tls_sni_name.to_s unless tls_sni_name.nil?
+      pass = resolve_password(pass, user, host, port)
       conn_attrs = parse_connect_attrs(opts[:connect_attrs])
 
       connect user, pass, host, port, database, socket, flags, conn_attrs, tls_sni_name
@@ -253,6 +266,16 @@ module Mysql2
     end
 
     private
+
+    # A callable :password is evaluated fresh for every physical connect --
+    # never memoized by the driver -- so rotating credentials (AWS RDS IAM
+    # tokens, Vault dynamic secrets) are minted at the moment they're needed.
+    # It runs here in Ruby, with the GVL held, before any network work.
+    # Static values keep the plain to_s treatment.
+    def resolve_password(pass, username, host, port)
+      pass = pass.call(PasswordContext.new(host, port, username, 1).freeze) if pass.respond_to?(:call)
+      pass.nil? ? nil : pass.to_s
+    end
 
     def apply_tls_option_aliases(opts)
       TLS_OPTION_ALIASES.each { |tls_key, legacy_key| opts[legacy_key] = opts[tls_key] if opts.key?(tls_key) }

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -2242,6 +2242,92 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     expect(client.inspect).not_to include("secretsecret")
   end
 
+  context "with a callable :password" do
+    let(:fake_client_class) do
+      Class.new(Mysql2::Client) do
+        attr_reader :connect_args
+
+        def connect(*args)
+          @connect_args = args
+        end
+      end
+    end
+
+    it "connects using the password the callable returns" do
+      client = new_client(password: ->(_ctx) { DatabaseCredentials['root']['password'] })
+      expect(client.query('SELECT 1').first.values).to eql([1])
+    end
+
+    it "passes a frozen PasswordContext carrying host, port, username, and attempt number" do
+      seen = nil
+      provider = lambda do |ctx|
+        seen = ctx
+        'tok3n'
+      end
+      client = fake_client_class.new(host: 'db.example.com', port: '13306', username: 'app_user', password: provider)
+
+      expect(seen).to be_an_instance_of(Mysql2::Client::PasswordContext)
+      expect(seen).to be_frozen
+      expect(seen.to_h).to eql(host: 'db.example.com', port: 13_306, username: 'app_user', attempt: 1)
+      expect(client.connect_args[1]).to eql('tok3n')
+    end
+
+    it "accepts any object responding to #call and massages its result like a static password" do
+      provider = Class.new do
+        def call(_ctx)
+          :secret_token
+        end
+      end.new
+
+      client = fake_client_class.new(password: provider)
+      expect(client.connect_args[1]).to eql('secret_token')
+    end
+
+    it "treats a callable returning nil as no password" do
+      client = fake_client_class.new(password: ->(_ctx) { nil })
+      expect(client.connect_args[1]).to be_nil
+    end
+
+    it "re-evaluates the callable for every connect, never memoizing" do
+      calls = 0
+      provider = lambda do |_ctx|
+        calls += 1
+        DatabaseCredentials['root']['password']
+      end
+
+      new_client(password: provider)
+      new_client(password: provider)
+      expect(calls).to eql(2)
+    end
+
+    it "propagates an error raised by the callable before any connection is made" do
+      error_class = Class.new(StandardError)
+      expect do
+        new_client(password: ->(_ctx) { raise error_class, "token minting failed" })
+      end.to raise_error(error_class, "token minting failed")
+    end
+
+    it "raises ArgumentError when combined with reconnect: true" do
+      expect do
+        fake_client_class.new(password: ->(_ctx) { 'tok3n' }, reconnect: true)
+      end.to raise_error(ArgumentError, /reconnect/)
+    end
+
+    it "connects when combined with reconnect: false" do
+      client = fake_client_class.new(password: ->(_ctx) { 'tok3n' }, reconnect: false)
+      expect(client.connect_args[1]).to eql('tok3n')
+    end
+
+    it "does not leak the callable or its result through #inspect" do
+      client_class = Class.new(Mysql2::Client) do
+        def connect(*args); end
+      end
+
+      client = client_class.new(password: ->(_ctx) { 'secretsecret' })
+      expect(client.inspect).not_to include('password', 'secretsecret', 'Proc')
+    end
+  end
+
   it "should not allow concurrent use of #ping" do
     @client.ping
     thread = new_thread { @client.query("SELECT SLEEP(1)") }


### PR DESCRIPTION
Proposed in #1531. Closes #1263.

## Motivation

`:password` was a string captured once at `Client#initialize`, so credentials that rotate — AWS RDS IAM tokens (15-minute lifetime), Vault dynamic secrets, any short-lived token — could not be expressed: whatever was current when the options hash was built is what the connect got. The protocol-level plumbing for IAM-style token auth already ships (`enable_cleartext_plugin`); the remaining driver gap was purely one of evaluation time.

## Approach

`:password` now accepts anything that responds to `#call`, evaluated fresh for every physical connect — never memoized by the driver — with a frozen `Mysql2::Client::PasswordContext` (`host`, `port`, `username`, `attempt`) so one provider object can serve many clients and implement its own caching and retry policy. Evaluation happens in Ruby, with the GVL held, before the C connect begins any network work. Static String/nil passwords keep their exact previous behavior, including the `to_s` massaging, which now applies to a callable's *result* rather than trapping the callable itself.

Three requirements carried over from the design sodabrew sketched in the #1370 thread (this supersedes davidsiaw's draft there):

1. **Re-evaluated per connect, never cached by the driver** — the entire point for rotating tokens. MySqlConnector (.NET) ships the same contract as `ProvidePasswordCallback`, invoked at initial connect and again on `COM_CHANGE_USER` reset.
2. **`ArgumentError` when combined with `reconnect: true`** — libmysqlclient's auto-reconnect re-authenticates inside the C library using the password it stored at connect time; a callable can never intercept that path, so the combination refuses to construct rather than silently going stale mid-token-lifetime.
3. **Redaction** — the callable is never stored on the client, so it cannot leak through `#inspect` or logs; the existing `@query_options` password scrub covers its option entry.

## Closing #1263 by composition

RDS IAM auth needs no AWS-specific code in the gem: a callable `:password` that mints the token, plus `enable_cleartext_plugin: true` and a verifying `ssl_mode`. The README documents the worked example and the recommended provider pattern — the one the AWS Advanced JDBC Wrapper implements: **cache the token** keyed by host/port/user with a TTL just under the token lifetime, and **on an authentication failure (error 1045) force-refresh and retry the connect once**. mysql2 supplies the hook; the provider supplies that policy.

## Specs

Each new assertion was demonstrated failing first (against pre-change `lib/`, or a deliberately broken build for the redaction spec): callable evaluated per connect with correct context values reaching the C connect args, `to_s` massaging of results, nil-result parity with a static nil password, provider errors propagating before any socket work, `ArgumentError` on the `reconnect: true` combination, and no callable leakage via `#inspect`.

Metrics caps in `.rubocop_todo.yml` re-measured exactly for the grown `Client#initialize` (AbcSize 92.62, ClassLength 198, MethodLength 55); `rubocop` clean, full suite green.