### PR TITLE
Add Client#reset: one-round-trip session reset via mysql_reset_connection

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -2266,6 +2266,95 @@ static VALUE rb_mysql_client_ping(VALUE self) {
 #endif
 }
 
+#ifdef HAVE_MYSQL_RESET_CONNECTION
+static void *nogvl_reset(void *ptr) {
+  MYSQL *client = ptr;
+
+  return (void *)(mysql_reset_connection(client) == 0 ? Qtrue : Qfalse);
+}
+
+static VALUE do_reset(VALUE completionval) {
+  struct query_completion *completion = (void *)completionval;
+
+  if (rb_thread_call_without_gvl(nogvl_reset, completion->wrapper->client, RUBY_UBF_IO, 0) == Qfalse) {
+    /* A complete round trip -- the server replied with an error, e.g. a
+     * pre-5.7.3 server or a proxy frontend rejecting COM_RESET_CONNECTION
+     * as an unknown command -- so the connection itself is still usable and
+     * the rb_ensure companion only releases the claim. */
+    completion->completed = 1;
+    rb_raise_mysql2_error(completion->wrapper);
+  }
+
+  completion->completed = 1;
+  return Qnil;
+}
+
+/* COM_RESET_CONNECTION deallocated every prepared statement server-side;
+ * bring the Ruby-visible bookkeeping into line. Snapshotting the values and
+ * clearing the hash before the walk keeps the iteration independent of the
+ * hash, since each invalidation releases the GVL to free its MYSQL_STMT. */
+static void invalidate_prepared_statements(mysql_client_wrapper *wrapper) {
+  VALUE stmts = rb_funcall(wrapper->prepared_statements, intern_values, 0);
+  long i;
+
+  rb_hash_clear(wrapper->prepared_statements);
+
+  for (i = 0; i < RARRAY_LEN(stmts); i++) {
+    rb_mysql_stmt_invalidate(rb_ary_entry(stmts, i));
+  }
+
+  (void)RB_GC_GUARD(stmts);
+}
+#endif
+
+/* call-seq:
+ *    client.reset
+ *
+ * Resets the connection's session state on the server in a single round
+ * trip, without reauthenticating: rolls back any open transaction, resets
+ * autocommit, releases locks, drops temporary tables, clears user variables
+ * and session-tracked state, and deallocates prepared statements
+ * (every Mysql2::Statement prepared on this connection is marked closed).
+ * Requires server support for COM_RESET_CONNECTION (MySQL 5.7.3+,
+ * MariaDB 10.2+); older servers and some proxy frontends reject it, which
+ * raises Mysql2::Error and leaves the session untouched.
+ */
+static VALUE rb_mysql_client_reset(VALUE self) {
+#ifdef HAVE_MYSQL_RESET_CONNECTION
+  struct query_completion completion;
+  GET_CLIENT(self);
+  REQUIRE_CONNECTED(wrapper);
+
+  if (mysql2_forked_without_reconnect(wrapper) && wrapper->automatic_close) {
+    mysql2_warn_forked_without_reconnect(wrapper, "reset");
+  }
+
+  rb_mysql_client_set_active_fiber(self, false);
+
+  /* Same preamble as every other command entry point: close out statements
+   * that were GC'd while the connection was busy and free any abandoned
+   * result sets -- mysql_reset_connection() sends a command, so a still-live
+   * abandoned stream needs the same active drain as rb_mysql_query, not just
+   * the reap. Reaping the pending statement closes here also matters for
+   * correctness, not just housekeeping: their COM_STMT_CLOSEs must go out
+   * before the reset deallocates (and potentially renumbers) server-side
+   * statement ids. */
+  mysql2_abandon_active_stream(wrapper);
+  mysql2_reap_pending_result_frees(wrapper);
+  mysql2_reap_pending_stmt_closes(wrapper);
+
+  completion.wrapper = wrapper;
+  completion.completed = 0;
+  rb_ensure(do_reset, (VALUE)&completion, release_claim_or_disconnect, (VALUE)&completion);
+
+  invalidate_prepared_statements(wrapper);
+
+  return Qtrue;
+#else
+  rb_raise(cMysql2Error, "reset is not available, you may need a newer MySQL or MariaDB client library");
+#endif
+}
+
 /* call-seq:
  *    client.set_server_option(value)
  *
@@ -2827,6 +2916,7 @@ void init_mysql2_client(void) {
   rb_define_method(cMysql2Client, "pending_result_frees", rb_mysql_client_pending_result_frees, 0);
   rb_define_method(cMysql2Client, "thread_id", rb_mysql_client_thread_id, 0);
   rb_define_method(cMysql2Client, "ping", rb_mysql_client_ping, 0);
+  rb_define_method(cMysql2Client, "reset", rb_mysql_client_reset, 0);
   rb_define_method(cMysql2Client, "select_db", rb_mysql_client_select_db, 1);
   rb_define_method(cMysql2Client, "set_server_option", rb_mysql_client_set_server_option, 1);
   rb_define_method(cMysql2Client, "more_results?", rb_mysql_client_more_results, 0);

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -271,6 +271,7 @@ $CFLAGS << ' -DMYSQL2_VERIFY_IDENTITY_SHIM' if have_verify_identity_shim
 have_func('mysql_ssl_set', mysql_h)
 have_func('mysql_next_result_nonblocking', mysql_h) # Added in MySQL 8.0.16; no MariaDB Connector/C equivalent under this name (see mysql_next_result_start/_cont)
 have_func('mysql_real_escape_string_quote', mysql_h) # Added in MySQL 5.7.6; no MariaDB Connector/C equivalent
+have_func('mysql_reset_connection', mysql_h) # Added in MySQL 5.7.3 and MariaDB Connector/C 3.0.4
 
 ### Compiler flags to help catch errors
 

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -926,6 +926,32 @@ static VALUE rb_mysql_stmt_close(VALUE self) {
   return Qnil;
 }
 
+/* Close out a statement whose server-side handle no longer exists: Client#reset
+ * sends COM_RESET_CONNECTION, which deallocates every prepared statement on the
+ * connection. This leaves the statement in exactly the state Statement#close
+ * does -- closed flag set, MYSQL_STMT freed and NULLed -- so later use raises
+ * the same clean "Invalid statement handle" error instead of whatever the
+ * client library or server reports for a deallocated handle, and freeing the
+ * client-side MYSQL_STMT here --
+ * rather than leaving it for the GC pending-close queue -- keeps a deferred
+ * COM_STMT_CLOSE from ever carrying a stale statement id that the server (or a
+ * proxy that renumbers ids) may have reassigned to a statement prepared after
+ * the reset. The mysql_stmt_close inside nogvl_stmt_close still sends one
+ * fire-and-forget COM_STMT_CLOSE for the dead id, which servers ignore.
+ *
+ * Runs from ordinary Ruby-level code with the connection idle, right after the
+ * reset round trip completes, so the blocking close is safe here. The caller
+ * (client.c) owns removing the statement from prepared_statements. */
+void rb_mysql_stmt_invalidate(VALUE rb_stmt) {
+  RAW_GET_STATEMENT(rb_stmt);
+
+  if (!stmt_wrapper->closed) {
+    stmt_wrapper->closed = 1;
+    rb_thread_call_without_gvl(nogvl_stmt_close, stmt_wrapper, RUBY_UBF_IO, 0);
+    mysql2_stmt_metadata_cache_clear(stmt_wrapper);
+  }
+}
+
 /* call-seq:
  *    stmt.closed?
  *

--- a/ext/mysql2/statement.h
+++ b/ext/mysql2/statement.h
@@ -54,6 +54,7 @@ typedef struct {
 
 void init_mysql2_statement(void);
 void decr_mysql2_stmt(mysql_stmt_wrapper *stmt_wrapper);
+void rb_mysql_stmt_invalidate(VALUE rb_stmt);
 
 VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql);
 void rb_raise_mysql2_stmt_error(mysql_stmt_wrapper *stmt_wrapper) RB_MYSQL_NORETURN;

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -2033,6 +2033,81 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
     expect(@client).to respond_to(:ping)
   end
 
+  context "#reset" do
+    it "should respond to #reset" do
+      expect(@client).to respond_to(:reset)
+    end
+
+    it "returns true on success" do
+      expect(@client.reset).to eql(true)
+    end
+
+    it "clears user variables" do
+      @client.query("SET @mysql2_test_reset_var = 42")
+      expect(@client.query("SELECT @mysql2_test_reset_var AS v").first["v"]).to eql(42)
+
+      @client.reset
+
+      expect(@client.query("SELECT @mysql2_test_reset_var AS v").first["v"]).to be_nil
+    end
+
+    it "rolls back an open transaction" do
+      @client.query("CREATE TABLE mysql2_test_reset (id INT NOT NULL PRIMARY KEY)")
+      begin
+        @client.query("START TRANSACTION")
+        @client.query("INSERT INTO mysql2_test_reset (id) VALUES (1)")
+
+        @client.reset
+
+        expect(@client.query("SELECT COUNT(*) AS n FROM mysql2_test_reset").first["n"]).to eql(0)
+      ensure
+        @client.query("DROP TABLE IF EXISTS mysql2_test_reset")
+      end
+    end
+
+    it "drops temporary tables" do
+      @client.query("CREATE TEMPORARY TABLE mysql2_test_reset_tmp (id INT)")
+
+      @client.reset
+
+      expect { @client.query("SELECT * FROM mysql2_test_reset_tmp") }.to \
+        raise_error(Mysql2::Error, /doesn't exist/)
+    end
+
+    it "marks prepared statements closed so use after reset raises cleanly instead of hitting the server's deallocated handle" do
+      stmt = @client.prepare("SELECT 1")
+
+      @client.reset
+
+      expect(stmt.closed?).to eql(true)
+      # Same error an explicitly closed statement raises (see statement_spec)
+      expect { stmt.execute }.to raise_error(Mysql2::Error, /Invalid statement handle/)
+      expect(@client.prepared_statements).to eq([])
+    end
+
+    it "leaves Statement#close a no-op for statements invalidated by reset" do
+      stmt = @client.prepare("SELECT 1")
+
+      @client.reset
+
+      expect(stmt.close).to be_nil
+    end
+
+    it "supports preparing new statements after reset" do
+      @client.prepare("SELECT 1 AS one")
+
+      @client.reset
+
+      expect(@client.prepare("SELECT 2 AS two").execute.first["two"]).to eql(2)
+    end
+
+    it "raises when the client is closed" do
+      client = new_client
+      client.close
+      expect { client.reset }.to raise_error(Mysql2::Error, "MySQL client is not connected")
+    end
+  end
+
   context "session_track" do
     before(:example) do
       unless Mysql2::Client.const_defined?(:SESSION_TRACK)


### PR DESCRIPTION
Proposed in #1516; the sanctioned session-reset primitive #948 asked for.

## Motivation

mysql2 has no session-reset primitive. A pool that gets a connection back dirty -- open transaction, session variables, temp tables, user locks -- either replays a multi-statement cleanup dance (ActiveRecord's `reset!` today) or pays a full `close`/`connect`, TCP + TLS + auth handshake included, to fix what the server can undo in one command. The server has had that command since MySQL 5.7.3 / MariaDB 10.2: `COM_RESET_CONNECTION` rolls back any open transaction, resets autocommit, releases locks, drops temp tables, clears user variables and session-tracked state, and deallocates prepared statements -- one round trip, no reauth.

## Approach

`Client#reset` wraps `mysql_reset_connection` under `rb_thread_call_without_gvl`:

- **Entry point**: ping's preamble (abandon the active stream, reap pending result frees and statement closes before touching the wire) with select_db's claim/completion structure -- the fiber claim is released on every unwind, and a server-reported rejection (pre-5.7.3 server, or a proxy frontend that doesn't accept `COM_RESET_CONNECTION`) marks the round trip complete and raises `Mysql2::Error`, leaving the connection usable and the session untouched. No silent fallback.
- **Statement invalidation**: after a successful reset the server has deallocated every prepared statement, so each `Statement` in `wrapper->prepared_statements` is put into exactly the state `Statement#close` leaves behind: closed flag set, client-side `MYSQL_STMT` freed and NULLed, metadata cache cleared. Later use raises the familiar `Invalid statement handle` instead of whatever the client library or server reports for a deallocated handle (modern libmysqlclient says CR_STMT_CLOSED 2056, other libs surface the server's unknown-handler error). Freeing immediately -- rather than leaving handles to the GC pending-close queue -- means no deferred `COM_STMT_CLOSE` can later carry a stale statement id the server (or a proxy that renumbers ids) may have reassigned to a statement prepared after the reset. Reaping the pending-close queue in the preamble matters for the same reason: those closes go out while their ids are still unambiguous.
- **Gating**: `have_func('mysql_reset_connection')` in extconf.rb (MySQL 5.7.3+, MariaDB Connector/C 3.0.4+). Built against an older client library, the method raises `Mysql2::Error`, matching the other unavailable-capability surfaces (get-server-public-key, tls_version, and friends). Every current CI leg has both client and server support, so the specs run unguarded.

Per the support-matrix follow-up in #1516, the `COM_CHANGE_USER` fallback stays never-build, and the opt-in SQL-level degradation rung is left for the proxy-CI round to pin down empirically.

## Specs

- Session-state invariants: user variables cleared, open transaction rolled back, temp tables dropped.
- Statement invalidation: `closed?` flips, `execute` raises the same clean error as after `Statement#close`, `prepared_statements` empties, `Statement#close` stays a no-op, and fresh prepares work after reset.
- Raise paths: closed client raises; server/proxy rejection raises `Mysql2::Error` via the same error path select_db uses.

Each behavior was verified to fail first: against master (no method), against a build with the invalidation walk removed (closed? stays false; execute surfaces the library's CR_STMT_CLOSED instead of the clean raise), and against a build whose reset skips the wire command entirely (all three session-state specs fail). Full suite: 635 examples, 0 failures. RuboCop clean.