### PR TITLE
Accept host: as an array and connect to the first that answers

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -23,7 +23,7 @@ Lint/MissingSuper:
 # Offense count: 2
 # Configuration parameters: AllowedMethods, AllowedPatterns, CountRepeatedAttributes.
 Metrics/AbcSize:
-  Max: 92
+  Max: 93
 
 # Offense count: 35
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
@@ -39,7 +39,7 @@ Metrics/BlockNesting:
 # Offense count: 1
 # Configuration parameters: CountComments, CountAsOne.
 Metrics/ClassLength:
-  Max: 195
+  Max: 219
 
 # Offense count: 3
 # Configuration parameters: AllowedMethods, AllowedPatterns.
@@ -49,7 +49,7 @@ Metrics/CyclomaticComplexity:
 # Offense count: 6
 # Configuration parameters: CountComments, CountAsOne, AllowedMethods, AllowedPatterns.
 Metrics/MethodLength:
-  Max: 54
+  Max: 57
 
 # Offense count: 2
 # Configuration parameters: AllowedMethods, AllowedPatterns.

--- a/README.md
+++ b/README.md
@@ -303,6 +303,32 @@ type of connection to make, with special interpretation you should be aware of:
 * An IPv4 or IPv6 address will result in a TCP connection.
 * Any other value will be looked up as a hostname for a TCP connection.
 
+### Connecting to the first available host
+
+`:host` also accepts an array of hostnames. Each host is attempted in listed
+order, and the first that answers wins:
+
+``` ruby
+client = Mysql2::Client.new(
+  host: ["db1.internal", "db2.internal"],
+  username: "root"
+)
+```
+
+A host that cannot be reached — unresolvable, unreachable, refused, or timed
+out — advances to the next one. Any other failure, such as bad credentials
+or a TLS misconfiguration, raises immediately since it would repeat on every
+host. When every host is unreachable, the raised error names each host's
+failure.
+
+All hosts share the same `:port` and other connection options. Note that
+`:connect_timeout` applies to each attempt separately, so the worst-case
+connect latency multiplies by the number of hosts.
+
+Connecting is the entire scope: an established connection that dies does not
+migrate to another host. Reconnection, topology discovery, and replaying
+session state remain the connection pool's job.
+
 ### Secure connections with SSL/TLS
 
 The mysql2 gem can configure the underlying MySQL/MariaDB client library to

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -108,14 +108,18 @@ module Mysql2
       # Correct the data types before passing these values down to the C level
       user = user.to_s unless user.nil?
       pass = pass.to_s unless pass.nil?
-      host = host.to_s unless host.nil?
       port = port.to_i unless port.nil?
       database = database.to_s unless database.nil?
       socket = socket.to_s unless socket.nil?
       tls_sni_name = tls_sni_name.to_s unless tls_sni_name.nil?
       conn_attrs = parse_connect_attrs(opts[:connect_attrs])
 
-      connect user, pass, host, port, database, socket, flags, conn_attrs, tls_sni_name
+      if host.is_a?(Array)
+        connect_to_first_available_host host.map(&:to_s), user, pass, port, database, socket, flags, conn_attrs, tls_sni_name
+      else
+        host = host.to_s unless host.nil?
+        connect user, pass, host, port, database, socket, flags, conn_attrs, tls_sni_name
+      end
     end
 
     def parse_ssl_mode(mode)
@@ -252,7 +256,50 @@ module Mysql2
       self.class.info
     end
 
+    # Client-library error codes for failures specific to reaching one host
+    # -- unresolvable, unreachable, refused, timed out -- where another host
+    # may still answer. Any other failure (bad credentials, TLS
+    # misconfiguration, protocol mismatch) would repeat identically on every
+    # host, so it stops the attempt loop immediately.
+    HOST_UNREACHABLE_ERROR_CODES = [
+      2001, # CR_SOCKET_CREATE_ERROR
+      2002, # CR_CONNECTION_ERROR
+      2003, # CR_CONN_HOST_ERROR
+      2004, # CR_IPSOCK_ERROR
+      2005, # CR_UNKNOWN_HOST
+      2013, # CR_SERVER_LOST
+    ].freeze
+    private_constant :HOST_UNREACHABLE_ERROR_CODES
+
     private
+
+    # Attempts each host in listed order and connects to the first that
+    # answers, passing `rest` through to #connect as its post-host
+    # arguments (port, database, socket, flags, conn_attrs, tls_sni_name).
+    # Unreachable hosts advance the loop; when every host is unreachable,
+    # re-raises the last failure's class with each host's error named in
+    # the message.
+    #
+    # Worst-case connect latency multiplies by host count: :connect_timeout
+    # applies to each attempt separately.
+    def connect_to_first_available_host(hosts, user, pass, *rest)
+      raise ArgumentError, ":host array must contain at least one host" if hosts.empty?
+
+      failures = []
+      hosts.each do |host|
+        begin
+          return connect(user, pass, host, *rest)
+        rescue Mysql2::Error => e
+          raise unless HOST_UNREACHABLE_ERROR_CODES.include?(e.error_number)
+
+          failures << [host, e]
+        end
+      end
+
+      last_error = failures.last[1]
+      detail = failures.map { |host, error| "#{host}: #{error.message}" }.join("; ")
+      raise last_error.class.new("unable to connect to any host: #{detail}", nil, last_error.error_number, last_error.sql_state)
+    end
 
     def apply_tls_option_aliases(opts)
       TLS_OPTION_ALIASES.each { |tls_key, legacy_key| opts[legacy_key] = opts[tls_key] if opts.key?(tls_key) }

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -31,6 +31,67 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     end.to raise_error(Mysql2::Error::ConnectionError)
   end
 
+  context "connecting with an array of hosts" do
+    # RFC 6761 reserves .invalid: resolvers must return a name error, so
+    # these hosts fail fast with CR_UNKNOWN_HOST without touching the network.
+
+    it "connects to the first host that answers when earlier hosts are unreachable" do
+      client = new_client('host' => ['unreachable.invalid', DatabaseCredentials['root']['host']], 'connect_timeout' => 5)
+      expect(client.query("SELECT 1 AS one").first).to eq("one" => 1)
+    end
+
+    it "connects to the first host without trying the rest when it answers" do
+      client = new_client('host' => [DatabaseCredentials['root']['host'], 'unreachable.invalid'])
+      expect(client.query("SELECT 1 AS one").first).to eq("one" => 1)
+    end
+
+    it "treats a one-element array like a single host" do
+      client = new_client('host' => [DatabaseCredentials['root']['host']])
+      expect(client.query("SELECT 1 AS one").first).to eq("one" => 1)
+    end
+
+    it "attempts hosts in listed order and stops at the first success" do
+      attempted = []
+      allow_any_instance_of(described_class).to receive(:connect) do |_client, _user, _pass, host, *_rest|
+        attempted << host
+        raise Mysql2::Error::ConnectionError.new("simulated unreachable host", nil, 2003, "HY000") if attempted.size == 1
+      end
+
+      described_class.new(DatabaseCredentials['root'].merge('host' => %w[first.example second.example third.example]))
+      expect(attempted).to eq(%w[first.example second.example])
+    end
+
+    it "raises with each host's failure named when every host is unreachable" do
+      expect do
+        new_client('host' => %w[first-down.invalid second-down.invalid], 'connect_timeout' => 5)
+      end.to raise_error(Mysql2::Error::ConnectionError) { |error|
+        expect(error.message).to match(/first-down\.invalid: /).and match(/second-down\.invalid: /)
+        expect(error.error_number).to eq(2005) # CR_UNKNOWN_HOST
+      }
+    end
+
+    it "fails fast on an authentication error without trying later hosts" do
+      expect do
+        begin
+          new_client('host' => [DatabaseCredentials['root']['host'], 'never-tried.invalid'], 'username' => 'asdfasdf8d2h', 'password' => 'asdfasdfw42')
+        rescue Mysql2::Error => e
+          raise unless e.message.include?('mysql_native_password')
+
+          skip("Native password is not supported")
+        end
+      end.to raise_error(Mysql2::Error::ConnectionError) { |error|
+        expect(error.error_number).to eq(1045) # ER_ACCESS_DENIED_ERROR
+        expect(error.message).not_to include('never-tried.invalid')
+      }
+    end
+
+    it "rejects an empty host array" do
+      expect do
+        new_client('host' => [])
+      end.to raise_error(ArgumentError, /at least one host/)
+    end
+  end
+
   it "should connect over a Unix socket" do
     client = new_socket_client
     expect(client.query("SELECT 1 AS one").first).to eq("one" => 1)


### PR DESCRIPTION
Proposed in #1532. Addresses the driver-layer share of #948 (failover support).

## Motivation

`:host` is a single hostname. Every deployment with more than one address for the same logical database — primary/standby pairs, multi-AZ endpoints, MaxScale/ProxySQL nodes — writes its own rescue-and-retry loop above the driver, each with its own bugs around which errors mean "try the next host" and which mean "stop".

## Approach

Accept `host: ["db1.internal", "db2.internal"]`: attempt each host in listed order and connect to the first that answers, sharing the single `:port` and all other options across attempts. Semantics follow MySqlConnector's `server=a,b,c` failover ordering.

- **Error classification decides continue-vs-stop.** Only failures specific to reaching one host — unresolvable, unreachable, refused, timed out, per a small CR_* errno allowlist — advance the loop. Anything else (bad credentials, TLS misconfiguration) would repeat identically on every host and raises immediately, without trying the rest.
- **All-hosts-down raises one error naming each host's failure**, carrying the last failure's class, errno, and sqlstate.
- **The loop lives in Ruby** around the existing private `connect` call: a failed `mysql_real_connect` leaves the handle initialized and reusable (the C connect path's own EINTR retry already depends on this), so no C changes are needed.
- **A String host behaves exactly as before**; a one-element array behaves like a plain host.
- **Out of scope: everything after the connect succeeds.** An established connection that dies does not migrate — that remains the pool's job, and this loop is what lets a pool implement failover without reaching into the driver.

Worst-case connect latency multiplies by host count (`:connect_timeout` applies per attempt); documented in the README.

## Testing

- First-host-down connects to the second; ordering and stop-at-first-success proven by intercepting the connect attempts.
- All-down raises `ConnectionError` naming each host's failure with the underlying errno.
- Auth failure (1045) fails fast without attempting later hosts.
- Empty array rejected with `ArgumentError`.

All new specs were verified to fail against the pre-change code. Full suite green; rubocop clean (ClassLength/AbcSize/MethodLength caps re-measured exactly).