### PR TITLE
Add Statement#execute_batch: bulk DML in one round trip, with a loop fallback

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,6 +244,43 @@ statement = @client.prepare("SELECT * FROM users WHERE last_login >= ? AND locat
 result = statement.execute(1, "CA", :as => :array)
 ```
 
+### Batch execution
+
+`Statement#execute_batch` executes a DML statement (INSERT/UPDATE/DELETE — no
+result sets) once per row of an array of parameter rows and returns the summed
+affected-rows count:
+
+``` ruby
+statement = client.prepare("INSERT INTO users (name, login_count) VALUES (?, ?)")
+statement.execute_batch([["fred", 1], ["wilma", 2], ["barney", nil]]) # => 3
+```
+
+On MariaDB Connector/C builds talking to a MariaDB 10.2+ server, the whole
+batch travels as a single `COM_STMT_BULK_EXECUTE` round trip: parameter types
+are sent once per column, values are packed in the binary protocol with a
+per-value NULL indicator, and the server answers with one OK packet.
+Everywhere else — libmysqlclient builds, MySQL servers — the same call falls
+back to executing the statement row by row.
+
+Both paths enforce the same contract, checked client-side before the first row
+executes: every row's arity must match the statement's parameter count, every
+non-nil value in a column must bind as one type (mixed types raise `TypeError`
+naming the row and parameter), and `nil` is SQL NULL anywhere. A batch that
+fails validation executes nothing on either path.
+
+One behavior necessarily differs on a server error partway through the batch
+(a duplicate key, say). The bulk command is a single statement server-side, so
+the error rolls back the whole batch on a transactional engine; the fallback
+loop leaves the rows before the failing one applied. Both raise the server's
+error either way — wrap `execute_batch` in a transaction if you need identical
+all-or-nothing behavior on every build and server.
+
+Batch execution returns only the summed affected-rows count — per-row insert
+ids are not available (`Statement#last_id` reflects the underlying protocol's
+answer and differs between the two paths; don't rely on it after a batch).
+MariaDB 11.5's bulk unit results, which report per-row ids, are a natural
+follow-on gated on newer client and server versions.
+
 Session Tracking information can be accessed with
 
 ``` ruby

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -188,6 +188,21 @@ have_const('MYSQL_OPT_GET_SERVER_PUBLIC_KEY', mysql_h)
 have_const('MYSQL_OPT_TLS_SNI_SERVERNAME', mysql_h) # Added in MySQL 8.1; no MariaDB equivalent (MDEV-10658)
 have_const('MYSQL_OPT_TLS_VERSION', mysql_h) # Added in MySQL 5.7.10; MariaDB Connector/C 3.4.3+ defines the same enum member
 
+# MariaDB Connector/C's bulk execution API (COM_STMT_BULK_EXECUTE): the
+# array-size statement attribute, per-value indicator variables, and the
+# MYSQL_BIND member carrying them. MySQL's libmysqlclient has none of these.
+# Statement#execute_batch sends one round trip per batch when the whole set
+# is present (and the server agrees at runtime); otherwise it falls back to
+# a per-row execute loop.
+if have_const('STMT_ATTR_ARRAY_SIZE', mysql_h) &&
+   have_const('STMT_INDICATOR_NULL', mysql_h) &&
+   have_const('MARIADB_CLIENT_STMT_BULK_OPERATIONS', mysql_h) &&
+   have_const('MARIADB_CONNECTION_EXTENDED_SERVER_CAPABILITIES', mysql_h) &&
+   have_func('mariadb_get_infov', mysql_h) &&
+   have_struct_member('MYSQL_BIND', 'u.indicator', mysql_h)
+  $CFLAGS << ' -DBULK_EXECUTE_SUPPORT'
+end
+
 # my_bool is replaced by C99 bool in MySQL 8.0, but we want
 # to retain compatibility with the typedef in earlier MySQLs.
 have_type('my_bool', mysql_h)

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -805,6 +805,568 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
   return resultObj;
 }
 
+/* Column classifications for Statement#execute_batch. Values classify with
+ * the same Ruby-type mapping Statement#execute uses to pick a MYSQL_BIND
+ * buffer type. execute_batch additionally requires every non-nil value in a
+ * column to classify identically, because a bulk execute sends one type
+ * header per column for the whole batch -- and the loop fallback enforces
+ * the same rule so a batch behaves identically on every build and server. */
+enum mysql2_batch_type {
+  MYSQL2_BATCH_NONE = 0, /* no non-nil value seen yet */
+  MYSQL2_BATCH_LONGLONG,
+  MYSQL2_BATCH_DOUBLE,
+  MYSQL2_BATCH_TINY,
+  MYSQL2_BATCH_DATETIME,
+  MYSQL2_BATCH_DATE,
+  MYSQL2_BATCH_STRING,
+  MYSQL2_BATCH_DECIMAL
+};
+
+static const char *mysql2_batch_type_names[] = {
+  "NULL", "Integer", "Float", "boolean", "Time", "Date", "String", "DECIMAL",
+};
+
+/* Classify one execute_batch value and convert it to the form the bind step
+ * consumes: strings and BigDecimals (and Integers beyond 64 bits, which bind
+ * as DECIMAL strings) are exported to the connection encoding; Time/DateTime/
+ * Date are packed into MYSQL_TIME bytes carried in a Ruby string; integers,
+ * floats, and booleans pass through as-is. Raises TypeError for anything
+ * Statement#execute couldn't bind, annotated with the value's position. */
+static enum mysql2_batch_type mysql2_batch_classify(VALUE v, VALUE *prepared, rb_encoding *conn_enc, unsigned long row, unsigned long col) {
+  *prepared = v;
+
+  switch (TYPE(v)) {
+    case T_FIXNUM:
+      return MYSQL2_BATCH_LONGLONG;
+    case T_BIGNUM:
+      {
+        LONG_LONG num;
+        if (my_big2ll(v, &num) == 0) {
+          return MYSQL2_BATCH_LONGLONG;
+        }
+        /* The bignum was larger than we can fit in LONG_LONG, send it as a string */
+        *prepared = rb_str_new_frozen(rb_str_export_to_enc(rb_big2str(v, 10), conn_enc));
+        return MYSQL2_BATCH_DECIMAL;
+      }
+    case T_FLOAT:
+      return MYSQL2_BATCH_DOUBLE;
+    case T_STRING:
+      /* rb_str_export_to_enc returns the caller's own string when its
+       * encoding already matches, and the bulk path reads each string's
+       * length twice -- once sizing the arena, once filling it -- so pin
+       * both length and bytes with a frozen copy-on-write shadow that a
+       * mutation of the original can't reach. */
+      *prepared = rb_str_new_frozen(rb_str_export_to_enc(v, conn_enc));
+      return MYSQL2_BATCH_STRING;
+    case T_TRUE:
+    case T_FALSE:
+      return MYSQL2_BATCH_TINY;
+    default:
+      if (CLASS_OF(v) == rb_cTime || CLASS_OF(v) == cDateTime) {
+        MYSQL_TIME t;
+
+        memset(&t, 0, sizeof(MYSQL_TIME));
+        t.neg = 0;
+
+        if (CLASS_OF(v) == rb_cTime) {
+          t.second_part = FIX2INT(rb_funcall(v, intern_usec, 0));
+        } else {
+          // sec_fraction is an exact Rational; keep the multiply in
+          // Rational-space and only truncate to an integer at the end,
+          // so no floating-point error can creep into the microseconds.
+          VALUE usec = rb_funcall(rb_funcall(v, intern_sec_fraction, 0), intern_mul, 1, INT2FIX(1000000));
+          t.second_part = NUM2ULONG(rb_funcall(usec, intern_truncate, 0));
+        }
+
+        t.second = FIX2INT(rb_funcall(v, intern_sec, 0));
+        t.minute = FIX2INT(rb_funcall(v, intern_min, 0));
+        t.hour = FIX2INT(rb_funcall(v, intern_hour, 0));
+        t.day = FIX2INT(rb_funcall(v, intern_day, 0));
+        t.month = FIX2INT(rb_funcall(v, intern_month, 0));
+        t.year = FIX2INT(rb_funcall(v, intern_year, 0));
+
+        *prepared = rb_str_new((const char *)&t, sizeof(MYSQL_TIME));
+        return MYSQL2_BATCH_DATETIME;
+      } else if (CLASS_OF(v) == cDate) {
+        MYSQL_TIME t;
+
+        memset(&t, 0, sizeof(MYSQL_TIME));
+        t.second_part = 0;
+        t.neg = 0;
+        t.day = FIX2INT(rb_funcall(v, intern_day, 0));
+        t.month = FIX2INT(rb_funcall(v, intern_month, 0));
+        t.year = FIX2INT(rb_funcall(v, intern_year, 0));
+
+        *prepared = rb_str_new((const char *)&t, sizeof(MYSQL_TIME));
+        return MYSQL2_BATCH_DATE;
+      } else if (CLASS_OF(v) == cBigDecimal) {
+        /* DECIMAL values travel as their string representation, same as
+         * Statement#execute. */
+        *prepared = rb_str_new_frozen(rb_str_export_to_enc(rb_funcall(v, intern_to_s, 0), conn_enc));
+        return MYSQL2_BATCH_DECIMAL;
+      } else {
+        int state = 0;
+        VALUE inspect = rb_protect(rb_inspect, v, &state);
+        if (!state && rb_str_strlen(inspect) > 40) {
+          inspect = rb_str_substr(inspect, 0, 40);
+          rb_str_cat2(inspect, "...");
+        }
+        /* An inspect that raised, or inspect output holding a NUL byte
+         * (which rb_raise's PRIsVALUE formatting rejects), still gets the
+         * TypeError -- just without the value. */
+        if (state || memchr(RSTRING_PTR(inspect), '\0', RSTRING_LEN(inspect))) {
+          rb_raise(rb_eTypeError, "can't bind parameter %lu in row %lu: no conversion for %s",
+                   col + 1, row + 1, rb_obj_classname(v));
+        }
+        rb_raise(rb_eTypeError, "can't bind parameter %lu in row %lu: no conversion for %s (%" PRIsVALUE ")",
+                 col + 1, row + 1, rb_obj_classname(v), inspect);
+      }
+  }
+}
+
+/* Raise unless the prepared statement is DML. Statements returning result
+ * sets have no bulk protocol (COM_STMT_BULK_EXECUTE refuses them
+ * server-side), so execute_batch rejects them up front -- client-side,
+ * before anything executes, identically on the bulk and fallback paths. */
+static void mysql2_batch_require_dml(MYSQL_STMT *stmt) {
+  if (mysql_stmt_field_count(stmt) > 0) {
+    rb_raise(cMysql2Error, "execute_batch is for DML statements (INSERT/UPDATE/DELETE); this statement returns a result set");
+  }
+}
+
+/* Validate the execute_batch contract for rows and convert each value to
+ * the form the bulk bind step consumes: rows must be an Array of Arrays,
+ * each row exactly ncols long, and every non-nil value in a column must
+ * classify as one bind type. Returns the converted values as a flat
+ * row-major Ruby array; fills col_types with each column's unified type,
+ * anchor_rows with the row that established it, and str_bytes with each
+ * string-typed column's summed byte length. Nothing here touches the
+ * statement handle or the wire, so a raise leaves the connection untouched
+ * -- and a batch that would raise here raises identically whether it then
+ * executes as one COM_STMT_BULK_EXECUTE or as a Ruby-level execute loop. */
+static VALUE mysql2_batch_validate(VALUE rows, unsigned long ncols, rb_encoding *conn_enc,
+                                   enum mysql2_batch_type *col_types, unsigned long *anchor_rows,
+                                   unsigned long *str_bytes) {
+  unsigned long nrows, r, c;
+  VALUE prepared;
+
+  Check_Type(rows, T_ARRAY);
+  nrows = (unsigned long)RARRAY_LEN(rows);
+
+  for (c = 0; c < ncols; c++) {
+    col_types[c] = MYSQL2_BATCH_NONE;
+    anchor_rows[c] = 0;
+    str_bytes[c] = 0;
+  }
+
+  prepared = rb_ary_new2((long)(nrows * ncols));
+
+  for (r = 0; r < nrows; r++) {
+    VALUE row = rb_ary_entry(rows, (long)r);
+    if (!RB_TYPE_P(row, T_ARRAY)) {
+      rb_raise(rb_eTypeError, "row %lu is not an Array (%s given)", r + 1, rb_obj_classname(row));
+    }
+    if ((unsigned long)RARRAY_LEN(row) != ncols) {
+      rb_raise(cMysql2Error, "Bind parameter count (%lu) doesn't match number of arguments (%ld) in row %lu",
+               ncols, RARRAY_LEN(row), r + 1);
+    }
+
+    for (c = 0; c < ncols; c++) {
+      VALUE v = rb_ary_entry(row, (long)c);
+      if (NIL_P(v)) {
+        rb_ary_push(prepared, Qnil);
+      } else {
+        VALUE conv;
+        enum mysql2_batch_type tag = mysql2_batch_classify(v, &conv, conn_enc, r, c);
+        if (col_types[c] == MYSQL2_BATCH_NONE) {
+          col_types[c] = tag;
+          anchor_rows[c] = r;
+        } else if (col_types[c] != tag) {
+          rb_raise(rb_eTypeError,
+                   "can't bind parameter %lu in row %lu: %s binds as %s, conflicting with the %s binding established by row %lu",
+                   c + 1, r + 1, rb_obj_classname(v), mysql2_batch_type_names[tag],
+                   mysql2_batch_type_names[col_types[c]], anchor_rows[c] + 1);
+        }
+        if (tag == MYSQL2_BATCH_STRING || tag == MYSQL2_BATCH_DECIMAL) {
+          str_bytes[c] += (unsigned long)RSTRING_LEN(conv);
+        }
+        rb_ary_push(prepared, conv);
+      }
+    }
+  }
+
+  return prepared;
+}
+
+/* call-seq: stmt._validate_batch(rows) # => nil
+ *
+ * Enforce the execute_batch contract without executing anything. The
+ * Ruby-level fallback loop runs this before its first execute, so a batch
+ * that would raise client-side under COM_STMT_BULK_EXECUTE raises
+ * identically -- with no row yet executed -- on builds and servers without
+ * bulk support.
+ */
+static VALUE rb_mysql_stmt_validate_batch(VALUE self, VALUE rows) {
+  unsigned long ncols;
+  enum mysql2_batch_type *col_types = NULL;
+  unsigned long *anchor_rows = NULL;
+  unsigned long *str_bytes = NULL;
+  rb_encoding *conn_enc;
+  GET_STATEMENT(self);
+  GET_CLIENT(stmt_wrapper->client);
+
+  mysql2_batch_require_dml(stmt_wrapper->stmt);
+
+  conn_enc = rb_to_encoding(wrapper->encoding);
+  ncols = mysql_stmt_param_count(stmt_wrapper->stmt);
+  if (ncols > 0) {
+    col_types = alloca(ncols * sizeof(*col_types));
+    anchor_rows = alloca(ncols * sizeof(*anchor_rows));
+    str_bytes = alloca(ncols * sizeof(*str_bytes));
+  }
+  mysql2_batch_validate(rows, ncols, conn_enc, col_types, anchor_rows, str_bytes);
+
+  return Qnil;
+}
+
+#ifdef BULK_EXECUTE_SUPPORT
+/* The library's own MARIADB_STMT_BULK_SUPPORTED macro reads a MYSQL member
+ * whose struct definition is private to the library; mariadb_get_infov is
+ * the public spelling of the same server-capability probe. */
+static int mysql2_bulk_execute_supported(MYSQL *client) {
+  unsigned long server_caps = 0;
+  unsigned long extended_caps = 0;
+
+  if (client == NULL ||
+      mariadb_get_infov(client, MARIADB_CONNECTION_SERVER_CAPABILITIES, &server_caps) ||
+      mariadb_get_infov(client, MARIADB_CONNECTION_EXTENDED_SERVER_CAPABILITIES, &extended_caps)) {
+    return 0;
+  }
+
+  /* A MariaDB-family server (CLIENT_MYSQL off) advertising bulk operations
+   * in its extended capabilities -- the same test the library applies
+   * before generating a COM_STMT_BULK_EXECUTE request. */
+  return !(server_caps & CLIENT_MYSQL) &&
+         (extended_caps & (unsigned long)(MARIADB_CLIENT_STMT_BULK_OPERATIONS >> 32)) != 0;
+}
+#endif
+
+/* call-seq: stmt._bulk_execute_supported? # => true or false
+ *
+ * True when this statement can execute a batch as a single
+ * COM_STMT_BULK_EXECUTE command: the client library was built with the
+ * MariaDB bulk API, the server advertises MARIADB_CLIENT_STMT_BULK_OPERATIONS
+ * (MariaDB 10.2+), and the statement binds at least one parameter (the bulk
+ * protocol rejects parameterless commands). Statement#execute_batch consults
+ * this to pick between the bulk command and its per-row fallback loop.
+ */
+static VALUE rb_mysql_stmt_bulk_execute_supported_p(VALUE self) {
+  GET_STATEMENT(self);
+#ifdef BULK_EXECUTE_SUPPORT
+  return (mysql_stmt_param_count(stmt_wrapper->stmt) > 0 &&
+          mysql2_bulk_execute_supported(stmt_wrapper->stmt->mysql)) ? Qtrue : Qfalse;
+#else
+  return Qfalse;
+#endif
+}
+
+#ifdef BULK_EXECUTE_SUPPORT
+
+/* Bump-allocation within the batch arena: every sub-array is rounded up to
+ * 8-byte alignment, which satisfies every type placed there. */
+#define MYSQL2_BATCH_ALIGN(n) (((size_t)(n) + 7) & ~(size_t)7)
+
+/* call-seq: stmt._execute_bulk(rows) # => Integer
+ *
+ * Execute the prepared statement once per row of rows as a single
+ * COM_STMT_BULK_EXECUTE round trip, returning the batch's summed
+ * affected-rows count from its one OK packet. Callers guard with
+ * _bulk_execute_supported?; Statement#execute_batch is the public face.
+ *
+ * Values for the whole batch are converted up front (mysql2_batch_validate,
+ * which may raise, allocates only GC-managed memory) and then copied into a
+ * single arena holding the MYSQL_BIND array plus each column's value,
+ * pointer, length, and indicator arrays. The copy phase makes no Ruby API
+ * calls that can raise, so the arena's post-execute xfree calls are the
+ * complete set. NULLs travel per value as STMT_INDICATOR_NULL, never via a
+ * column's type header.
+ */
+static VALUE rb_mysql_stmt_execute_bulk(VALUE self, VALUE rows) {
+  MYSQL_STMT *stmt;
+  MYSQL_BIND *bind_buffers;
+  unsigned long ncols, nrows, r, c;
+  enum mysql2_batch_type *col_types;
+  unsigned long *anchor_rows;
+  unsigned long *str_bytes;
+  VALUE prepared;
+  VALUE execute_ok;
+  unsigned int array_size;
+  unsigned int reset_array_size = 0;
+  my_ulonglong affected;
+  char *arena, *cursor;
+  size_t arena_size;
+  struct nogvl_stmt_execute_args execute_args;
+  rb_encoding *conn_enc;
+
+  GET_STATEMENT(self);
+  GET_CLIENT(stmt_wrapper->client);
+
+  if (mysql2_forked_without_reconnect(wrapper) && wrapper->automatic_close) {
+    mysql2_warn_forked_without_reconnect(wrapper, "execute a statement");
+  }
+
+  /* We're about to issue a new command on this connection: a safe point to
+   * close out any statements that were GC'd while it was last busy and to
+   * free any abandoned result sets -- see rb_mysql_stmt_execute. */
+  mysql2_abandon_active_stream(wrapper);
+  mysql2_reap_pending_result_frees(wrapper);
+  mysql2_reap_pending_stmt_closes(wrapper);
+
+  conn_enc = rb_to_encoding(wrapper->encoding);
+
+  stmt = stmt_wrapper->stmt;
+  ncols = mysql_stmt_param_count(stmt);
+
+  mysql2_batch_require_dml(stmt);
+  if (ncols == 0) {
+    rb_raise(cMysql2Error, "COM_STMT_BULK_EXECUTE requires at least one bind parameter");
+  }
+
+  col_types = alloca(ncols * sizeof(*col_types));
+  anchor_rows = alloca(ncols * sizeof(*anchor_rows));
+  str_bytes = alloca(ncols * sizeof(*str_bytes));
+  prepared = mysql2_batch_validate(rows, ncols, conn_enc, col_types, anchor_rows, str_bytes);
+
+  nrows = (unsigned long)RARRAY_LEN(rows);
+  if (nrows == 0) {
+    return INT2FIX(0);
+  }
+  if (nrows > UINT_MAX) {
+    rb_raise(cMysql2Error, "Batch is too large for STMT_ATTR_ARRAY_SIZE (%lu rows)", nrows);
+  }
+
+  /* Size the arena. Column layouts follow what Connector/C's bulk request
+   * generation reads for each buffer type (ma_get_buffer_offset): fixed-size
+   * types are contiguous value arrays indexed by row; date/time and
+   * string-family types are arrays of per-row pointers, strings paired with
+   * a per-row length array. Every column carries a per-value indicator
+   * array. An all-nil column binds as MYSQL_TYPE_STRING whose every
+   * indicator is STMT_INDICATOR_NULL, so its type header is never acted
+   * on. */
+  arena_size = MYSQL2_BATCH_ALIGN(ncols * sizeof(MYSQL_BIND));
+  for (c = 0; c < ncols; c++) {
+    arena_size += MYSQL2_BATCH_ALIGN(nrows); /* indicators */
+    switch (col_types[c]) {
+      case MYSQL2_BATCH_LONGLONG:
+        arena_size += MYSQL2_BATCH_ALIGN(nrows * sizeof(LONG_LONG));
+        break;
+      case MYSQL2_BATCH_DOUBLE:
+        arena_size += MYSQL2_BATCH_ALIGN(nrows * sizeof(double));
+        break;
+      case MYSQL2_BATCH_TINY:
+        arena_size += MYSQL2_BATCH_ALIGN(nrows);
+        break;
+      case MYSQL2_BATCH_DATETIME:
+      case MYSQL2_BATCH_DATE:
+        arena_size += MYSQL2_BATCH_ALIGN(nrows * sizeof(MYSQL_TIME *)) +
+                      MYSQL2_BATCH_ALIGN(nrows * sizeof(MYSQL_TIME));
+        break;
+      case MYSQL2_BATCH_NONE:
+      case MYSQL2_BATCH_STRING:
+      case MYSQL2_BATCH_DECIMAL:
+        arena_size += MYSQL2_BATCH_ALIGN(nrows * sizeof(char *)) +
+                      MYSQL2_BATCH_ALIGN(nrows * sizeof(unsigned long)) +
+                      MYSQL2_BATCH_ALIGN(str_bytes[c]);
+        break;
+    }
+  }
+
+  arena = xcalloc(1, arena_size);
+  cursor = arena;
+
+  bind_buffers = (MYSQL_BIND *)(void *)cursor;
+  cursor += MYSQL2_BATCH_ALIGN(ncols * sizeof(MYSQL_BIND));
+
+  for (c = 0; c < ncols; c++) {
+    /* xcalloc zeroed the indicators: 0 is STMT_INDICATOR_NONE. */
+    char *indicators = cursor;
+    cursor += MYSQL2_BATCH_ALIGN(nrows);
+    bind_buffers[c].u.indicator = indicators;
+
+    switch (col_types[c]) {
+      case MYSQL2_BATCH_LONGLONG:
+        {
+          LONG_LONG *values = (LONG_LONG *)(void *)cursor;
+          cursor += MYSQL2_BATCH_ALIGN(nrows * sizeof(LONG_LONG));
+          bind_buffers[c].buffer_type = MYSQL_TYPE_LONGLONG;
+          bind_buffers[c].buffer = values;
+          for (r = 0; r < nrows; r++) {
+            VALUE v = rb_ary_entry(prepared, (long)(r * ncols + c));
+            if (NIL_P(v)) {
+              indicators[r] = STMT_INDICATOR_NULL;
+            } else if (FIXNUM_P(v)) {
+              values[r] = FIX2LONG(v);
+            } else {
+              LONG_LONG num = 0;
+              (void)my_big2ll(v, &num); /* validated to fit */
+              values[r] = num;
+            }
+          }
+        }
+        break;
+      case MYSQL2_BATCH_DOUBLE:
+        {
+          double *values = (double *)(void *)cursor;
+          cursor += MYSQL2_BATCH_ALIGN(nrows * sizeof(double));
+          bind_buffers[c].buffer_type = MYSQL_TYPE_DOUBLE;
+          bind_buffers[c].buffer = values;
+          for (r = 0; r < nrows; r++) {
+            VALUE v = rb_ary_entry(prepared, (long)(r * ncols + c));
+            if (NIL_P(v)) {
+              indicators[r] = STMT_INDICATOR_NULL;
+            } else {
+              values[r] = RFLOAT_VALUE(v);
+            }
+          }
+        }
+        break;
+      case MYSQL2_BATCH_TINY:
+        {
+          signed char *values = (signed char *)(void *)cursor;
+          cursor += MYSQL2_BATCH_ALIGN(nrows);
+          bind_buffers[c].buffer_type = MYSQL_TYPE_TINY;
+          bind_buffers[c].buffer = values;
+          for (r = 0; r < nrows; r++) {
+            VALUE v = rb_ary_entry(prepared, (long)(r * ncols + c));
+            if (NIL_P(v)) {
+              indicators[r] = STMT_INDICATOR_NULL;
+            } else {
+              values[r] = (v == Qtrue) ? 1 : 0;
+            }
+          }
+        }
+        break;
+      case MYSQL2_BATCH_DATETIME:
+      case MYSQL2_BATCH_DATE:
+        {
+          MYSQL_TIME **ptrs = (MYSQL_TIME **)(void *)cursor;
+          MYSQL_TIME *values;
+          cursor += MYSQL2_BATCH_ALIGN(nrows * sizeof(MYSQL_TIME *));
+          values = (MYSQL_TIME *)(void *)cursor;
+          cursor += MYSQL2_BATCH_ALIGN(nrows * sizeof(MYSQL_TIME));
+          bind_buffers[c].buffer_type = (col_types[c] == MYSQL2_BATCH_DATETIME) ? MYSQL_TYPE_DATETIME : MYSQL_TYPE_DATE;
+          bind_buffers[c].buffer = ptrs;
+          for (r = 0; r < nrows; r++) {
+            VALUE v = rb_ary_entry(prepared, (long)(r * ncols + c));
+            if (NIL_P(v)) {
+              indicators[r] = STMT_INDICATOR_NULL;
+            } else {
+              memcpy(&values[r], RSTRING_PTR(v), sizeof(MYSQL_TIME));
+              ptrs[r] = &values[r];
+            }
+          }
+        }
+        break;
+      case MYSQL2_BATCH_NONE:
+      case MYSQL2_BATCH_STRING:
+      case MYSQL2_BATCH_DECIMAL:
+        {
+          char **ptrs = (char **)(void *)cursor;
+          unsigned long *lengths;
+          char *bytes;
+          cursor += MYSQL2_BATCH_ALIGN(nrows * sizeof(char *));
+          lengths = (unsigned long *)(void *)cursor;
+          cursor += MYSQL2_BATCH_ALIGN(nrows * sizeof(unsigned long));
+          bytes = cursor;
+          cursor += MYSQL2_BATCH_ALIGN(str_bytes[c]);
+          bind_buffers[c].buffer_type = (col_types[c] == MYSQL2_BATCH_DECIMAL) ? MYSQL_TYPE_NEWDECIMAL : MYSQL_TYPE_STRING;
+          bind_buffers[c].buffer = ptrs;
+          bind_buffers[c].length = lengths;
+          for (r = 0; r < nrows; r++) {
+            VALUE v = rb_ary_entry(prepared, (long)(r * ncols + c));
+            if (NIL_P(v)) {
+              indicators[r] = STMT_INDICATOR_NULL;
+            } else {
+              unsigned long len = (unsigned long)RSTRING_LEN(v);
+              memcpy(bytes, RSTRING_PTR(v), len);
+              ptrs[r] = bytes;
+              lengths[r] = len;
+              bytes += len;
+            }
+          }
+        }
+        break;
+    }
+  }
+
+  /* Abandon/reap once more, right before the network write below: the value
+   * conversion above allocates and can trigger the GC sweep that abandons a
+   * different stream on this connection -- see rb_mysql_stmt_execute. */
+  mysql2_abandon_active_stream(wrapper);
+  mysql2_reap_pending_result_frees(wrapper);
+  mysql2_reap_pending_stmt_closes(wrapper);
+
+  // copies bind_buffers into internal storage
+  if (mysql_stmt_bind_param(stmt, bind_buffers)) {
+    xfree(arena);
+    rb_raise_mysql2_stmt_error(stmt_wrapper);
+  }
+
+  array_size = (unsigned int)nrows;
+  if (mysql_stmt_attr_set(stmt, STMT_ATTR_ARRAY_SIZE, &array_size)) {
+    xfree(arena);
+    rb_raise(cMysql2Error, "Unable to set STMT_ATTR_ARRAY_SIZE for bulk execution");
+  }
+
+  // From here through reading the response, the connection is BUSY: a
+  // Statement freed elsewhere during this window must not be allowed to
+  // write COM_STMT_CLOSE to this socket. See rb_mysql_stmt_execute.
+  wrapper->state = MYSQL2_CLIENT_QUERYING;
+  execute_args.stmt = stmt;
+  execute_ok = (VALUE)rb_thread_call_without_gvl(nogvl_stmt_execute, &execute_args, RUBY_UBF_IO, 0);
+
+  /* Statement attributes persist on the handle across executes: clear the
+   * array size on every outcome, before anything can raise, so a later
+   * plain #execute on this statement doesn't go out as a bulk command. */
+  (void)mysql_stmt_attr_set(stmt, STMT_ATTR_ARRAY_SIZE, &reset_array_size);
+
+  /* mysql_stmt_execute serialized the values into the request (or failed);
+   * either way the bind arrays are done with. */
+  xfree(arena);
+
+  wrapper->state = MYSQL2_CLIENT_IDLE;
+
+  if (execute_ok == Qfalse) {
+    rb_raise_mysql2_stmt_error(stmt_wrapper);
+  }
+
+  /* The batch's one OK packet carries the affected-rows sum for every
+   * parameter set. DML returns no result set, so there is nothing further
+   * to read or store. */
+  affected = mysql_stmt_affected_rows(stmt);
+  if (affected == (my_ulonglong)-1) {
+    rb_raise_mysql2_stmt_error(stmt_wrapper);
+  }
+
+  mysql2_reap_pending_result_frees(wrapper);
+  mysql2_reap_pending_stmt_closes(wrapper);
+
+  RB_GC_GUARD(prepared);
+  RB_GC_GUARD(rows);
+
+  return ULL2NUM(affected);
+}
+
+#else /* BULK_EXECUTE_SUPPORT */
+
+static VALUE rb_mysql_stmt_execute_bulk(VALUE self, VALUE rows) {
+  (void)self;
+  (void)rows;
+  rb_raise(cMysql2Error, "This mysql2 build has no COM_STMT_BULK_EXECUTE support");
+}
+
+#endif /* BULK_EXECUTE_SUPPORT */
+
 /* call-seq: stmt.fields # => array
  *
  * Returns a list of fields that will be returned by this statement.
@@ -954,6 +1516,9 @@ void init_mysql2_statement(void) {
   rb_define_method(cMysql2Statement, "param_count", rb_mysql_stmt_param_count, 0);
   rb_define_method(cMysql2Statement, "field_count", rb_mysql_stmt_field_count, 0);
   rb_define_method(cMysql2Statement, "_execute", rb_mysql_stmt_execute, -1);
+  rb_define_method(cMysql2Statement, "_execute_bulk", rb_mysql_stmt_execute_bulk, 1);
+  rb_define_method(cMysql2Statement, "_validate_batch", rb_mysql_stmt_validate_batch, 1);
+  rb_define_method(cMysql2Statement, "_bulk_execute_supported?", rb_mysql_stmt_bulk_execute_supported_p, 0);
   rb_define_method(cMysql2Statement, "fields", rb_mysql_stmt_fields, 0);
   rb_define_method(cMysql2Statement, "last_id", rb_mysql_stmt_last_id, 0);
   rb_define_method(cMysql2Statement, "affected_rows", rb_mysql_stmt_affected_rows, 0);

--- a/lib/mysql2/statement.rb
+++ b/lib/mysql2/statement.rb
@@ -5,5 +5,29 @@ module Mysql2
         _execute(*args, **kwargs)
       end
     end
+
+    # Execute the prepared statement once per row of +rows+, an Array of
+    # parameter Arrays, returning the batch's summed affected-rows count.
+    #
+    # On MariaDB Connector/C builds talking to a MariaDB 10.2+ server the
+    # whole batch travels as a single COM_STMT_BULK_EXECUTE round trip;
+    # everywhere else each row executes through the ordinary execute path.
+    # Both paths enforce the same contract before the first row executes:
+    # the statement must be DML (no result set), every row's arity must
+    # match the statement's parameter count, and every non-nil value in a
+    # column must bind as one type. +nil+ is SQL NULL anywhere.
+    def execute_batch(rows)
+      Thread.handle_interrupt(::Mysql2::Util::TIMEOUT_ERROR_NEVER) do
+        if _bulk_execute_supported?
+          _execute_bulk(rows)
+        else
+          _validate_batch(rows)
+          rows.reduce(0) do |count, row|
+            _execute(*row)
+            count + affected_rows
+          end
+        end
+      end
+    end
   end
 end

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -1380,4 +1380,191 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
       expect(@client.pending_prepared_statement_closes).to eq(0)
     end
   end
+
+  context "#execute_batch" do
+    before(:example) do
+      @client.query 'DROP TABLE IF EXISTS mysql2_stmt_batch_test'
+      @client.query <<-SQL
+        CREATE TABLE mysql2_stmt_batch_test (
+          id INT PRIMARY KEY AUTO_INCREMENT,
+          int_col INT,
+          str_col VARCHAR(32),
+          float_col DOUBLE,
+          time_col DATETIME(6),
+          date_col DATE,
+          dec_col DECIMAL(30,3),
+          bool_col TINYINT
+        )
+      SQL
+    end
+
+    after(:example) do
+      @client.query 'DROP TABLE IF EXISTS mysql2_stmt_batch_test'
+    end
+
+    def batch_rows
+      @client.query('SELECT * FROM mysql2_stmt_batch_test ORDER BY id').to_a
+    end
+
+    # The whole contract runs twice: once over COM_STMT_BULK_EXECUTE where
+    # the build and server support it, and once over the per-row fallback
+    # loop, forced by stubbing the capability probe. Client-side behavior --
+    # validation, raise-early ordering, return values, mid-batch server
+    # errors -- must not differ between the two.
+    shared_examples "the execute_batch contract" do
+      def prepare_batch(sql)
+        stmt = @client.prepare(sql)
+        allow(stmt).to receive(:_bulk_execute_supported?).and_return(false) if forced_fallback
+        stmt
+      end
+
+      it "executes every row type-faithfully and returns the summed affected-rows count" do
+        stmt = prepare_batch('INSERT INTO mysql2_stmt_batch_test (int_col, str_col, float_col, time_col, date_col, dec_col, bool_col) VALUES (?, ?, ?, ?, ?, ?, ?)')
+        time = Time.local(2026, 6, 7, 8, 9, 10, 654_321)
+        date = Date.new(2011, 2, 3)
+
+        count = stmt.execute_batch(
+          [
+            [1, "one", 1.5, time, date, BigDecimal("123.456"), true],
+            [2, "二", -2.5, time, date, BigDecimal("-1.5"), false],
+            [nil, nil, nil, nil, nil, nil, nil],
+          ],
+        )
+        expect(count).to eq(3)
+
+        rows = batch_rows
+        expect(rows.map { |r| r['int_col'] }).to eq([1, 2, nil])
+        expect(rows.map { |r| r['str_col'] }).to eq(["one", "二", nil])
+        expect(rows.map { |r| r['float_col'] }).to eq([1.5, -2.5, nil])
+        expect(rows.map { |r| r['time_col'] }).to eq([time, time, nil])
+        expect(rows.map { |r| r['date_col'] }).to eq([date, date, nil])
+        expect(rows.map { |r| r['dec_col'] }).to eq([BigDecimal("123.456"), BigDecimal("-1.5"), nil])
+        expect(rows.map { |r| r['bool_col'] }).to eq([1, 0, nil])
+      end
+
+      it "returns 0 and executes nothing for an empty batch" do
+        stmt = prepare_batch('INSERT INTO mysql2_stmt_batch_test (int_col) VALUES (?)')
+        expect(stmt.execute_batch([])).to eq(0)
+        expect(batch_rows).to be_empty
+      end
+
+      it "binds a column holding only nils as NULL for every row" do
+        stmt = prepare_batch('INSERT INTO mysql2_stmt_batch_test (int_col, str_col) VALUES (?, ?)')
+        expect(stmt.execute_batch([[nil, "a"], [nil, "b"]])).to eq(2)
+        expect(batch_rows.map { |r| [r['int_col'], r['str_col']] }).to eq([[nil, "a"], [nil, "b"]])
+      end
+
+      it "binds a column mixing 64-bit-overflowing Integers and BigDecimals as DECIMAL" do
+        stmt = prepare_batch('INSERT INTO mysql2_stmt_batch_test (dec_col) VALUES (?)')
+        expect(stmt.execute_batch([[2**70], [BigDecimal("1.5")]])).to eq(2)
+        expect(batch_rows.map { |r| r['dec_col'] }).to eq([BigDecimal(2**70), BigDecimal("1.5")])
+      end
+
+      it "sums affected rows across UPDATEs, counting rows that matched nothing as zero" do
+        @client.query "INSERT INTO mysql2_stmt_batch_test (int_col, str_col) VALUES (1, 'a'), (2, 'b')"
+        stmt = prepare_batch('UPDATE mysql2_stmt_batch_test SET str_col = ? WHERE int_col = ?')
+        expect(stmt.execute_batch([["x", 1], ["y", 999]])).to eq(1)
+        expect(batch_rows.map { |r| r['str_col'] }).to eq(%w[x b])
+      end
+
+      it "counts ON DUPLICATE KEY updates the way a per-row execute loop does" do
+        stmt = prepare_batch('INSERT INTO mysql2_stmt_batch_test (id, int_col) VALUES (?, ?) ON DUPLICATE KEY UPDATE int_col = ?')
+        expect(stmt.execute_batch([[1, 10, 10], [1, 20, 20], [2, 30, 30]])).to eq(4)
+        expect(batch_rows.map { |r| r['int_col'] }).to eq([20, 30])
+      end
+
+      it "executes a parameterless statement once per empty row" do
+        stmt = prepare_batch('INSERT INTO mysql2_stmt_batch_test () VALUES ()')
+        expect(stmt.execute_batch([[], [], []])).to eq(3)
+        expect(batch_rows.size).to eq(3)
+      end
+
+      it "raises before executing anything when a row's arity doesn't match the parameter count" do
+        stmt = prepare_batch('INSERT INTO mysql2_stmt_batch_test (int_col) VALUES (?)')
+        expect { stmt.execute_batch([[1], [1, 2]]) }.to raise_error(Mysql2::Error, /doesn't match number of arguments \(2\) in row 2/)
+        expect(batch_rows).to be_empty
+      end
+
+      it "raises before executing anything when a column mixes bind types" do
+        stmt = prepare_batch('INSERT INTO mysql2_stmt_batch_test (int_col) VALUES (?)')
+        expect { stmt.execute_batch([[1], [2], ["three"]]) }.to \
+          raise_error(TypeError, /can't bind parameter 1 in row 3: String binds as String, conflicting with the Integer binding established by row 1/)
+        expect(batch_rows).to be_empty
+      end
+
+      it "raises before executing anything when a value has no conversion" do
+        stmt = prepare_batch('INSERT INTO mysql2_stmt_batch_test (int_col) VALUES (?)')
+        expect { stmt.execute_batch([[1], [:nope]]) }.to raise_error(TypeError, /can't bind parameter 1 in row 2: no conversion for Symbol \(:nope\)/)
+        expect(batch_rows).to be_empty
+      end
+
+      it "raises when a row is not an Array" do
+        stmt = prepare_batch('INSERT INTO mysql2_stmt_batch_test (int_col) VALUES (?)')
+        expect { stmt.execute_batch([[1], 2]) }.to raise_error(TypeError, /row 2 is not an Array \(Integer given\)/)
+        expect(batch_rows).to be_empty
+      end
+
+      it "raises when rows is not an Array" do
+        stmt = prepare_batch('INSERT INTO mysql2_stmt_batch_test (int_col) VALUES (?)')
+        expect { stmt.execute_batch(:nope) }.to raise_error(TypeError)
+      end
+
+      it "rejects statements that return a result set, even for an empty batch" do
+        stmt = prepare_batch('SELECT ?')
+        expect { stmt.execute_batch([]) }.to raise_error(Mysql2::Error, /DML/)
+        expect { stmt.execute_batch([[1]]) }.to raise_error(Mysql2::Error, /DML/)
+      end
+
+      it "raises the server's error on a mid-batch failure" do
+        stmt = prepare_batch('INSERT INTO mysql2_stmt_batch_test (id) VALUES (?)')
+        expect { stmt.execute_batch([[1], [2], [1], [3]]) }.to raise_error(Mysql2::Error, /[Dd]uplicate entry/)
+
+        # The one behavior the two paths cannot share: a bulk batch is a
+        # single statement server-side, so an error rolls the whole batch
+        # back on a transactional engine, while the per-row loop leaves the
+        # rows before the failure applied. Callers needing the same
+        # visibility everywhere wrap execute_batch in their own transaction.
+        expect(batch_rows.map { |r| r['id'] }).to eq(ids_kept_after_mid_batch_error)
+      end
+
+      it "leaves the statement reusable for ordinary executes and further batches" do
+        stmt = prepare_batch('INSERT INTO mysql2_stmt_batch_test (int_col) VALUES (?)')
+        expect(stmt.execute_batch([[1], [2]])).to eq(2)
+        stmt.execute(3)
+        expect(stmt.affected_rows).to eq(1)
+        expect(stmt.execute_batch([[4]])).to eq(1)
+        expect(batch_rows.map { |r| r['int_col'] }).to eq([1, 2, 3, 4])
+      end
+    end
+
+    context "over the per-row fallback loop" do
+      let(:forced_fallback) { true }
+      let(:ids_kept_after_mid_batch_error) { [1, 2] }
+
+      include_examples "the execute_batch contract"
+    end
+
+    context "over COM_STMT_BULK_EXECUTE" do
+      let(:forced_fallback) { false }
+      let(:ids_kept_after_mid_batch_error) { [] }
+
+      before(:example) do
+        probe = @client.prepare('INSERT INTO mysql2_stmt_batch_test (int_col) VALUES (?)')
+        skip "COM_STMT_BULK_EXECUTE requires a MariaDB Connector/C build and a MariaDB 10.2+ server" unless probe._bulk_execute_supported?
+      end
+
+      include_examples "the execute_batch contract"
+    end
+
+    it "never chooses the bulk protocol for a parameterless statement" do
+      stmt = @client.prepare('INSERT INTO mysql2_stmt_batch_test () VALUES ()')
+      expect(stmt._bulk_execute_supported?).to eq(false)
+    end
+
+    it "raises on a closed statement" do
+      stmt = @client.prepare('INSERT INTO mysql2_stmt_batch_test (int_col) VALUES (?)')
+      stmt.close
+      expect { stmt.execute_batch([[1]]) }.to raise_error(Mysql2::Error, /Invalid statement handle/)
+    end
+  end
 end


### PR DESCRIPTION
Proposed in #1527.

N-row DML through mysql2 is N executes and N round trips — there is no bulk surface anywhere in ext/. MariaDB's `COM_STMT_BULK_EXECUTE` (server 10.2+, MDEV-12471) sends one command carrying N parameter sets — types once per column, a per-value indicator byte, one OK packet back — and mysql2 couldn't reach it.

`Statement#execute_batch(rows)` executes the prepared statement once per row of an array of parameter rows and returns the summed affected-rows count:

```ruby
stmt = client.prepare("INSERT INTO users (name, login_count) VALUES (?, ?)")
stmt.execute_batch([["fred", 1], ["wilma", 2], ["barney", nil]]) # => 3
```

## Approach

**Bulk path** (MariaDB Connector/C build + MariaDB 10.2+ server): the batch is column-wise bound — fixed-size types as value arrays, date/times and strings/decimals as per-row pointer arrays with per-row lengths, the exact layouts Connector/C's bulk request generation reads for each buffer type — and executed once with `STMT_ATTR_ARRAY_SIZE` set. The attribute is cleared again on every outcome, since statement attributes persist on the handle and a later plain `#execute` must not go out as a bulk command. Values convert up front (the only phase that can raise), then copy into a single xcalloc'd arena whose fill phase makes no raising Ruby calls, so the post-execute frees are the complete set. String params are pinned as frozen copy-on-write shadows, since the encoding export can return the caller's own string and the arena is sized from lengths read before the copy.

**Fallback path** (libmysqlclient builds, MySQL servers, parameterless statements): the same call loops the existing execute path and sums per-execute affected rows.

**Gating**: build-time `have_const`/`have_func`/`have_struct_member` probes for the full API surface (`STMT_ATTR_ARRAY_SIZE`, `STMT_INDICATOR_NULL`, `MYSQL_BIND.u.indicator`, `mariadb_get_infov` + the extended-capabilities enum); runtime probe of the server's `MARIADB_CLIENT_STMT_BULK_OPERATIONS` bit through `mariadb_get_infov` — the public spelling of the library's own `MARIADB_STMT_BULK_SUPPORTED` macro, which is unusable from client code because it reads a struct the public headers leave incomplete.

**One contract, shared C, enforced before anything executes** on either path:

- DML only — statements returning result sets are rejected client-side (the bulk protocol refuses them server-side; the fallback matches).
- Every row's arity must match the statement's parameter count.
- One bind type per column across the batch, classified with `#execute`'s exact type mapping. Mixed concrete types raise `TypeError` naming the row, parameter, and both types, rather than draw the server's error after part of the batch executed; unbindable values raise `#execute`'s annotated `TypeError`.
- `nil` is SQL NULL anywhere, sent per value as `STMT_INDICATOR_NULL` — never via the column's type header, so columns mix values and NULLs freely and an all-nil column needs no type anchor.

A batch that fails validation executes nothing on either path.

**The one behavior the paths cannot share**, documented in the README and specs rather than papered over: the bulk command is a single statement server-side, so a mid-batch error rolls back the whole batch on a transactional engine, while the loop leaves rows before the failure applied (empirically confirmed against MariaDB 11.8). Both raise the same server error; callers needing identical all-or-nothing visibility everywhere wrap `execute_batch` in their own transaction.

The summed count is a new, explicit API rather than a transparent upgrade of existing execute loops — the trap Connector/J hit when `useBulkStmts` silently turned per-row counts into an aggregate OK and broke optimistic-locking users. Per-row insert ids remain unavailable in both shapes; MariaDB 11.5's bulk unit results (`MARIADB_CLIENT_BULK_UNIT_RESULTS`) are the separately-gated follow-on for that.

## Specs

The identical contract runs through both paths: over real `COM_STMT_BULK_EXECUTE` where build and server support it (skipped elsewhere — the existing MariaDB CI legs exercise it), and over the fallback loop everywhere, forced by stubbing the capability probe. Verified to fail against deliberately broken builds:

- dropping the `ARRAY_SIZE` reset → statement-reusability spec fails (bulk path);
- sending nil as `STMT_INDICATOR_NONE` → type-fidelity specs crash into it (bulk path);
- skipping fallback validation → all six raise-early contract specs fail (fallback path);
- miscounting the fallback sum → UPDATE and ON DUPLICATE KEY affected-rows specs fail (fallback path).

Suites: full spec suite green on macOS/arm64 with a libmysqlclient 9.6 build against MySQL 9.6 (658 examples, 0 failures); full suite green on x86 Linux against MariaDB 11.8 with a Connector/C 12.3 build — the real bulk path — except the two specs requiring a local Unix socket (server in Docker; they skip under `MYSQL2_SPEC_NO_LOCAL_SOCKET=1` as in CI). A macOS MariaDB Connector/C build against the MySQL 9.6 server — bulk API compiled in, runtime-refused by the server — runs the full statement spec plus the execute_batch matrix green, exercising the runtime gate; CI's cross-vendor rows cover that client/server pairing end to end.

## Numbers

thelio (32-core x86 Linux), MariaDB 11.8 in Docker over loopback TCP, Connector/C 12.3; interleaved arms, median of 30 with min–max. Batch INSERT of (INT, VARCHAR(32), DOUBLE) rows, all arms inside one transaction so every arm pays one commit:

| arm | 100 rows | 1000 rows |
|---|---|---|
| per-row execute loop | 3.199 ms (2.929–3.884) | 37.614 ms (34.806–42.986) |
| **execute_batch (bulk)** | **0.171 ms (0.157–0.259) — 18.7x** | **6.682 ms (5.539–8.674) — 5.6x** |
| hand-built multi-VALUES INSERT | 0.273 ms (0.245–1.558) | 7.478 ms (6.273–8.506) |

In autocommit the loop additionally pays a commit per row and the 100-row gap widens to 89x (163.7 ms vs 1.8 ms). The fallback path is the execute loop, and benches as one (macOS, libmysqlclient against local MySQL 9.6 over TLS, autocommit: 36.483 ms loop vs 36.475 ms execute_batch medians for 100 rows).

## Adjacency

Builds alongside #1596 (param-arena), which reworks `rb_mysql_stmt_execute`'s bind-buffer allocation in this same file. This PR deliberately adds all its code outside that function — its own conversion helper and arena — so the two should merge cleanly in either order; the post-merge cleanup of unifying the two arena mechanisms is a natural follow-up. Same-file adjacency disclosed per the precedent in #1563/#1571.
