### PR TITLE
Add an :as => :splat row mode that yields cells as block arguments

### DIFF
--- a/README.md
+++ b/README.md
@@ -703,6 +703,25 @@ Pass the `:as => :array` option to any of the above methods of configuration
 
 The default result type is set to `:hash`, but you can override a previous setting to something else with `:as => :hash`
 
+### Splat block arguments
+
+Pass the `:as => :splat` option to yield each row's values directly as block arguments, without building a per-row Array or Hash at all:
+
+``` ruby
+client.query("SELECT id, name FROM users", :as => :splat).each do |id, name|
+  # ...
+end
+```
+
+Values are cast exactly as in the other modes (`:cast`, `:cast_booleans`, and NULL-as-nil all apply); the only per-row objects are the values themselves. Because the row exists only as block arguments, the mode comes with a block-oriented iteration contract:
+
+* A block with fewer parameters than columns sees the leading values -- `{ |id| ... }` on a two-column result receives just the first column -- exactly like any Ruby block called with multiple arguments. Use `:as => :array` if you want the whole row as one object.
+* Rows are never cached: `:cache_rows` is implicitly disabled, `#each` returns an empty array rather than the rows, and a Result whose underlying result set has been freed cannot be re-iterated (a live one can, as with `:cache_rows => false`).
+* Enumerable methods are built on these multi-value yields: most pack each row into an Array (`#to_a` on a two-column result returns pairs), and a single-column row arrives as its bare value.
+* Prepared statement results are not supported -- they materialize and cache every row up front, which is exactly what splat rows can't do -- and raise `Mysql2::Error`.
+
+Works for buffered and streaming queries alike. On older mysql2 versions an unrecognized `:as` value silently means `:hash`, so check your version before relying on this option.
+
 ### Timezones
 
 Mysql2 now supports two timezone options:

--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -70,9 +70,19 @@ typedef enum {
   MYSQL2_CAST_FAST = 2  /* cast: :fast -- cast cheap types; defer expensive ones as Strings */
 } mysql2_cast_mode;
 
+/* The shape #each produces each row as, parsed from the :as option: only the
+ * exact symbols :array and :splat select those modes, and any other value --
+ * recognized or not -- keeps meaning hash rows, as every non-:array value
+ * always has. */
+typedef enum {
+  MYSQL2_ROW_AS_HASH  = 0, /* as: :hash -- a Hash per row (the default) */
+  MYSQL2_ROW_AS_ARRAY = 1, /* as: :array -- an Array per row */
+  MYSQL2_ROW_AS_SPLAT = 2  /* as: :splat -- cells yielded as block arguments; no per-row container */
+} mysql2_row_mode;
+
 typedef struct {
   int symbolizeKeys;
-  int asArray;
+  mysql2_row_mode rowMode;
   int castBool;
   int cacheRows;
   mysql2_cast_mode cast;
@@ -85,11 +95,13 @@ typedef struct {
    * per row. Changing it mid-iteration therefore no longer affects later rows
    * of that same call; the next #each call observes the new value. */
   rb_encoding *default_internal_enc;
-  /* Array-mode cell scratch: one slot per field, ALLOCV-allocated (so the
-   * VALUEs written into it are GC-visible) once per #each call and reused for
-   * every row. Each row's cells are cast into it and the row is built with a
-   * single rb_ary_new4 instead of one rb_ary_push per cell. NULL in hash mode
-   * and when the fetch functions can never run (freed result). */
+  /* Cell scratch for the container-free row modes: one slot per field,
+   * ALLOCV-allocated (so the VALUEs written into it are GC-visible) once per
+   * #each call and reused for every row. Each row's cells are cast into it;
+   * array mode then builds the row with a single rb_ary_new4 instead of one
+   * rb_ary_push per cell, and splat mode yields straight from it
+   * (rb_yield_values2) without building any per-row container at all. NULL
+   * in hash mode and when the fetch functions can never run (freed result). */
   VALUE *rowScratch;
 } result_each_args;
 
@@ -100,7 +112,7 @@ static VALUE opt_time_anchor_utc;
 static ID intern_new, intern_utc, intern_local, intern_localtime, intern_local_offset,
   intern_civil, intern_new_offset, intern_merge, intern_BigDecimal, intern_Float,
   intern_query_options, intern_plus;
-static VALUE sym_symbolize_keys, sym_as, sym_array, sym_database_timezone,
+static VALUE sym_symbolize_keys, sym_as, sym_array, sym_splat, sym_database_timezone,
   sym_application_timezone, sym_local, sym_utc, sym_cast_booleans,
   sym_cache_rows, sym_cast, sym_fast, sym_stream, sym_name, sym_rows_per_gvl_yield,
   sym_no_good_index_used, sym_no_index_used, sym_query_was_slow,
@@ -1197,6 +1209,36 @@ static void rb_mysql_result_alloc_result_buffers(VALUE self, MYSQL_FIELD *fields
   }
 }
 
+/* Finish a row whose cells the fetch loop wrote into args->rowScratch:
+ * array mode materializes them into a new Array; splat mode leaves them in
+ * the scratch for rb_mysql_result_yield_row to pass as block arguments and
+ * returns Qtrue as its row-fetched marker -- never Qnil, which every
+ * consumer treats as the end-of-rows sentinel, so a splat row can never
+ * terminate iteration early. Hash rows never touch the scratch and pass
+ * through unchanged. */
+static VALUE rb_mysql_result_finish_scratch_row(const mysql2_result_wrapper *wrapper, const result_each_args *args, VALUE rowVal) {
+  switch (args->rowMode) {
+    case MYSQL2_ROW_AS_ARRAY:
+      return rb_ary_new4(wrapper->numberOfFields, args->rowScratch);
+    case MYSQL2_ROW_AS_SPLAT:
+      return Qtrue;
+    default:
+      return rowVal;
+  }
+}
+
+/* Yield one fetched row to the iteration block. A splat row's cells are
+ * still in args->rowScratch (its row VALUE is just the Qtrue marker) and
+ * are passed as one block argument per column; the other modes yield the
+ * row object itself. */
+static void rb_mysql_result_yield_row(const mysql2_result_wrapper *wrapper, const result_each_args *args, VALUE row) {
+  if (args->rowMode == MYSQL2_ROW_AS_SPLAT) {
+    rb_yield_values2((int)wrapper->numberOfFields, args->rowScratch);
+  } else {
+    rb_yield(row);
+  }
+}
+
 static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, const result_each_args *args)
 {
   VALUE rowVal = Qnil;
@@ -1221,7 +1263,7 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
     wrapper->numberOfFields = mysql_num_fields(wrapper->result);
     wrapper->fields = rb_ary_new2(wrapper->numberOfFields);
   }
-  if (!args->asArray) {
+  if (args->rowMode == MYSQL2_ROW_AS_HASH) {
 #ifdef HAVE_RB_HASH_NEW_CAPA
     rowVal = rb_hash_new_capa(wrapper->numberOfFields);
 #else
@@ -1346,7 +1388,7 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
   /* Placed after the fetch above rather than with the wrapper->fields
    * allocation so an empty result set stays untouched, exactly as it was
    * when the (never-entered) cell loop did the materializing. */
-  if (args->asArray) {
+  if (args->rowMode != MYSQL2_ROW_AS_HASH) {
     rb_mysql_result_materialize_field_names(self, args->symbolizeKeys);
   }
 
@@ -1360,8 +1402,8 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
    * handling, and the same key-before-value evaluation order. */
   if (args->cast == MYSQL2_CAST_NONE) {
     for (i = 0; i < wrapper->numberOfFields; i++) {
-      /* Hash keys only; array-mode names were batch-materialized above. */
-      VALUE field = args->asArray ? Qnil : rb_mysql_result_fetch_field(self, i, args->symbolizeKeys);
+      /* Hash keys only; array/splat-mode names were batch-materialized above. */
+      VALUE field = args->rowMode != MYSQL2_ROW_AS_HASH ? Qnil : rb_mysql_result_fetch_field(self, i, args->symbolizeKeys);
       VALUE val;
 
       if (!wrapper->is_null[i] && fields[i].type != MYSQL_TYPE_NULL) {
@@ -1371,21 +1413,18 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
         val = Qnil;
       }
 
-      if (args->asArray) {
+      if (args->rowMode != MYSQL2_ROW_AS_HASH) {
         args->rowScratch[i] = val;
       } else {
         rb_hash_aset(rowVal, field, val);
       }
     }
-    if (args->asArray) {
-      rowVal = rb_ary_new4(wrapper->numberOfFields, args->rowScratch);
-    }
-    return rowVal;
+    return rb_mysql_result_finish_scratch_row(wrapper, args, rowVal);
   }
 
   for (i = 0; i < wrapper->numberOfFields; i++) {
-    /* Hash keys only; array-mode names were batch-materialized above. */
-    VALUE field = args->asArray ? Qnil : rb_mysql_result_fetch_field(self, i, args->symbolizeKeys);
+    /* Hash keys only; array/splat-mode names were batch-materialized above. */
+    VALUE field = args->rowMode != MYSQL2_ROW_AS_HASH ? Qnil : rb_mysql_result_fetch_field(self, i, args->symbolizeKeys);
     VALUE val = Qnil;
     MYSQL_TIME *ts;
 
@@ -1588,18 +1627,14 @@ static VALUE rb_mysql_result_fetch_row_stmt(VALUE self, MYSQL_FIELD * fields, co
       }
     }
 
-    if (args->asArray) {
+    if (args->rowMode != MYSQL2_ROW_AS_HASH) {
       args->rowScratch[i] = val;
     } else {
       rb_hash_aset(rowVal, field, val);
     }
   }
 
-  if (args->asArray) {
-    rowVal = rb_ary_new4(wrapper->numberOfFields, args->rowScratch);
-  }
-
-  return rowVal;
+  return rb_mysql_result_finish_scratch_row(wrapper, args, rowVal);
 }
 
 /* Whether a MySQL DECIMAL wire value is zero: sign, digits, '.', digits,
@@ -1660,7 +1695,7 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
     wrapper->numberOfFields = mysql_num_fields(wrapper->result);
     wrapper->fields = rb_ary_new2(wrapper->numberOfFields);
   }
-  if (args->asArray) {
+  if (args->rowMode != MYSQL2_ROW_AS_HASH) {
     /* This runs after the NULL-row check above, so it materializes on the
      * first fetched row and an empty result set stays untouched, exactly
      * as it was when the (never-entered) cell loop did the materializing. */
@@ -1688,8 +1723,8 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
    * fetch above). */
   if (args->cast == MYSQL2_CAST_NONE) {
     for (i = 0; i < wrapper->numberOfFields; i++) {
-      /* Hash keys only; array-mode names were batch-materialized above. */
-      VALUE field = args->asArray ? Qnil : rb_mysql_result_fetch_field(self, i, args->symbolizeKeys);
+      /* Hash keys only; array/splat-mode names were batch-materialized above. */
+      VALUE field = args->rowMode != MYSQL2_ROW_AS_HASH ? Qnil : rb_mysql_result_fetch_field(self, i, args->symbolizeKeys);
       VALUE val;
 
       if (row[i] && fields[i].type != MYSQL_TYPE_NULL) {
@@ -1699,21 +1734,18 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
         val = Qnil;
       }
 
-      if (args->asArray) {
+      if (args->rowMode != MYSQL2_ROW_AS_HASH) {
         args->rowScratch[i] = val;
       } else {
         rb_hash_aset(rowVal, field, val);
       }
     }
-    if (args->asArray) {
-      rowVal = rb_ary_new4(wrapper->numberOfFields, args->rowScratch);
-    }
-    return rowVal;
+    return rb_mysql_result_finish_scratch_row(wrapper, args, rowVal);
   }
 
   for (i = 0; i < wrapper->numberOfFields; i++) {
-    /* Hash keys only; array-mode names were batch-materialized above. */
-    VALUE field = args->asArray ? Qnil : rb_mysql_result_fetch_field(self, i, args->symbolizeKeys);
+    /* Hash keys only; array/splat-mode names were batch-materialized above. */
+    VALUE field = args->rowMode != MYSQL2_ROW_AS_HASH ? Qnil : rb_mysql_result_fetch_field(self, i, args->symbolizeKeys);
     if (row[i]) {
       VALUE val = Qnil;
       enum enum_field_types type = fields[i].type;
@@ -1932,23 +1964,20 @@ static VALUE rb_mysql_result_fetch_row(VALUE self, MYSQL_FIELD * fields, const r
           val = mysql2_set_field_string_encoding(val, fields[i], default_internal_enc, conn_enc, wrapper->forced_enc);
           break;
       }
-      if (args->asArray) {
+      if (args->rowMode != MYSQL2_ROW_AS_HASH) {
         args->rowScratch[i] = val;
       } else {
         rb_hash_aset(rowVal, field, val);
       }
     } else {
-      if (args->asArray) {
+      if (args->rowMode != MYSQL2_ROW_AS_HASH) {
         args->rowScratch[i] = Qnil;
       } else {
         rb_hash_aset(rowVal, field, Qnil);
       }
     }
   }
-  if (args->asArray) {
-    rowVal = rb_ary_new4(wrapper->numberOfFields, args->rowScratch);
-  }
-  return rowVal;
+  return rb_mysql_result_finish_scratch_row(wrapper, args, rowVal);
 }
 
 static VALUE rb_mysql_result_fetch_fields(VALUE self) {
@@ -2107,7 +2136,7 @@ static VALUE rb_mysql_result_each_(VALUE self,
         if (row != Qnil) {
           wrapper->numberOfRows++;
           if (args->block_given) {
-            rb_yield(row);
+            rb_mysql_result_yield_row(wrapper, args, row);
           }
         }
       } while(row != Qnil);
@@ -2183,7 +2212,7 @@ static VALUE rb_mysql_result_each_(VALUE self,
         }
 
         if (args->block_given) {
-          rb_yield(row);
+          rb_mysql_result_yield_row(wrapper, args, row);
         }
       }
       if (wrapper->lastRowProcessed == wrapper->numberOfRows && args->cacheRows) {
@@ -2204,7 +2233,8 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
   VALUE rows;
   VALUE opts, (*fetch_row_func)(VALUE, MYSQL_FIELD *fields, const result_each_args *args);
   ID db_timezone, app_timezone;
-  int symbolizeKeys, asArray, castBool, cacheRows;
+  int symbolizeKeys, castBool, cacheRows;
+  mysql2_row_mode rowMode;
   mysql2_cast_mode cast;
   int warnDbTimezone, perEachOpts;
   unsigned long rowsPerGvlYield;
@@ -2236,7 +2266,7 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
      * conditions are recomputed from the cached (pre-forcing) values below,
      * so they fire on every call exactly as an uncached parse would. */
     symbolizeKeys   = wrapper->each_opts.symbolizeKeys;
-    asArray         = wrapper->each_opts.asArray;
+    rowMode         = (mysql2_row_mode)wrapper->each_opts.rowMode;
     castBool        = wrapper->each_opts.castBool;
     cacheRows       = wrapper->each_opts.cacheRows;
     cast            = wrapper->each_opts.cast;
@@ -2245,16 +2275,26 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
     db_timezone     = wrapper->each_opts.db_timezone;
     app_timezone    = wrapper->each_opts.app_timezone;
   } else {
-    VALUE dbTz, appTz, rowsPerGvlYieldOpt, castOpt;
+    VALUE dbTz, appTz, rowsPerGvlYieldOpt, castOpt, asOpt;
     VALUE defaults = rb_ivar_get(self, intern_query_options);
     Check_Type(defaults, T_HASH);
 
     opts = perEachOpts ? rb_funcall(defaults, intern_merge, 1, opts) : defaults;
 
     symbolizeKeys = RTEST(rb_hash_aref(opts, sym_symbolize_keys));
-    asArray       = rb_hash_aref(opts, sym_as) == sym_array;
     castBool      = RTEST(rb_hash_aref(opts, sym_cast_booleans));
     cacheRows     = RTEST(rb_hash_aref(opts, sym_cache_rows));
+
+    /* See mysql2_row_mode: only the exact symbols :array and :splat select
+     * those modes; any other :as value keeps meaning hash rows. */
+    asOpt = rb_hash_aref(opts, sym_as);
+    if (asOpt == sym_array) {
+      rowMode = MYSQL2_ROW_AS_ARRAY;
+    } else if (asOpt == sym_splat) {
+      rowMode = MYSQL2_ROW_AS_SPLAT;
+    } else {
+      rowMode = MYSQL2_ROW_AS_HASH;
+    }
 
     /* See mysql2_cast_mode: only the exact symbol :fast selects partial
      * casting; any other truthy value stays full casting. */
@@ -2310,7 +2350,7 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
        * unset so the next call re-parses and re-raises just as an uncached
        * one would. */
       wrapper->each_opts.symbolizeKeys   = symbolizeKeys;
-      wrapper->each_opts.asArray         = asArray;
+      wrapper->each_opts.rowMode         = (int)rowMode;
       wrapper->each_opts.castBool        = castBool;
       wrapper->each_opts.cacheRows       = cacheRows;
       wrapper->each_opts.cast            = cast;
@@ -2320,6 +2360,20 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
       wrapper->each_opts.app_timezone    = app_timezone;
       wrapper->each_opts.parsed          = 1;
     }
+  }
+
+  if (rowMode == MYSQL2_ROW_AS_SPLAT) {
+    /* Splat rows exist only as block arguments, never as storable objects,
+     * so the mode cannot serve the prepared-statement path, which
+     * materializes and caches every row inside Statement#execute (the
+     * :cache_rows forcing below). And :cache_rows has nothing to store:
+     * it is overridden off -- which also makes a freed splat result
+     * unreplayable, so the freed-result guard below raises instead of
+     * handing hash/array rows to a block expecting splat arguments. */
+    if (wrapper->stmt_wrapper) {
+      rb_raise(cMysql2Error, "as: :splat is not supported on prepared statement results");
+    }
+    cacheRows = 0;
   }
 
   if (wrapper->is_streaming && cacheRows) {
@@ -2367,7 +2421,7 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
 
   // Backward compat
   args.symbolizeKeys = symbolizeKeys;
-  args.asArray = asArray;
+  args.rowMode = rowMode;
   args.castBool = castBool;
   args.cacheRows = cacheRows;
   args.rowsPerGvlYield = rowsPerGvlYield;
@@ -2388,7 +2442,7 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
    * that is the standard ALLOCV trade, bounded to one buffer per raised
    * iteration because the allocation is per-#each, not per-row. */
   args.rowScratch = NULL;
-  if (asArray && !wrapper->resultFreed) {
+  if (rowMode != MYSQL2_ROW_AS_HASH && !wrapper->resultFreed) {
     args.rowScratch = ALLOCV_N(VALUE, scratch_holder, mysql_num_fields(wrapper->result));
   }
 
@@ -2658,6 +2712,7 @@ void init_mysql2_result(void) {
   sym_symbolize_keys  = ID2SYM(rb_intern("symbolize_keys"));
   sym_as              = ID2SYM(rb_intern("as"));
   sym_array           = ID2SYM(rb_intern("array"));
+  sym_splat           = ID2SYM(rb_intern("splat"));
   sym_local           = ID2SYM(rb_intern("local"));
   sym_utc             = ID2SYM(rb_intern("utc"));
   sym_cast_booleans   = ID2SYM(rb_intern("cast_booleans"));

--- a/ext/mysql2/result.h
+++ b/ext/mysql2/result.h
@@ -40,7 +40,7 @@ void mysql2_result_force_free(VALUE self);
 typedef struct {
   int parsed;
   int symbolizeKeys;
-  int asArray;
+  int rowMode; /* a mysql2_row_mode value */
   int castBool;
   int cacheRows;
   int cast;

--- a/lib/mysql2/client.rb
+++ b/lib/mysql2/client.rb
@@ -4,7 +4,7 @@ module Mysql2
 
     def self.default_query_options
       @default_query_options ||= {
-        as: :hash,                   # the type of object you want each row back as; also supports :array (an array of values)
+        as: :hash,                   # the type of object you want each row back as; also supports :array (an array of values) and :splat (yields each row's values as block arguments, no per-row container)
         async: false,                # don't wait for a result after sending the query, you'll have to monitor the socket yourself then eventually call Mysql2::Client#async_result
         cast_booleans: false,        # cast tinyint(1) fields as true/false in ruby
         symbolize_keys: false,       # return field names as symbols instead of strings

--- a/spec/mysql2/result_spec.rb
+++ b/spec/mysql2/result_spec.rb
@@ -258,6 +258,117 @@ RSpec.describe Mysql2::Result do # rubocop:disable Metrics/BlockLength
       end
     end
 
+    context "when yielding as: :splat rows" do
+      # Splat rows exist only as block arguments: the cells are cast into the
+      # per-#each scratch buffer and passed via rb_yield_values2, one block
+      # argument per column, with no per-row Array or Hash built at all.
+      it "should yield each row's cells as block arguments" do
+        pairs = []
+        @client.query("SELECT 1 AS a, 'x' AS b UNION SELECT 2, 'y'", as: :splat).each { |a, b| pairs << [a, b] }
+        expect(pairs).to eql([[1, "x"], [2, "y"]])
+      end
+
+      it "should yield cells, not a row container, to a single-parameter block" do
+        seen = []
+        @client.query("SELECT 1 AS a, 'x' AS b", as: :splat).each { |cell| seen << cell }
+        expect(seen).to eql([1])
+      end
+
+      it "should yield every cell in field order for wide rows" do
+        width = 40
+        sql = "SELECT #{Array.new(width) { |i| "#{i} AS c#{i}" }.join(', ')}"
+        cells = nil
+        @client.query(sql, as: :splat).each { |*row| cells = row }
+        expect(cells).to eql((0...width).to_a)
+      end
+
+      it "should yield nil cells in position without ending iteration early" do
+        # A NULL cell must arrive as nil in its argument slot, and an all-NULL
+        # row must never read as the end-of-rows sentinel.
+        rows = []
+        @client.query("SELECT 1 AS a, NULL AS b UNION SELECT NULL, NULL UNION SELECT 3, 'z'", as: :splat)
+               .each { |a, b| rows << [a, b] }
+        expect(rows).to eql([[1, nil], [nil, nil], [3, "z"]])
+      end
+
+      it "should return an empty array from #each instead of rows" do
+        result = @client.query("SELECT 1 UNION SELECT 2", as: :splat)
+        expect(result.each { |_| }).to eql([])
+        expect(result.each).to eql([]) # no block: nothing is materialized either
+      end
+
+      it "should pack rows into Arrays under Enumerable methods built on the multi-value yields" do
+        expect(@client.query("SELECT 1, 'x' UNION SELECT 2, 'y'", as: :splat).to_a).to eql([[1, "x"], [2, "y"]])
+        # A single-column row is a single yielded value, so it arrives bare.
+        expect(@client.query("SELECT 1 UNION SELECT 2", as: :splat).to_a).to eql([1, 2])
+      end
+
+      it "should support re-iterating a live result" do
+        result = @client.query("SELECT 1 AS a UNION SELECT 2", as: :splat)
+        first = []
+        result.each { |v| first << v }
+        second = []
+        result.each { |v| second << v }
+        expect(first).to eql([1, 2])
+        expect(second).to eql([1, 2])
+      end
+
+      it "should raise instead of replaying a freed result" do
+        # :cache_rows is overridden off in splat mode, so a freed result has
+        # nothing to replay from.
+        result = @client.query("SELECT 1 AS a UNION SELECT 2", as: :splat)
+        result.each { |_| }
+        result.free
+        expect { result.each { |_| } }.to raise_error(Mysql2::Error, "Result set has already been freed")
+      end
+
+      it "should raise for a per-each :as => :splat once the result has been freed" do
+        result = @client.query("SELECT 1 AS a UNION SELECT 2")
+        result.to_a # fully cached; C result auto-freed
+        expect { result.each(as: :splat) { |_| } }.to raise_error(Mysql2::Error, "Result set has already been freed")
+      end
+
+      it "should support a per-each :as => :splat override on a live result" do
+        result = @client.query("SELECT 1 AS a, 'x' AS b", cache_rows: false)
+        hashes = []
+        result.each { |row| hashes << row }
+        expect(hashes).to eql([{ "a" => 1, "b" => "x" }])
+        cells = []
+        result.each(as: :splat) { |a, b| cells << [a, b] }
+        expect(cells).to eql([[1, "x"]])
+      end
+
+      it "should yield cells for streaming results" do
+        rows = []
+        @client.query("SELECT 1 AS a, 'x' AS b UNION SELECT 2, 'y'", as: :splat, stream: true, cache_rows: false)
+               .each { |a, b| rows << [a, b] }
+        expect(rows).to eql([[1, "x"], [2, "y"]])
+      end
+
+      it "should compose with :cast => false and :cast => :fast" do
+        raw = []
+        @client.query("SELECT 1 AS a, 2.5 AS t", as: :splat, cast: false).each { |a, t| raw << [a, t] }
+        expect(raw).to eql([%w[1 2.5]])
+        fast = []
+        @client.query("SELECT 1 AS a, DATE('2020-01-02') AS d", as: :splat, cast: :fast).each { |a, d| fast << [a, d] }
+        expect(fast).to eql([[1, "2020-01-02"]])
+      end
+
+      it "should still answer #fields after splat iteration" do
+        result = @client.query("SELECT 1 AS a, 2 AS b", as: :splat)
+        result.each { |_| }
+        expect(result.fields).to eql(%w[a b])
+      end
+
+      it "should raise on prepared statement results" do
+        expect { @client.prepare("SELECT 1").execute(as: :splat) }.to \
+          raise_error(Mysql2::Error, "as: :splat is not supported on prepared statement results")
+        stmt_stream = @client.prepare("SELECT 1").execute(stream: true, cache_rows: false, as: :splat)
+        expect { stmt_stream.each { |_| } }.to \
+          raise_error(Mysql2::Error, "as: :splat is not supported on prepared statement results")
+      end
+    end
+
     it "should cache previously yielded results by default" do
       expect(@result.first.object_id).to eql(@result.first.object_id)
     end


### PR DESCRIPTION
Proposed in #1513.

After #1487/#1489/#1490 stripped casting and row assembly down, the per-row Array/Hash container is the last structural per-row allocation in row materialization -- and when the caller iterates with a block, it is pure protocol overhead: built, destructured into block parameters, and discarded without outliving the yield by a single instruction. extralite ships the same idea as `query_mode: :splat`.

## Approach

`:as` now parses into a three-way row-mode enum (`hash`/`array`/`splat`) replacing the `asArray` flag -- the shape suggested in the #1592 thread, so a future `:as => :column` slots in as a fourth value rather than another flag. Splat mode casts each row's cells into the existing per-`#each` `ALLOCV_N` scratch buffer (GC-visible, one slot per field, already used by array mode) and yields them with `rb_yield_values2`, one block argument per column: no per-row container is allocated at all. The fetch functions return `Qtrue` as the mode's row-fetched marker, so `Qnil` stays unambiguously the end-of-rows sentinel and an all-NULL row can never terminate iteration early (the hazard flagged in the #1592 thread never arises in this dispatch shape; a spec pins it anyway).

The mode's contract (README has the user-facing version):

- **Block-only.** A block sees the cells as arguments; a shorter parameter list sees the leading cells, like any Ruby block called with multiple values. Enumerable methods drive `#each` with their own collector blocks, so they receive the multi-value yields and mostly pack them: `#to_a` returns Arrays for multi-column results and bare values for single-column ones. (The proposal sketched "no-block falls back to ordinary materialization"; mechanically `#to_a` *is* block-given, so this packing contract replaces that line -- and a no-block `#each` now materializes nothing and returns `[]`, which is strictly less work for the same visible result, since implied `cache_rows: false` returned `[]` there anyway.)
- **`:cache_rows` is overridden off** -- a splatted row is never a storable object. `#each` returns an empty array; a live result re-iterates via `mysql_data_seek` exactly as `cache_rows: false` does; a freed result raises `Mysql2::Error` instead of replaying cached rows in the wrong shape (deliberately stricter than the existing first-shape-wins replay for `:array` vs `:hash`). Because the override runs before the `:cache_rows is ignored if :stream is true` check, streaming splat queries no longer emit that (moot) warning.
- **Prepared statement results raise `Mysql2::Error`** -- that path materializes and caches every row inside `Statement#execute`, which is exactly what a splat row cannot do. Text protocol only, buffered and streaming alike, per the proposal's scope constraint; a stmt splat branch can be its own parcel if demand shows.
- **Casting is unchanged**: `:cast` (true/`:fast`/false), `:cast_booleans`, and NULL-as-nil apply cell for cell, and field names are still batch-materialized on the first row so `#fields` answers exactly as in array mode.

An unrecognized `:as` keeps meaning hash rows, as it always has, so the new symbol changes nothing for existing callers (and on older mysql2 versions `as: :splat` silently means hash -- the README notes the version floor).

## Specs

New "when yielding as: :splat rows" block in `spec/mysql2/result_spec.rb` (14 examples): cells as block arguments; single-parameter block receives the first cell, not a container; 40-column field order; NULL cells in position with an all-NULL row mid-set (sentinel pin); `#each` returns `[]` with and without a block; Enumerable packing incl. bare single-column `#to_a`; live re-iteration; freed-result raise for both query-time and per-`#each` splat; per-`#each` override on a live result; streaming; `cast: false`/`cast: :fast` composition; `#fields` after splat iteration; stmt rejection for buffered and streaming executes.

Verified to fail: the full block was run against a build of this branch's parent (222ee2c), where `as: :splat` falls through to hash rows -- 13 of 14 examples fail there (wrong yield shapes, no raise on stmt, rows returned from `#each`, hash replay after free) and all pass on this branch. The one exception, the `#fields` example, passes on both by design: it pins splat/array parity rather than new behavior.

## Benchmark

50,000 rows x 10 columns (5 INT, 5 VARCHAR(16)), `cast: true`, buffered; the timed region is repeated `#each` passes over a live result (`mysql_data_seek` replay), i.e. pure client-side materialization and yield dispatch with no server or network time. Min-of-5 per sample, 9 samples per run, three serial alternating base/branch run pairs per machine; medians of run medians, ms per pass. Base is 222ee2c (this branch's parent). On the base arm `as: :splat` falls through to hash rows, so its row is a fall-through control, not a comparison.

Linux x86_64 (Ryzen 9 7950X, Ruby 4.0.6, MySQL 8.0.43 over TCP loopback; machine shared, but the interleaving and tight sub-0.5ms ranges held):

| mode (block shape)        | base 222ee2c | this branch |
|---------------------------|--------------|-------------|
| hash `{ \|row\| }`        |        20.53 |       20.51 |
| array `{ \|row\| }`       |        11.14 |       11.13 |
| array `{ \|c0..c9\| }`    |        11.41 |       11.42 |
| splat `{ \|c0..c9\| }`    | 21.81 (=hash control) | **10.12** |

macOS arm64 (M-series laptop, Ruby 4.0.6, MySQL 9.6, noisier -- shared with concurrent builds; directionally identical):

| mode (block shape)        | base 222ee2c | this branch |
|---------------------------|--------------|-------------|
| hash `{ \|row\| }`        |        32.77 |       32.50 |
| array `{ \|row\| }`       |        16.62 |       17.88 |
| array `{ \|c0..c9\| }`    |        18.01 |       18.95 |
| splat `{ \|c0..c9\| }`    | 33.72 (=hash control) | **14.77** |

Headline (x86): against the same 10-parameter block over array rows, splat is **-11.4%**; against the default hash iteration, **-50.7%**; allocations drop from 6 to 5 objects per row (the row container; the remaining 5 are the VARCHAR cell strings). As the proposal predicted, the wall-clock win over array mode is modest and the structural win is the allocation: this removes the last per-row object that isn't a value the caller asked for, which matters most as sustained GC pressure on long streams. The untouched modes are flat on the quiet box (hash/array within 0.2% with overlapping ranges); the arm64 array deltas are run-to-run noise from concurrent builds (their ranges overlap the base runs').

## Adjacencies

- #1592 (`:as => :column`): this PR deliberately lands the row-mode enum that proposal's thread converged on; column mode composes as a fourth enum value with no sequencing dependency either way. The Qnil-to-Qundef sentinel change discussed there is *not* needed for splat (marker is `Qtrue`) and is left for that parcel.
- #1589 (TIME duration-anchored cast) touches the same `result.c` cast loops, README, and `result_spec.rb`; whichever lands second has a mechanical rebase (this PR renames the per-cell container-write branches that sit directly below the TIME cast arms).

Full suite: 640 examples, 0 failures, 25 pending (environment-gated), RuboCop clean, Ruby 4.0.6, macOS arm64 + specs also exercised on Linux x86_64 during benching.
