### PR TITLE
Report the stored result's client-heap copy to Ruby's GC

### DIFF
--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -37,6 +37,9 @@ have_func('rb_absint_singlebit_p')
 # 2.2+
 have_func('rb_check_symbol_cstr', 'ruby.h')
 
+# 2.4+
+have_func('rb_gc_adjust_memory_usage', 'ruby.h')
+
 # 2.7+
 have_func('rb_gc_mark_movable')
 

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -263,6 +263,20 @@ static void rb_mysql_result_free_result(mysql2_result_wrapper * wrapper, int fro
     } else {
       mysql_free_result(wrapper->result);
     }
+
+#ifdef HAVE_RB_GC_ADJUST_MEMORY_USAGE
+    /* Hand back exactly the bytes reported to the GC at store time --
+     * reading the stashed value keeps the negative adjustment the mirror
+     * image of the positive one, whatever the estimator said. Safe from the
+     * GC dfree path: a negative adjustment only decrements the GC's malloc
+     * bookkeeping (atomically, floored at zero) and can never itself start
+     * a collection. */
+    if (wrapper->reported_size > 0) {
+      rb_gc_adjust_memory_usage(-(ssize_t)wrapper->reported_size);
+      wrapper->reported_size = 0;
+    }
+#endif
+
     wrapper->resultFreed = 1;
   }
 }
@@ -301,6 +315,19 @@ static void rb_mysql_result_free(void *ptr) {
 static size_t rb_mysql_result_memsize(const void * wrapper) {
   const mysql2_result_wrapper * w = wrapper;
   size_t memsize = sizeof(*w);
+  /* The client library's heap copy of the stored result: zero while
+   * streaming and once the underlying result has been freed. */
+  memsize += w->reported_size;
+  /* Statement result bind buffers: the per-field MYSQL_BIND array, its
+   * is_null/error/length side arrays, and each field's value buffer. */
+  if (w->result_buffers) {
+    unsigned int i;
+    memsize += (size_t)w->numberOfFields
+             * (sizeof(MYSQL_BIND) + 2 * sizeof(my_bool) + sizeof(unsigned long));
+    for (i = 0; i < w->numberOfFields; i++) {
+      memsize += w->result_buffers[i].buffer_length;
+    }
+  }
   if (w->stmt_wrapper) {
     memsize += sizeof(*w->stmt_wrapper);
   }
@@ -2494,6 +2521,92 @@ static VALUE rb_mysql_result_query_time(VALUE self) {
   return wrapper->query_time < 0 ? Qnil : DBL2NUM(wrapper->query_time);
 }
 
+#ifdef HAVE_RB_GC_ADJUST_MEMORY_USAGE
+/* Largest size the paired rb_gc_adjust_memory_usage(+N)/(-N) calls can
+ * express: the adjustment parameter is a signed ssize_t. */
+#define MYSQL2_MAX_REPORTED_SIZE ((size_t)-1 >> 1)
+
+/* Estimate the bytes mysql_store_result copied into the client library's
+ * own heap for a buffered text-protocol result. Per row, both
+ * libmysqlclient and MariaDB Connector/C allocate a MYSQL_ROWS list node, a
+ * (fields + 1)-slot cell-pointer array, and the NUL-terminated cell data.
+ * Cell bytes are measured through mysql_fetch_lengths on a log-scaled
+ * sample of rows and extrapolated to the full row count, in the spirit of
+ * pg's pg_result.c sampler: the store just paid O(data) to buffer the rows,
+ * and sizing them shouldn't cost a second full scan. The sampling pass
+ * advances the stored result's cursor with mysql_fetch_row -- pointer
+ * chasing over local memory, no I/O and no error path -- and rewinds with
+ * mysql_data_seek, leaving the result exactly as adopted. The caller must
+ * pass a fully stored (non-streaming) result. */
+static size_t rb_mysql_result_estimate_heap_size(MYSQL_RES *result) {
+  const my_ulonglong num_rows = mysql_num_rows(result);
+  const unsigned int num_fields = mysql_num_fields(result);
+  double size = (double)num_fields * sizeof(MYSQL_FIELD);
+
+  if (num_rows > 0) {
+    my_ulonglong i, target, stride;
+    my_ulonglong sampled = 0;
+    unsigned long long sampled_bytes = 0;
+
+    /* 16 sampled rows per power of two of row count, capped at every row:
+     * results up to a few hundred rows are summed exactly; a million-row
+     * result probes ~320 of them. */
+    target = 0;
+    { my_ulonglong n = num_rows; while (n > 0) { target += 16; n >>= 1; } }
+    if (target > num_rows) target = num_rows;
+    stride = num_rows / target;
+
+    for (i = 0; i < num_rows && mysql_fetch_row(result) != NULL; i++) {
+      if (i % stride == 0) {
+        const unsigned long *lengths = mysql_fetch_lengths(result);
+
+        if (lengths != NULL) {
+          unsigned int f;
+          for (f = 0; f < num_fields; f++) {
+            sampled_bytes += lengths[f];
+          }
+          sampled++;
+        }
+      }
+    }
+    mysql_data_seek(result, 0);
+
+    /* Extrapolate the sampled cell bytes to all rows, then add the fixed
+     * per-row costs: the list node, the cell-pointer array, and one NUL
+     * terminator per cell. Accumulated in double so a huge result cannot
+     * overflow the intermediate products; clamped below. */
+    if (sampled > 0) {
+      size += (double)sampled_bytes * ((double)num_rows / (double)sampled);
+    }
+    size += (double)num_rows * (sizeof(MYSQL_ROWS) + (num_fields + 1) * sizeof(char *) + num_fields);
+  }
+
+  return size >= (double)MYSQL2_MAX_REPORTED_SIZE ? MYSQL2_MAX_REPORTED_SIZE : (size_t)size;
+}
+
+/* Estimate the bytes mysql_stmt_store_result copied into the client
+ * library's own heap for a buffered binary-protocol result by walking the
+ * statement's row list: one MYSQL_ROWS node per row, allocated together
+ * with that row's wire packet, whose length both libmysqlclient
+ * (add_binary_row) and MariaDB Connector/C (mthd_stmt_read_all_rows) record
+ * in MYSQL_ROWS.length as they buffer it. MYSQL_STMT and its result member
+ * are declared in both clients' public headers -- the free path already
+ * reaches into the struct the same way for stmt->bind_result_done. The
+ * separately allocated metadata MYSQL_RES rides along in the fields term.
+ * The caller must pass a statement whose result was just stored
+ * (non-streaming). */
+static size_t rb_mysql_stmt_estimate_heap_size(MYSQL_STMT *stmt, unsigned int num_fields) {
+  const MYSQL_ROWS *row;
+  size_t size = num_fields * sizeof(MYSQL_FIELD);
+
+  for (row = stmt->result.data; row != NULL; row = row->next) {
+    size += sizeof(MYSQL_ROWS) + row->length;
+  }
+
+  return size > MYSQL2_MAX_REPORTED_SIZE ? MYSQL2_MAX_REPORTED_SIZE : size;
+}
+#endif /* HAVE_RB_GC_ADJUST_MEMORY_USAGE */
+
 /* Mysql2::Result */
 VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_RES *r, VALUE statement, double query_time) {
   VALUE obj;
@@ -2537,6 +2650,7 @@ VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_
   wrapper->is_null = NULL;
   wrapper->error = NULL;
   wrapper->length = NULL;
+  wrapper->reported_size = 0;
   /* Plain assignment only: nothing in this function may raise (post-#1463
    * streaming lifecycle). The parse itself happens in the first
    * argument-less #each. */
@@ -2617,6 +2731,26 @@ VALUE rb_mysql_result_to_obj(VALUE client, VALUE encoding, VALUE options, MYSQL_
     VALUE forced = rb_hash_aref(options, sym_force_encoding);
     wrapper->forced_enc = NIL_P(forced) ? NULL : rb_to_encoding(forced);
   }
+
+#ifdef HAVE_RB_GC_ADJUST_MEMORY_USAGE
+  /* Report the client library's freshly stored heap copy of this result to
+   * Ruby's GC, which otherwise never sees it: malloc-driven GC pacing would
+   * let a process holding large results grow its RSS unbounded without ever
+   * provoking a major collection. The estimate is stashed on the wrapper
+   * and handed back, negated, when the underlying result is freed
+   * (rb_mysql_result_free_result), so the two adjustments balance exactly.
+   * Streaming results are exempt: their rows are never client-buffered.
+   * Estimation and adjustment cannot raise and cannot themselves trigger a
+   * collection, keeping this function's no-raise contract. */
+  if (!wrapper->is_streaming) {
+    if (wrapper->stmt_wrapper) {
+      wrapper->reported_size = rb_mysql_stmt_estimate_heap_size(wrapper->stmt_wrapper->stmt, mysql_num_fields(r));
+    } else {
+      wrapper->reported_size = rb_mysql_result_estimate_heap_size(r);
+    }
+    rb_gc_adjust_memory_usage((ssize_t)wrapper->reported_size);
+  }
+#endif
 
   return obj;
 }

--- a/ext/mysql2/result.h
+++ b/ext/mysql2/result.h
@@ -78,6 +78,15 @@ typedef struct {
    * negative when no reading applies (e.g. Client#store_result results).
    * Exposed as #query_time. */
   double query_time;
+  /* Bytes of client-library heap this Result pins, as reported to Ruby's
+   * GC: the estimated size of the mysql_store_result /
+   * mysql_stmt_store_result copy, computed at Result creation and adjusted
+   * +N then, and read back for an exactly-mirrored -N when the underlying
+   * result is freed -- so the paired adjustments always balance, whatever
+   * the estimator returns. Zero for streaming results (rows are never
+   * client-buffered) and once the underlying result has been freed. Also
+   * counted by rb_mysql_result_memsize. */
+  size_t reported_size;
   my_ulonglong numberOfFields;
   my_ulonglong numberOfRows;
   unsigned long lastRowProcessed;

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -88,6 +88,144 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
     expect { result.each { |_| } }.to raise_error(Mysql2::Error, /streaming is true.*to reiterate you must requery/)
   end
 
+  context "GC memory reporting" do
+    # A buffered query pins its whole result set in the client library's own
+    # heap until the C result is freed. That copy is reported to Ruby's GC
+    # via rb_gc_adjust_memory_usage (visible in GC.stat's
+    # :malloc_increase_bytes) and counted by ObjectSpace.memsize_of, with an
+    # exactly-mirrored negative adjustment when the copy is freed.
+    let(:payload) { 1_000_000 }
+    let(:payload_query) { "SELECT REPEAT('x', #{payload}) AS a" }
+
+    before do
+      require "objspace"
+    end
+
+    it "counts the client-side copy of a stored result in ObjectSpace.memsize_of" do
+      result = @client.query payload_query
+      expect(ObjectSpace.memsize_of(result)).to be >= payload
+      result.free
+      expect(ObjectSpace.memsize_of(result)).to be < payload
+    end
+
+    it "keeps the estimate within sane bounds when extrapolating across many rows" do
+      @client.query "CREATE TEMPORARY TABLE gc_report_test (v VARCHAR(2048) NOT NULL)"
+      @client.query "INSERT INTO gc_report_test VALUES #{Array.new(512) { "('#{'y' * 2000}')" }.join(',')}"
+      data_bytes = 512 * 2000
+
+      result = @client.query "SELECT v FROM gc_report_test"
+      expect(ObjectSpace.memsize_of(result)).to be_between(data_bytes, data_bytes * 2)
+      result.free
+      @client.query "DROP TEMPORARY TABLE gc_report_test"
+    end
+
+    it "stops counting the copy once rows are cached and the C result auto-freed" do
+      result = @client.query payload_query
+      result.to_a # cache_rows (the default) frees the C copy at full materialization
+      expect(ObjectSpace.memsize_of(result)).to be < payload
+    end
+
+    it "counts statement result bind buffers in ObjectSpace.memsize_of" do
+      stmt = @client.prepare payload_query
+      result = stmt.execute(stream: true, cache_rows: false)
+      sizes = []
+      result.each { |_row| sizes << ObjectSpace.memsize_of(result) }
+      expect(sizes.max).to be >= payload
+      stmt.close
+    end
+
+    it "adjusts the GC's malloc bookkeeping up at store and back down at free" do
+      skip "needs GC.stat(:malloc_increase_bytes)" unless GC.stat.key?(:malloc_increase_bytes)
+
+      GC.start
+      GC.disable
+      begin
+        # Some Rubies report this counter as mallocs net of frees since the
+        # last GC, clamped at zero, so it can sit far enough underwater to
+        # swallow a payload-sized adjustment whole. Prove a plain malloc of
+        # the same size surfaces before trusting the counter to show ours.
+        probe_base = GC.stat(:malloc_increase_bytes)
+        probe = "x" * payload
+        skip "GC.stat(:malloc_increase_bytes) does not surface malloc growth on this Ruby" \
+          unless GC.stat(:malloc_increase_bytes) - probe_base >= probe.bytesize
+
+        before = GC.stat(:malloc_increase_bytes)
+        result = @client.query payload_query
+        stored = GC.stat(:malloc_increase_bytes)
+        expect(stored - before).to be >= payload
+
+        # Ruby-side allocations from the assertion machinery move the counter
+        # by a few KB of their own, so measure the free's negative adjustment
+        # from its own snapshot and leave allocation-noise headroom.
+        before_free = GC.stat(:malloc_increase_bytes)
+        result.free
+        freed = before_free - GC.stat(:malloc_increase_bytes)
+        expect(freed).to be >= payload - 16_384
+      ensure
+        GC.enable
+      end
+    end
+
+    it "does not report streaming results, whose rows are never client-buffered" do
+      skip "needs GC.stat(:malloc_increase_bytes)" unless GC.stat.key?(:malloc_increase_bytes)
+
+      GC.start
+      GC.disable
+      begin
+        before = GC.stat(:malloc_increase_bytes)
+        result = @client.query payload_query, stream: true, cache_rows: false
+        expect(GC.stat(:malloc_increase_bytes) - before).to be < payload
+        expect(ObjectSpace.memsize_of(result)).to be < payload
+        result.each { |_| } # drain the cursor so the connection is reusable
+      ensure
+        GC.enable
+      end
+    end
+
+    it "balances adjustments exactly across repeated store/free cycles" do
+      skip "needs GC.stat(:malloc_increase_bytes)" unless GC.stat.key?(:malloc_increase_bytes)
+
+      GC.start
+      GC.disable
+      begin
+        before = GC.stat(:malloc_increase_bytes)
+        10.times { @client.query(payload_query).free }
+        drift = GC.stat(:malloc_increase_bytes) - before
+
+        # Each cycle adjusts ~payload up at store and exactly that back down
+        # at free, leaving only small Ruby-side allocations behind; a
+        # one-sided adjustment would accumulate ~payload per cycle.
+        expect(drift).to be < 10 * payload / 2
+      ensure
+        GC.enable
+      end
+    end
+
+    it "nets to zero across a statement execute, whose stored copy is freed at materialization" do
+      skip "needs GC.stat(:malloc_increase_bytes)" unless GC.stat.key?(:malloc_increase_bytes)
+
+      GC.start
+      GC.disable
+      begin
+        stmt = @client.prepare payload_query
+        before = GC.stat(:malloc_increase_bytes)
+        results = Array.new(2) { stmt.execute.to_a }
+        drift = GC.stat(:malloc_increase_bytes) - before
+
+        # Each execute buffers ~payload client-side (adjusted up),
+        # materializes ~payload of Ruby strings, frees the client copy
+        # (adjusted back down), and the first grows a ~payload bind buffer
+        # that later executes adopt: balanced, the counter grows by roughly
+        # 3x payload here, while a one-sided adjustment would leave ~5x.
+        expect(drift).to be < 4 * payload
+        expect(results.first.first["a"].bytesize).to eql(payload)
+        stmt.close
+      ensure
+        GC.enable
+      end
+    end
+  end
+
   it "should keep field_types valid across GC and compaction" do
     result = @client.query "SELECT 1 AS a, 'x' AS b"
     before_types = result.field_types.dup


### PR DESCRIPTION
A buffered query holds its entire result set in the client library's own heap — `mysql_store_result` on the text path, `mysql_stmt_store_result` on the binary path — where Ruby's GC never sees it. Malloc-driven GC pacing never learns that a Result is pinning tens of MB, so a process holding large results grows its RSS unbounded without ever provoking a collection, and `ObjectSpace.memsize_of` reports a few hundred bytes for a Result pinning megabytes.

Proposed in #1517.

## Approach

**GC pacing.** Estimate the client-side copy when the Result adopts it and report it with `rb_gc_adjust_memory_usage(+N)`. The estimate is stashed on the wrapper and handed back, negated, when the underlying result is freed, so the paired adjustments balance by construction however the estimator evolves. Streaming results are exempt: their rows are never client-buffered. pg has shipped this mechanism since 2017 (`pg_result.c`), including its boundary lesson: only memory Ruby cannot otherwise see is reported — the statement bind buffers are xmalloc'd and already flow through Ruby's allocator, so they are deliberately not part of the adjustment.

The estimator differs per protocol because the client libraries record different things:

- **Text**: `mysql_fetch_lengths` over a log-scaled sample of rows (16 per power of two of row count; a million-row result probes ~320), extrapolated to the full row count and added to the per-row node/pointer-array/NUL overheads both client libraries allocate. The pass advances the stored cursor with `mysql_fetch_row` — local pointer chasing, no I/O, no error path — and rewinds with `mysql_data_seek`. (libmysqlclient leaves `MYSQL_ROWS.length` unpopulated for text rows, so the exact walk below isn't available here.)
- **Binary**: walk the statement's `MYSQL_ROWS` list, whose per-row packet length both libmysqlclient (`add_binary_row`) and MariaDB Connector/C (`mthd_stmt_read_all_rows`) record as they buffer it — exact, no sampling. `MYSQL_STMT` and its `result` member are public in both clients' headers; the free path already reaches into the struct the same way for `stmt->bind_result_done`.

Both adjustments are safe from every caller: `rb_gc_adjust_memory_usage` feeds `malloc_increase` as a `MEMOP_TYPE_REALLOC`, which never starts a collection itself (the next real malloc paces off it), so the negative side may run from the GC dfree path, exactly as pg's does. Guarded by `have_func("rb_gc_adjust_memory_usage")` (Ruby 2.4+).

**Honest memsize.** `rb_mysql_result_memsize` gains the stored estimate and the statement result bind buffers (the `MYSQL_BIND` array, its side arrays, and each field's value buffer), so heap dumps stop understating a Result by its entire payload. Accuracy in practice: 1,045,576 reported for 512 rows × 2,000 bytes (+2.1%) on the sampled text path; 1,038,976 (+1.5%) on the exact binary path.

## Evidence

Held-result workload — 40 × 10MB stored results dropped unreferenced (no explicit `#free`), light allocation churn, 7 interleaved runs per arm, medians (ranges), arm64 macOS, Ruby 4.0.6, MySQL 9.6, base 222ee2c:

|  | base | branch |
|---|---|---|
| GC runs | 0 (0..0) | 13 (13..13) |
| … major | 0 (0..0) | 4 (4..4) |
| peak RSS | 283MB (190..467) | 120MB (119..126) |

**The flip side is the point**: workloads that hold big buffered results now GC when they should, where before they silently grew until an OOM. In allocation-heavy microbenchmarks that hold large results, this can read as a throughput loss — that's the corrected pacing, not a regression.

Store-time cost of the estimator is noise: with GC disabled to isolate it, query+free of a 50,000-row result overlaps across arms (branch medians 26–38ms vs base 24–43ms across three interleaved runs).

## Specs

Eight new examples: memsize covers the stored copy (single-row and multi-row/extrapolated, with upper-bound sanity), memsize returns to baseline on free and on materialization auto-free, statement bind buffers counted, `malloc_increase_bytes` adjusts up at store and back down at free, streaming exempt, and no drift across repeated store/free cycles nor across statement executes. The four assertions that pin new behavior fail against base exactly as expected (memsize ≈ 450 bytes vs ≥ payload; `malloc_increase_bytes` delta 1,592 vs ≥ 1,000,000); the other four pass on base by design as regression guards.
