### PR TITLE
Document private security reporting

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,7 @@
+# Security Policy
+
+## Reporting a vulnerability
+
+Please do not report security vulnerabilities in public issues.
+
+Use GitHub's [private vulnerability reporting form](https://github.com/brianmario/mysql2/security/advisories/new). If the form is unavailable, email the maintainers listed in [`mysql2.gemspec`](mysql2.gemspec) with a brief summary and arrange a secure channel before sending exploit details, credentials, or production data.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -4,4 +4,6 @@
 
 Please do not report security vulnerabilities in public issues.
 
-Use GitHub's [private vulnerability reporting form](https://github.com/brianmario/mysql2/security/advisories/new). If the form is unavailable, email the maintainers listed in [`mysql2.gemspec`](mysql2.gemspec) with a brief summary and arrange a secure channel before sending exploit details, credentials, or production data.
+Use GitHub's [private vulnerability reporting form](https://github.com/brianmario/mysql2/security/advisories/new).
+If the form is unavailable, email the maintainers listed in [`mysql2.gemspec`](mysql2.gemspec)
+with a brief summary and arrange a secure channel before sending exploit details, credentials, or production data.


### PR DESCRIPTION
Adds a concise SECURITY.md directing vulnerability reports to GitHub private vulnerability reporting, with a maintainer-email fallback when the form is unavailable.

This is the companion documentation change for #1600. Enabling private vulnerability reporting remains a repository setting, so this PR does not close that issue.

Tests: documentation-only change.