### PR TITLE
Guard prepared-statement operations against concurrent client use

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -908,10 +908,11 @@ static void rb_mysql_client_set_active_fiber(VALUE self, bool closing) {
     // mark this connection active
     wrapper->active_fiber = fiber_current;
   } else if (wrapper->active_fiber == fiber_current) {
-    /* Closing an async text query from its owner is supported. A generic
-     * command may be inside a user conversion callback, though, and closing
-     * it here would free the MYSQL/MYSQL_STMT still on that same C stack. */
-    if (!closing || wrapper->state == MYSQL2_CLIENT_COMMAND) {
+    /* Closing an async text query from its owner is supported. Every other
+     * claimed phase may be inside a user callback -- including prepared
+     * result construction after a streaming cursor has opened -- so closing
+     * there would free the MYSQL/MYSQL_STMT still on that same C stack. */
+    if (!closing || wrapper->state != MYSQL2_CLIENT_QUERYING) {
       rb_raise(cMysql2Error, "This connection is still waiting for a result, try again once you have the result");
     }
   } else {
@@ -2804,7 +2805,11 @@ static VALUE rb_mysql_client_prepared_statements_read(VALUE self) {
   completion.wrapper = wrapper;
   completion.completed = 0;
 
+  /* Reaping may send COM_STMT_CLOSE or drain an abandoned result. Do not do
+   * either while a live streaming Result still owns the connection. */
+  mysql2_client_check_idle(self);
   rb_mysql_client_set_active_fiber(self, false);
+  wrapper->state = MYSQL2_CLIENT_COMMAND;
   return rb_ensure(do_prepared_statements_read, (VALUE)&completion,
                    release_claim_or_disconnect, (VALUE)&completion);
 }

--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -144,6 +144,7 @@ struct nogvl_select_db_args {
 };
 
 static VALUE rb_mysql_client_close(VALUE self);
+static VALUE release_claim_or_disconnect(VALUE completionval);
 
 /*
  * ssl_mode: :verify_identity enforcement for MariaDB Connector/C.
@@ -907,9 +908,36 @@ static void rb_mysql_client_set_active_fiber(VALUE self, bool closing) {
     // mark this connection active
     wrapper->active_fiber = fiber_current;
   } else if (wrapper->active_fiber == fiber_current) {
-    if (!closing) {
+    /* Closing an async text query from its owner is supported. A generic
+     * command may be inside a user conversion callback, though, and closing
+     * it here would free the MYSQL/MYSQL_STMT still on that same C stack. */
+    if (!closing || wrapper->state == MYSQL2_CLIENT_COMMAND) {
       rb_raise(cMysql2Error, "This connection is still waiting for a result, try again once you have the result");
     }
+  } else {
+    VALUE inspect = rb_inspect(wrapper->active_fiber);
+    const char *thr = StringValueCStr(inspect);
+
+    rb_raise(cMysql2Error, "This connection is in use by: %s", thr);
+  }
+}
+
+void mysql2_client_claim(VALUE self) {
+  rb_mysql_client_set_active_fiber(self, false);
+}
+
+void mysql2_client_check_idle(VALUE self) {
+  VALUE fiber_current = rb_fiber_current();
+  GET_CLIENT(self);
+
+  if (NIL_P(wrapper->active_fiber)) {
+    if (wrapper->state == MYSQL2_CLIENT_IDLE) {
+      return;
+    }
+    rb_raise(cMysql2Error, "This connection is still waiting for a result, try again once you have the result");
+  }
+  if (wrapper->active_fiber == fiber_current) {
+    rb_raise(cMysql2Error, "This connection is still waiting for a result, try again once you have the result");
   } else {
     VALUE inspect = rb_inspect(wrapper->active_fiber);
     const char *thr = StringValueCStr(inspect);
@@ -1329,8 +1357,9 @@ static VALUE rb_mysql_client_closed(VALUE self) {
  *
  * @return [nil]
  */
-static VALUE rb_mysql_client_discard(VALUE self) {
-  GET_CLIENT(self);
+static VALUE do_discard(VALUE completionval) {
+  struct query_completion *completion = (void *)completionval;
+  mysql_client_wrapper *wrapper = completion->wrapper;
 
   if (wrapper->initialized && !wrapper->closed) {
 #ifndef _WIN32
@@ -1359,7 +1388,20 @@ static VALUE rb_mysql_client_discard(VALUE self) {
     rb_thread_call_without_gvl(nogvl_close, wrapper, RUBY_UBF_IO, 0);
   }
 
+  completion->completed = 1;
   return Qnil;
+}
+
+static VALUE rb_mysql_client_discard(VALUE self) {
+  struct query_completion completion;
+  GET_CLIENT(self);
+
+  completion.wrapper = wrapper;
+  completion.completed = 0;
+
+  rb_mysql_client_set_active_fiber(self, true);
+  return rb_ensure(do_discard, (VALUE)&completion,
+                   release_claim_or_disconnect, (VALUE)&completion);
 }
 
 double mysql2_monotonic_now(void) {
@@ -1519,9 +1561,15 @@ static VALUE rb_mysql_client_async_result(VALUE self) {
   double query_elapsed;
   GET_CLIENT(self);
 
-  /* if we're not waiting on a result, do nothing */
+  /* Only a text query has a result for this method to read. Other commands
+   * use the same ownership guard but must not be mistaken for an async query
+   * merely because their active_fiber is non-nil. */
   if (NIL_P(wrapper->active_fiber))
     return Qnil;
+  if (wrapper->state != MYSQL2_CLIENT_QUERYING) {
+    mysql2_client_check_idle(self);
+    return Qnil;
+  }
 
   REQUIRE_CONNECTED(wrapper);
   read_args.mysql = wrapper->client;
@@ -1662,21 +1710,20 @@ static VALUE disconnect_and_mark_inactive(VALUE self) {
   return Qnil;
 }
 
-/* rb_ensure companion for the fiber-claimed command methods that release the
- * GVL mid-command (select_db, next_result, abandon_results!): releases the
- * claim on every kind of unwind, so no raise -- or Thread#exit -- between
+/* Shared cleanup for fiber-claimed commands that release the GVL: releases
+ * the claim on every kind of unwind, so no raise -- or Thread#exit -- between
  * claim and release can leave the connection permanently reporting "This
  * connection is in use by". When the body never reached its completion mark,
  * an interrupt landed mid-exchange and the connection may be stuck
  * mid-protocol, so it also gets invalidated, same as an interrupted query.
  * Bodies mark completion before raising a server-reported error: that reply
  * finished the round trip, so the connection itself is still usable. */
-static VALUE release_claim_or_disconnect(VALUE completionval) {
-  struct query_completion *completion = (void *)completionval;
-  mysql_client_wrapper *wrapper = completion->wrapper;
-
-  if (completion->completed) {
+void mysql2_client_finish_claim(mysql_client_wrapper *wrapper, int reusable) {
+  if (reusable) {
     wrapper->active_fiber = Qnil;
+    if (wrapper->state == MYSQL2_CLIENT_COMMAND) {
+      wrapper->state = MYSQL2_CLIENT_IDLE;
+    }
   } else {
 #ifndef _WIN32
     invalidate_after_interrupted_query(wrapper);
@@ -1689,6 +1736,12 @@ static VALUE release_claim_or_disconnect(VALUE completionval) {
     }
 #endif
   }
+}
+
+static VALUE release_claim_or_disconnect(VALUE completionval) {
+  struct query_completion *completion = (void *)completionval;
+
+  mysql2_client_finish_claim(completion->wrapper, completion->completed);
 
   return Qnil;
 }
@@ -2369,7 +2422,7 @@ static VALUE mysql2_next_result_body(VALUE argsval) {
    * on another thread getting GC'd during that window must not be allowed
    * to enqueue-and-flush a close over this same socket mid-command. See
    * the QUERYING/IDLE bracket rb_mysql_query uses for the same reason. */
-  wrapper->state = MYSQL2_CLIENT_QUERYING;
+  wrapper->state = MYSQL2_CLIENT_COMMAND;
 
 #if defined(HAVE_MYSQL_NEXT_RESULT_NONBLOCKING) && !defined(_WIN32)
   {
@@ -2733,13 +2786,27 @@ static VALUE rb_mysql_client_prepare_statement(VALUE self, VALUE sql) {
  *
  * Returns an array of prepared statement objects.
  */
-static VALUE rb_mysql_client_prepared_statements_read(VALUE self) {
-  GET_CLIENT(self);
+static VALUE do_prepared_statements_read(VALUE completionval) {
+  struct query_completion *completion = (void *)completionval;
+  mysql_client_wrapper *wrapper = completion->wrapper;
 
   mysql2_reap_pending_result_frees(wrapper);
   mysql2_reap_pending_stmt_closes(wrapper);
+  completion->completed = 1;
 
   return rb_funcall(wrapper->prepared_statements, intern_values, 0);
+}
+
+static VALUE rb_mysql_client_prepared_statements_read(VALUE self) {
+  struct query_completion completion;
+  GET_CLIENT(self);
+
+  completion.wrapper = wrapper;
+  completion.completed = 0;
+
+  rb_mysql_client_set_active_fiber(self, false);
+  return rb_ensure(do_prepared_statements_read, (VALUE)&completion,
+                   release_claim_or_disconnect, (VALUE)&completion);
 }
 
 /* call-seq:

--- a/ext/mysql2/client.h
+++ b/ext/mysql2/client.h
@@ -2,14 +2,15 @@
 #define MYSQL2_CLIENT_H
 
 /* Whether the connection is in the middle of a protocol exchange that a
- * concurrent mysql_stmt_close() would corrupt. QUERYING covers the window
- * from sending a command through reading/storing its result; STREAMING
- * additionally covers the whole lifetime of an open server-side cursor,
- * since rows are pulled one at a time by later, separate Ruby calls. */
+ * concurrent mysql_stmt_close() would corrupt. QUERYING covers a text query;
+ * COMMAND covers another command such as Statement#execute; STREAMING covers
+ * the whole lifetime of an open server-side cursor, since rows are pulled one
+ * at a time by later, separate Ruby calls. */
 typedef enum {
   MYSQL2_CLIENT_IDLE = 0,
   MYSQL2_CLIENT_QUERYING,
-  MYSQL2_CLIENT_STREAMING
+  MYSQL2_CLIENT_STREAMING,
+  MYSQL2_CLIENT_COMMAND
 } mysql2_client_state_t;
 
 /* A MYSQL_STMT handle whose Ruby wrapper was freed while the connection
@@ -108,6 +109,17 @@ extern const rb_data_type_t rb_mysql_client_type;
 
 void init_mysql2_client(void);
 void decr_mysql2_client(mysql_client_wrapper *wrapper);
+
+/* Claim a connection for the current Fiber before issuing a command. */
+void mysql2_client_claim(VALUE self);
+
+/* Reject access to a client handle while a command or stream owns it. Callers
+ * make no Ruby calls before their final handle access, so a check suffices. */
+void mysql2_client_check_idle(VALUE self);
+
+/* Release a completed command's claim. If completion is uncertain, invalidate
+ * the connection so unread bytes cannot become a later command's response. */
+void mysql2_client_finish_claim(mysql_client_wrapper *wrapper, int reusable);
 
 /* Seconds on a clock suitable for measuring elapsed intervals: monotonic
  * (immune to wall-clock adjustment) where available, gettimeofday otherwise.

--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -298,7 +298,7 @@ wishlist = [
 ]
 
 usable_flags = wishlist.select do |flag|
-  try_link('int main() {return 0;}',  "-Werror #{flag}")
+  try_link('int main() {return 0;}', "-Werror #{flag}")
 end
 
 $CFLAGS << ' ' << usable_flags.join(' ')
@@ -312,13 +312,13 @@ case sanitizers
 when true
   # Try them all, turn on whatever we can
   enabled_sanitizers = %w[address cfi integer memory thread undefined].select do |s|
-    try_link('int main() {return 0;}',  "-Werror -fsanitize=#{s}")
+    try_link('int main() {return 0;}', "-Werror -fsanitize=#{s}")
   end
   abort "-----\nCould not enable any sanitizers!\n-----" if enabled_sanitizers.empty?
 when String
   # Figure out which sanitizers are supported
   enabled_sanitizers, disabled_sanitizers = sanitizers.split(',').partition do |s|
-    try_link('int main() {return 0;}',  "-Werror -fsanitize=#{s}")
+    try_link('int main() {return 0;}', "-Werror -fsanitize=#{s}")
   end
 end
 

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -239,12 +239,30 @@ static void *nogvl_prepare_statement(void *ptr) {
   }
 }
 
-VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql) {
+static int mysql2_stmt_error_is_transport(unsigned int error_number);
+
+struct new_statement_call {
+  VALUE rb_client;
+  VALUE sql;
+  mysql_client_wrapper *client_wrapper;
+  int reusable;
+};
+
+static VALUE finish_new_statement(VALUE callval) {
+  struct new_statement_call *call = (void *)callval;
+
+  mysql2_client_finish_claim(call->client_wrapper, call->reusable);
+  return Qnil;
+}
+
+static VALUE do_mysql_stmt_new(VALUE callval) {
+  struct new_statement_call *call = (void *)callval;
+  VALUE rb_client = call->rb_client;
+  VALUE sql = call->sql;
+  mysql_client_wrapper *client_wrapper = call->client_wrapper;
   mysql_stmt_wrapper *stmt_wrapper;
   VALUE rb_stmt;
   rb_encoding *conn_enc;
-
-  Check_Type(sql, T_STRING);
 
 #ifdef NEW_TYPEDDATA_WRAPPER
   rb_stmt = TypedData_Make_Struct(cMysql2Statement, mysql_stmt_wrapper, &rb_mysql_statement_type, stmt_wrapper);
@@ -269,7 +287,7 @@ VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql) {
     /* Keep a handle to the Client to ensure it doesn't get garbage collected first */
     stmt_wrapper->client = rb_client;
     if (rb_client != Qnil) {
-      stmt_wrapper->client_wrapper = DATA_PTR(rb_client);
+      stmt_wrapper->client_wrapper = client_wrapper;
       stmt_wrapper->client_wrapper->refcount++;
 
       /* We're about to prepare on this connection: a safe point to close
@@ -277,9 +295,12 @@ VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql) {
        * free any abandoned result sets left over from a stream that was
        * dropped mid-iteration -- including one still live (not yet
        * collected by GC), which the reap below alone wouldn't catch. */
-      mysql2_abandon_active_stream(stmt_wrapper->client_wrapper);
-      mysql2_reap_pending_result_frees(stmt_wrapper->client_wrapper);
-      mysql2_reap_pending_stmt_closes(stmt_wrapper->client_wrapper);
+      call->reusable = 0;
+      mysql2_abandon_active_stream(client_wrapper);
+      mysql2_reap_pending_result_frees(client_wrapper);
+      mysql2_reap_pending_stmt_closes(client_wrapper);
+      client_wrapper->state = MYSQL2_CLIENT_COMMAND;
+      call->reusable = 1;
     } else {
       stmt_wrapper->client_wrapper = NULL;
     }
@@ -304,9 +325,12 @@ VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql) {
     args.sql_ptr = RSTRING_PTR(args.sql);
     args.sql_len = RSTRING_LEN(args.sql);
 
+    call->reusable = 0;
     if ((VALUE)rb_thread_call_without_gvl(nogvl_prepare_statement, &args, RUBY_UBF_IO, 0) == Qfalse) {
+      call->reusable = !mysql2_stmt_error_is_transport(mysql_stmt_errno(stmt_wrapper->stmt));
       rb_raise_mysql2_stmt_error(stmt_wrapper);
     }
+    call->reusable = 1;
   }
 
   // Stash a reference to this statement handle into the Client to prevent
@@ -324,12 +348,28 @@ VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql) {
   return rb_stmt;
 }
 
+VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql) {
+  struct new_statement_call call;
+  GET_CLIENT(rb_client);
+
+  Check_Type(sql, T_STRING);
+  call.rb_client = rb_client;
+  call.sql = sql;
+  call.client_wrapper = wrapper;
+  call.reusable = 1;
+
+  mysql2_client_claim(rb_client);
+  return rb_ensure(do_mysql_stmt_new, (VALUE)&call,
+                   finish_new_statement, (VALUE)&call);
+}
+
 /* call-seq: stmt.param_count # => Numeric
  *
  * Returns the number of parameters the prepared statement expects.
  */
 static VALUE rb_mysql_stmt_param_count(VALUE self) {
   GET_STATEMENT(self);
+  mysql2_client_check_idle(stmt_wrapper->client);
 
   return ULL2NUM(mysql_stmt_param_count(stmt_wrapper->stmt));
 }
@@ -340,6 +380,7 @@ static VALUE rb_mysql_stmt_param_count(VALUE self) {
  */
 static VALUE rb_mysql_stmt_field_count(VALUE self) {
   GET_STATEMENT(self);
+  mysql2_client_check_idle(stmt_wrapper->client);
 
   return UINT2NUM(mysql_stmt_field_count(stmt_wrapper->stmt));
 }
@@ -363,29 +404,75 @@ static void *nogvl_stmt_execute(void *ptr) {
 
 static void set_buffer_for_string(MYSQL_BIND* bind_buffer, unsigned long *length_buffer, VALUE string) {
   unsigned long length;
-
-  bind_buffer->buffer = RSTRING_PTR(string);
+  void *bytes;
 
   length = RSTRING_LEN(string);
+  bytes = xmalloc(length == 0 ? 1 : length);
+  if (length > 0) {
+    memcpy(bytes, RSTRING_PTR(string), length);
+  }
+
+  bind_buffer->buffer = bytes;
   bind_buffer->buffer_length = length;
   *length_buffer = length;
 
   bind_buffer->length = length_buffer;
 }
 
-/* Free each bind_buffer[i].buffer except when params_enc is non-nil, this means
- * the buffer is a Ruby string pointer and not our memory to manage.
- */
-#define FREE_BINDS                                          \
-  for (i = 0; i < bind_count; i++) {                        \
-    if (bind_buffers[i].buffer && NIL_P(params_enc[i])) {   \
-      xfree(bind_buffers[i].buffer);                        \
-    }                                                       \
-  }                                                         \
-  if (argc > 0) {                                           \
-    xfree(bind_buffers);                                    \
-    xfree(length_buffers);                                  \
+struct execute_statement_call {
+  int argc;
+  VALUE *argv;
+  VALUE self;
+  mysql_client_wrapper *client_wrapper;
+  MYSQL_BIND *bind_buffers;
+  unsigned long *length_buffers;
+  unsigned long bind_count;
+  int claimed;
+  int reusable;
+};
+
+static void free_execute_binds(struct execute_statement_call *call) {
+  unsigned long i;
+
+  if (call->bind_buffers) {
+    for (i = 0; i < call->bind_count; i++) {
+      if (call->bind_buffers[i].buffer) {
+        xfree(call->bind_buffers[i].buffer);
+      }
+    }
+    xfree(call->bind_buffers);
+    call->bind_buffers = NULL;
   }
+  if (call->length_buffers) {
+    xfree(call->length_buffers);
+    call->length_buffers = NULL;
+  }
+}
+
+static VALUE finish_execute_statement(VALUE callval) {
+  struct execute_statement_call *call = (void *)callval;
+
+  free_execute_binds(call);
+  if (call->claimed) {
+    mysql2_client_finish_claim(call->client_wrapper, call->reusable);
+    call->claimed = 0;
+  }
+
+  return Qnil;
+}
+
+/* Draining an abandoned stream or deferred free can itself touch the wire.
+ * Until every drain returns, an interrupt leaves protocol completion unknown. */
+static void prepare_connection_for_statement(struct execute_statement_call *call) {
+  mysql_client_wrapper *wrapper = call->client_wrapper;
+
+  call->reusable = 0;
+  mysql2_abandon_active_stream(wrapper);
+  mysql2_reap_pending_result_frees(wrapper);
+  mysql2_reap_pending_stmt_closes(wrapper);
+  wrapper->state = MYSQL2_CLIENT_COMMAND;
+  call->reusable = 1;
+}
 
 /* return 0 if the given bignum can cast as LONG_LONG, otherwise 1 */
 static int my_big2ll(VALUE bignum, LONG_LONG *ptr)
@@ -432,11 +519,32 @@ overflow:
   return 1;
 }
 
+/* Client-library errors do not prove that the server reply was consumed.
+ * Server errors do: mysql_stmt_execute has read the complete error packet, so
+ * the connection can be released for another command. */
+static int mysql2_stmt_error_is_transport(unsigned int error_number) {
+#if defined(CR_MIN_ERROR) && defined(CR_MAX_ERROR)
+  if (error_number >= CR_MIN_ERROR && error_number <= CR_MAX_ERROR) {
+    return 1;
+  }
+#endif
+#if defined(CER_MIN_ERROR) && defined(CER_MAX_ERROR)
+  if (error_number >= CER_MIN_ERROR && error_number <= CER_MAX_ERROR) {
+    return 1;
+  }
+#endif
+  return error_number == 0;
+}
+
 /* call-seq: stmt.execute
  *
  * Executes the current prepared statement, returns +result+.
  */
-static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
+static VALUE do_execute_statement(VALUE callval) {
+  struct execute_statement_call *call = (void *)callval;
+  int argc = call->argc;
+  VALUE *argv = call->argv;
+  VALUE self = call->self;
   MYSQL_BIND *bind_buffers = NULL;
   unsigned long *length_buffers = NULL;
   unsigned long bind_count;
@@ -446,7 +554,6 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
   VALUE opts;
   VALUE current;
   VALUE resultObj;
-  VALUE *params_enc = NULL;
   int is_streaming;
   struct nogvl_stmt_execute_args execute_args;
   double query_start, query_elapsed;
@@ -455,6 +562,10 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
 
   GET_STATEMENT(self);
   GET_CLIENT(stmt_wrapper->client);
+
+  call->client_wrapper = wrapper;
+  mysql2_client_claim(stmt_wrapper->client);
+  call->claimed = 1;
 
   if (mysql2_forked_without_reconnect(wrapper) && wrapper->automatic_close) {
     mysql2_warn_forked_without_reconnect(wrapper, "execute a statement");
@@ -468,14 +579,13 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
    * fully drained. That must happen before we touch stmt below again.
    * mysql2_abandon_active_stream handles the still-live case (not yet
    * collected by GC), which the reap below alone wouldn't catch. */
-  mysql2_abandon_active_stream(wrapper);
-  mysql2_reap_pending_result_frees(wrapper);
-  mysql2_reap_pending_stmt_closes(wrapper);
+  prepare_connection_for_statement(call);
 
   conn_enc = rb_to_encoding(wrapper->encoding);
 
   stmt = stmt_wrapper->stmt;
   bind_count = mysql_stmt_param_count(stmt);
+  call->bind_count = bind_count;
 
   // Get count of ordinary arguments, and extract hash opts/keyword arguments
   // Use a local scope to avoid leaking the temporary count variable
@@ -536,14 +646,13 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
 
   // setup any bind variables in the query
   if (bind_count > 0) {
-    // Scratch space for string encoding exports, allocate on the stack
-    params_enc = alloca(sizeof(VALUE) * bind_count);
-    bind_buffers = xcalloc(bind_count, sizeof(MYSQL_BIND));
-    length_buffers = xcalloc(bind_count, sizeof(unsigned long));
+    call->bind_buffers = xcalloc(bind_count, sizeof(MYSQL_BIND));
+    call->length_buffers = xcalloc(bind_count, sizeof(unsigned long));
+    bind_buffers = call->bind_buffers;
+    length_buffers = call->length_buffers;
 
     for (i = 0; i < bind_count; i++) {
       bind_buffers[i].buffer = NULL;
-      params_enc[i] = Qnil;
 
       switch (TYPE(argv[i])) {
         case T_NIL:
@@ -569,9 +678,10 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
               *(LONG_LONG*)(bind_buffers[i].buffer) = num;
             } else {
               /* The bignum was larger than we can fit in LONG_LONG, send it as a string */
+              VALUE encoded;
               bind_buffers[i].buffer_type = MYSQL_TYPE_NEWDECIMAL;
-              params_enc[i] = rb_str_export_to_enc(rb_big2str(argv[i], 10), conn_enc);
-              set_buffer_for_string(&bind_buffers[i], &length_buffers[i], params_enc[i]);
+              encoded = rb_str_export_to_enc(rb_big2str(argv[i], 10), conn_enc);
+              set_buffer_for_string(&bind_buffers[i], &length_buffers[i], encoded);
             }
           }
           break;
@@ -582,10 +692,10 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
           break;
         case T_STRING:
           bind_buffers[i].buffer_type = MYSQL_TYPE_STRING;
-
-          params_enc[i] = argv[i];
-          params_enc[i] = rb_str_export_to_enc(params_enc[i], conn_enc);
-          set_buffer_for_string(&bind_buffers[i], &length_buffers[i], params_enc[i]);
+          {
+            VALUE encoded = rb_str_export_to_enc(argv[i], conn_enc);
+            set_buffer_for_string(&bind_buffers[i], &length_buffers[i], encoded);
+          }
           break;
         case T_TRUE:
           bind_buffers[i].buffer_type = MYSQL_TYPE_TINY;
@@ -652,9 +762,8 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
             // and the client side.
             VALUE rb_val_as_string = rb_funcall(argv[i], intern_to_s, 0);
 
-            params_enc[i] = rb_val_as_string;
-            params_enc[i] = rb_str_export_to_enc(params_enc[i], conn_enc);
-            set_buffer_for_string(&bind_buffers[i], &length_buffers[i], params_enc[i]);
+            rb_val_as_string = rb_str_export_to_enc(rb_val_as_string, conn_enc);
+            set_buffer_for_string(&bind_buffers[i], &length_buffers[i], rb_val_as_string);
           } else {
             int state = 0;
             VALUE inspect = rb_protect(rb_inspect, argv[i], &state);
@@ -678,7 +787,6 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
 
     // copies bind_buffers into internal storage
     if (mysql_stmt_bind_param(stmt, bind_buffers)) {
-      FREE_BINDS;
       rb_raise_mysql2_stmt_error(stmt_wrapper);
     }
   }
@@ -699,14 +807,12 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
   if (is_streaming) {
     unsigned long type = CURSOR_TYPE_READ_ONLY;
     if (mysql_stmt_attr_set(stmt, STMT_ATTR_CURSOR_TYPE, &type)) {
-      FREE_BINDS;
       rb_raise(cMysql2Error, "Unable to stream prepared statement, could not set CURSOR_TYPE_READ_ONLY");
     }
     // Set unconditionally: statement attributes persist on the handle
     // across executes, so stream: true must restore the one-row default
     // after an earlier stream: {size: N} execute on the same statement.
     if (mysql_stmt_attr_set(stmt, STMT_ATTR_PREFETCH_ROWS, &prefetch_rows)) {
-      FREE_BINDS;
       rb_raise(cMysql2Error, "Unable to stream prepared statement, could not set STMT_ATTR_PREFETCH_ROWS");
     }
   }
@@ -719,22 +825,21 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
   // earlier checks up top can't see that yet, and leaving it undrained here
   // would desync the protocol once this command's bytes hit the wire ahead
   // of the old stream's rows.
-  mysql2_abandon_active_stream(wrapper);
-  mysql2_reap_pending_result_frees(wrapper);
-  mysql2_reap_pending_stmt_closes(wrapper);
+  prepare_connection_for_statement(call);
 
   // From here through mysql_stmt_result_metadata/mysql_stmt_store_result,
   // the connection is BUSY: a Statement freed elsewhere during this window
   // must not be allowed to write COM_STMT_CLOSE to this socket. See
   // mysql2_enqueue_pending_stmt_close / mysql2_reap_pending_stmt_closes.
-  wrapper->state = MYSQL2_CLIENT_QUERYING;
+  wrapper->state = MYSQL2_CLIENT_COMMAND;
+  call->reusable = 0;
 
   query_start = mysql2_monotonic_now();
   execute_args.stmt = stmt;
 
   if ((VALUE)rb_thread_call_without_gvl(nogvl_stmt_execute, &execute_args, RUBY_UBF_IO, 0) == Qfalse) {
-    FREE_BINDS;
     wrapper->state = MYSQL2_CLIENT_IDLE;
+    call->reusable = !mysql2_stmt_error_is_transport(mysql_stmt_errno(stmt));
     rb_raise_mysql2_stmt_error(stmt_wrapper);
   }
 
@@ -747,35 +852,36 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
   query_elapsed = (query_start < 0 || execute_args.query_end < 0)
     ? -1 : execute_args.query_end - query_start;
 
-  FREE_BINDS;
+  free_execute_binds(call);
 
   metadata = mysql_stmt_result_metadata(stmt);
   if (metadata == NULL) {
     wrapper->state = MYSQL2_CLIENT_IDLE;
     if (mysql_stmt_errno(stmt) != 0) {
       // either CR_OUT_OF_MEMORY or CR_UNKNOWN_ERROR. both fatal.
-      wrapper->active_fiber = Qnil;
+      call->reusable = !mysql2_stmt_error_is_transport(mysql_stmt_errno(stmt));
       rb_raise_mysql2_stmt_error(stmt_wrapper);
     }
     // no data and no error, so query was not a SELECT
-    mysql2_reap_pending_result_frees(wrapper);
-    mysql2_reap_pending_stmt_closes(wrapper);
+    call->reusable = 1;
+    prepare_connection_for_statement(call);
     return Qnil;
   }
 
   if (!is_streaming) {
     // receive the whole result set from the server
     if (mysql_stmt_store_result(stmt)) {
+      unsigned int error_number = mysql_stmt_errno(stmt);
       mysql_free_result(metadata);
       wrapper->state = MYSQL2_CLIENT_IDLE;
+      call->reusable = !mysql2_stmt_error_is_transport(error_number);
       rb_raise_mysql2_stmt_error(stmt_wrapper);
     }
-    wrapper->active_fiber = Qnil;
     // The whole result set is buffered locally; free to reap and to run
     // another command right away.
     wrapper->state = MYSQL2_CLIENT_IDLE;
-    mysql2_reap_pending_result_frees(wrapper);
-    mysql2_reap_pending_stmt_closes(wrapper);
+    call->reusable = 1;
+    prepare_connection_for_statement(call);
   } else {
     // A cursor is now open on the server; leave the connection BUSY until
     // the Result finishes (or abandons) streaming rows -- see result.c.
@@ -795,6 +901,7 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
    * abandoned instead of exhausted -- see mysql2_abandon_active_stream. */
   if (is_streaming) {
     wrapper->active_streaming_result = resultObj;
+    call->reusable = 1;
   }
 
   if (!is_streaming) {
@@ -805,11 +912,47 @@ static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
   return resultObj;
 }
 
+/* call-seq: stmt.execute
+ *
+ * Executes the current prepared statement, returns +result+.
+ */
+static VALUE rb_mysql_stmt_execute(int argc, VALUE *argv, VALUE self) {
+  struct execute_statement_call call;
+
+  MEMZERO(&call, struct execute_statement_call, 1);
+  call.argc = argc;
+  call.argv = argv;
+  call.self = self;
+  call.reusable = 1;
+
+  return rb_ensure(do_execute_statement, (VALUE)&call,
+                   finish_execute_statement, (VALUE)&call);
+}
+
 /* call-seq: stmt.fields # => array
  *
  * Returns a list of fields that will be returned by this statement.
  */
-static VALUE rb_mysql_stmt_fields(VALUE self) {
+struct statement_handle_access {
+  VALUE self;
+  mysql_client_wrapper *client_wrapper;
+  MYSQL_RES *metadata;
+};
+
+static VALUE finish_statement_handle_access(VALUE accessval) {
+  struct statement_handle_access *access = (void *)accessval;
+
+  if (access->metadata) {
+    mysql_free_result(access->metadata);
+    access->metadata = NULL;
+  }
+  mysql2_client_finish_claim(access->client_wrapper, 1);
+  return Qnil;
+}
+
+static VALUE do_mysql_stmt_fields(VALUE accessval) {
+  struct statement_handle_access *access = (void *)accessval;
+  VALUE self = access->self;
   MYSQL_FIELD *fields;
   MYSQL_RES *metadata;
   unsigned int field_count;
@@ -818,7 +961,6 @@ static VALUE rb_mysql_stmt_fields(VALUE self) {
   MYSQL_STMT* stmt;
   rb_encoding *default_internal_enc, *conn_enc;
   GET_STATEMENT(self);
-  GET_CLIENT(stmt_wrapper->client);
   stmt = stmt_wrapper->stmt;
 
   default_internal_enc = rb_default_internal_encoding();
@@ -831,12 +973,12 @@ static VALUE rb_mysql_stmt_fields(VALUE self) {
   if (metadata == NULL) {
     if (mysql_stmt_errno(stmt) != 0) {
       // either CR_OUT_OF_MEMORY or CR_UNKNOWN_ERROR. both fatal.
-      wrapper->active_fiber = Qnil;
       rb_raise_mysql2_stmt_error(stmt_wrapper);
     }
     // no data and no error, so query was not a SELECT
     return Qnil;
   }
+  access->metadata = metadata;
 
   fields      = mysql_fetch_fields(metadata);
   field_count = mysql_stmt_field_count(stmt);
@@ -862,7 +1004,23 @@ static VALUE rb_mysql_stmt_fields(VALUE self) {
   }
 
   mysql_free_result(metadata);
+  access->metadata = NULL;
   return field_list;
+}
+
+static VALUE rb_mysql_stmt_fields(VALUE self) {
+  struct statement_handle_access access;
+  GET_STATEMENT(self);
+
+  access.self = self;
+  access.client_wrapper = stmt_wrapper->client_wrapper;
+  access.metadata = NULL;
+
+  mysql2_client_check_idle(stmt_wrapper->client);
+  mysql2_client_claim(stmt_wrapper->client);
+  stmt_wrapper->client_wrapper->state = MYSQL2_CLIENT_COMMAND;
+  return rb_ensure(do_mysql_stmt_fields, (VALUE)&access,
+                   finish_statement_handle_access, (VALUE)&access);
 }
 
 /* call-seq:
@@ -872,6 +1030,7 @@ static VALUE rb_mysql_stmt_fields(VALUE self) {
  */
 static VALUE rb_mysql_stmt_last_id(VALUE self) {
   GET_STATEMENT(self);
+  mysql2_client_check_idle(stmt_wrapper->client);
   return ULL2NUM(mysql_stmt_insert_id(stmt_wrapper->stmt));
 }
 
@@ -880,7 +1039,7 @@ static VALUE rb_mysql_stmt_last_id(VALUE self) {
  *
  * Returns the number of rows changed, deleted, or inserted.
  */
-static VALUE rb_mysql_stmt_affected_rows(VALUE self) {
+static VALUE do_mysql_stmt_affected_rows(VALUE self) {
   my_ulonglong affected;
   GET_STATEMENT(self);
 
@@ -892,6 +1051,21 @@ static VALUE rb_mysql_stmt_affected_rows(VALUE self) {
   return ULL2NUM(affected);
 }
 
+static VALUE rb_mysql_stmt_affected_rows(VALUE self) {
+  struct statement_handle_access access;
+  GET_STATEMENT(self);
+
+  access.self = self;
+  access.client_wrapper = stmt_wrapper->client_wrapper;
+  access.metadata = NULL;
+
+  mysql2_client_check_idle(stmt_wrapper->client);
+  mysql2_client_claim(stmt_wrapper->client);
+  stmt_wrapper->client_wrapper->state = MYSQL2_CLIENT_COMMAND;
+  return rb_ensure(do_mysql_stmt_affected_rows, self,
+                   finish_statement_handle_access, (VALUE)&access);
+}
+
 /* call-seq:
  *    stmt.close
  *
@@ -899,31 +1073,65 @@ static VALUE rb_mysql_stmt_affected_rows(VALUE self) {
  * than waiting for the garbage collector. Useful if you're managing your
  * own prepared statement cache.
  */
-static VALUE rb_mysql_stmt_close(VALUE self) {
-  RAW_GET_STATEMENT(self);
+struct close_statement_call {
+  mysql_stmt_wrapper *stmt_wrapper;
+  mysql_client_wrapper *client_wrapper;
+  int reusable;
+};
 
-  if (!stmt_wrapper->closed) {
-      GET_CLIENT(stmt_wrapper->client);
+static VALUE finish_close_statement(VALUE callval) {
+  struct close_statement_call *call = (void *)callval;
 
-      /* Ordinary Ruby-level call, not GC/dfree: a safe point to also close
-       * out any other statements that were GC'd while the connection was
-       * last busy. Abandon/reap pending result frees first: this statement
-       * itself may have an abandoned streaming result on it -- still live
-       * (mysql2_abandon_active_stream) or already queued
-       * (mysql2_reap_pending_result_frees) -- and that must be drained
-       * before nogvl_stmt_close below frees the same MYSQL_STMT* out from
-       * under it. */
-      mysql2_abandon_active_stream(wrapper);
-      mysql2_reap_pending_result_frees(wrapper);
-      mysql2_reap_pending_stmt_closes(wrapper);
+  mysql2_client_finish_claim(call->client_wrapper, call->reusable);
+  return Qnil;
+}
 
-      stmt_wrapper->closed = 1;
-      rb_hash_delete(wrapper->prepared_statements, ULL2NUM((unsigned long long)stmt_wrapper));
-      rb_thread_call_without_gvl(nogvl_stmt_close, stmt_wrapper, RUBY_UBF_IO, 0);
-      mysql2_stmt_metadata_cache_clear(stmt_wrapper);
-  }
+static VALUE do_close_statement(VALUE callval) {
+  struct close_statement_call *call = (void *)callval;
+  mysql_stmt_wrapper *stmt_wrapper = call->stmt_wrapper;
+  mysql_client_wrapper *wrapper = call->client_wrapper;
+
+  /* Ordinary Ruby-level call, not GC/dfree: a safe point to also close
+   * out any other statements that were GC'd while the connection was
+   * last busy. Abandon/reap pending result frees first: this statement
+   * itself may have an abandoned streaming result on it -- still live
+   * (mysql2_abandon_active_stream) or already queued
+   * (mysql2_reap_pending_result_frees) -- and that must be drained
+   * before nogvl_stmt_close below frees the same MYSQL_STMT* out from
+   * under it. */
+  call->reusable = 0;
+  mysql2_abandon_active_stream(wrapper);
+  mysql2_reap_pending_result_frees(wrapper);
+  mysql2_reap_pending_stmt_closes(wrapper);
+  wrapper->state = MYSQL2_CLIENT_COMMAND;
+  call->reusable = 1;
+
+  rb_hash_delete(wrapper->prepared_statements, ULL2NUM((unsigned long long)stmt_wrapper));
+  stmt_wrapper->closed = 1;
+
+  call->reusable = 0;
+  rb_thread_call_without_gvl(nogvl_stmt_close, stmt_wrapper, RUBY_UBF_IO, 0);
+  call->reusable = 1;
+  mysql2_stmt_metadata_cache_clear(stmt_wrapper);
 
   return Qnil;
+}
+
+static VALUE rb_mysql_stmt_close(VALUE self) {
+  struct close_statement_call call;
+  RAW_GET_STATEMENT(self);
+
+  if (stmt_wrapper->closed) {
+    return Qnil;
+  }
+
+  call.stmt_wrapper = stmt_wrapper;
+  call.client_wrapper = stmt_wrapper->client_wrapper;
+  call.reusable = 1;
+
+  mysql2_client_claim(stmt_wrapper->client);
+  return rb_ensure(do_close_statement, (VALUE)&call,
+                   finish_close_statement, (VALUE)&call);
 }
 
 /* call-seq:

--- a/spec/mysql2/client_spec.rb
+++ b/spec/mysql2/client_spec.rb
@@ -1623,6 +1623,18 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
         expect(ticks).to be > 5
       end
 
+      it "rejects #async_result while #next_result owns the connection" do
+        @multi_client.query("SELECT 1 AS a; SELECT SLEEP(0.3) AS waited")
+        thread = new_thread { @multi_client.next_result }
+        thread.join(0.1)
+
+        expect(thread).to be_alive
+        expect { @multi_client.async_result }.to \
+          raise_error(Mysql2::Error, /This connection is in use by/)
+        expect(thread.value).to be true
+        expect(@multi_client.store_result.first).to eq('waited' => 0)
+      end
+
       it "should be interruptible via Thread#raise while #next_result waits on a slow next statement" do
         @multi_client.query("SELECT 1 AS a; SELECT SLEEP(2) AS b")
 
@@ -2500,6 +2512,91 @@ RSpec.describe Mysql2::Client do # rubocop:disable Metrics/BlockLength
           e
         end
         expect(follow_up_error.to_s).not_to match(/This connection is in use by/)
+      ensure
+        begin
+          client.close
+        rescue StandardError
+          nil
+        end
+        proxy.shutdown
+      end
+    end
+  end
+
+  context "Thread#exit mid-Statement#execute" do
+    it "invalidates the connection instead of leaving a stale claim" do
+      creds = DatabaseCredentials['root']
+      proxy = FreezableProxy.new(creds['host'], creds['port'] || 3306)
+      proxy.run
+      sleep 0.1
+
+      client = new_client('host' => '127.0.0.1', 'port' => proxy.port)
+      statement = client.prepare('SELECT 1')
+
+      begin
+        proxy.freeze!
+        thread = Thread.new { statement.execute }
+        thread.report_on_exception = false
+        thread.join(0.3)
+
+        expect(thread).to be_alive
+        thread.exit
+        sleep 0.1
+        proxy.unfreeze!
+        thread.join(5)
+
+        follow_up_error = begin
+          client.query("SELECT 1")
+          nil
+        rescue Mysql2::Error => e
+          e
+        end
+
+        expect(follow_up_error).to be_a(Mysql2::Error)
+        expect(follow_up_error.to_s).not_to \
+          match(/This connection is in use by|still waiting for a result/)
+      ensure
+        begin
+          client.close
+        rescue StandardError
+          nil
+        end
+        proxy.shutdown
+      end
+    end
+  end
+
+  context "Thread#exit mid-Client#prepare" do
+    it "invalidates the connection instead of leaving a stale claim" do
+      creds = DatabaseCredentials['root']
+      proxy = FreezableProxy.new(creds['host'], creds['port'] || 3306)
+      proxy.run
+      sleep 0.1
+
+      client = new_client('host' => '127.0.0.1', 'port' => proxy.port)
+
+      begin
+        proxy.freeze!
+        thread = Thread.new { client.prepare("SELECT 1") }
+        thread.report_on_exception = false
+        thread.join(0.3)
+
+        expect(thread).to be_alive
+        thread.exit
+        sleep 0.1
+        proxy.unfreeze!
+        thread.join(5)
+
+        follow_up_error = begin
+          client.query("SELECT 1")
+          nil
+        rescue Mysql2::Error => e
+          e
+        end
+
+        expect(follow_up_error).to be_a(Mysql2::Error)
+        expect(follow_up_error.to_s).not_to \
+          match(/This connection is in use by|still waiting for a result/)
       ensure
         begin
           client.close

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -117,6 +117,49 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
     expect(thread.value).to eq("waited" => 0)
   end
 
+  it "rejects same-Fiber teardown while constructing a streaming Result" do
+    client = @client
+    attempts = {}
+    statement = client.prepare("SELECT 1 AS value UNION SELECT 2")
+
+    trace = TracePoint.new(:c_call) do |event|
+      next unless event.method_id == :initialize && event.self.is_a?(Mysql2::Result)
+
+      trace.disable
+      %i[close discard!].each do |method|
+        begin
+          client.public_send(method)
+        rescue Mysql2::Error => e
+          attempts[method] = e.message
+        end
+      end
+    end
+
+    begin
+      trace.enable
+      result = statement.execute(stream: true, cache_rows: false)
+    ensure
+      trace.disable
+    end
+
+    expect(attempts.keys).to eq(%i[close discard!])
+    attempts.each_value do |message|
+      expect(message).to match(/still waiting for a result/)
+    end
+    expect(result.to_a).to eq([{ "value" => 1 }, { "value" => 2 }])
+    expect(client.query("SELECT 3 AS value").first).to eq("value" => 3)
+  end
+
+  it "does not inspect or reap prepared statements while a stream is open" do
+    statement = @client.prepare("SELECT 1 AS value UNION SELECT 2")
+    result = statement.execute(stream: true, cache_rows: false)
+
+    expect { @client.prepared_statements }.to \
+      raise_error(Mysql2::Error, /still waiting for a result/)
+    expect(result.to_a).to eq([{ "value" => 1 }, { "value" => 2 }])
+    expect(@client.prepared_statements).to include(statement)
+  end
+
   it "rejects #execute while another Fiber owns the client" do
     statement = @client.prepare("SELECT 2 AS value")
     thread = new_thread { @client.query("SELECT SLEEP(0.3) AS waited").first }
@@ -141,7 +184,7 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
   it "keeps string bind bytes stable while GC compacts during setup" do
     skip "GC compaction is unavailable" unless GC.respond_to?(:auto_compact=)
 
-    statement = @client.prepare("SELECT ? AS first_value, ? AS second_value")
+    statement = @client.prepare("SELECT ? AS bind_one, ? AS bind_two")
     old_auto_compact = GC.auto_compact
     old_stress = GC.stress
     begin
@@ -156,7 +199,7 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
       GC.auto_compact = old_auto_compact
     end
 
-    expect(result).to eq("first_value" => "é", "second_value" => "ß")
+    expect(result).to eq("bind_one" => "é", "bind_two" => "ß")
   end
 
   it "should raise an exception without a block" do

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -27,6 +27,11 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
     expect(statement).to be_an_instance_of(Mysql2::Statement)
   end
 
+  it "releases the client after a completed prepare error" do
+    expect { @client.prepare("NOT VALID SQL") }.to raise_error(Mysql2::Error)
+    expect(@client.query("SELECT 1 AS value").first).to eq("value" => 1)
+  end
+
   it "should raise an exception when server disconnects" do
     @client.close
     expect { @client.prepare 'SELECT 1' }.to raise_error(Mysql2::Error)
@@ -51,6 +56,107 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
   it "should let us execute our statement" do
     statement = @client.prepare 'SELECT 1'
     expect(statement.execute).not_to eq(nil)
+  end
+
+  it "claims the client while #execute is in flight" do
+    statement = @client.prepare("SELECT SLEEP(0.3) AS waited")
+    thread = new_thread { statement.execute.first }
+    thread.join(0.1)
+
+    expect(thread).to be_alive
+    expect { @client.query("SELECT 1") }.to \
+      raise_error(Mysql2::Error, /This connection is in use by/)
+    expect(thread.value).to eq("waited" => 0)
+    expect(@client.query("SELECT 1 AS value").first).to eq("value" => 1)
+  end
+
+  [
+    [:async_result, []],
+    [:discard!, []],
+    [:prepare, ["SELECT 3"]],
+    [:prepared_statements, []],
+  ].each do |method, arguments|
+    it "rejects Client##{method} while #execute is in flight" do
+      statement = @client.prepare("SELECT SLEEP(0.3) AS waited")
+      thread = new_thread { statement.execute.first }
+      thread.join(0.1)
+
+      expect(thread).to be_alive
+      expect { @client.public_send(method, *arguments) }.to \
+        raise_error(Mysql2::Error, /This connection is in use by/)
+      expect(thread.value).to eq("waited" => 0)
+      expect(@client.query("SELECT 1 AS value").first).to eq("value" => 1)
+    end
+  end
+
+  it "rejects Statement#close while #execute is in flight" do
+    statement = @client.prepare("SELECT SLEEP(0.3) AS waited")
+    other_statement = @client.prepare("SELECT 2 AS value")
+    thread = new_thread { statement.execute.first }
+    thread.join(0.1)
+
+    expect(thread).to be_alive
+    expect { statement.close }.to raise_error(Mysql2::Error, /This connection is in use by/)
+    expect { other_statement.close }.to raise_error(Mysql2::Error, /This connection is in use by/)
+    expect(thread.value).to eq("waited" => 0)
+    expect(statement).not_to be_closed
+    expect(other_statement).not_to be_closed
+  end
+
+  it "rejects Statement handle getters while #execute is in flight" do
+    statement = @client.prepare("SELECT SLEEP(0.3) AS waited")
+    thread = new_thread { statement.execute.first }
+    thread.join(0.1)
+
+    getters = %i[affected_rows field_count fields last_id param_count]
+    expect(thread).to be_alive
+    getters.each do |getter|
+      expect { statement.public_send(getter) }.to \
+        raise_error(Mysql2::Error, /This connection is in use by/)
+    end
+    expect(thread.value).to eq("waited" => 0)
+  end
+
+  it "rejects #execute while another Fiber owns the client" do
+    statement = @client.prepare("SELECT 2 AS value")
+    thread = new_thread { @client.query("SELECT SLEEP(0.3) AS waited").first }
+    thread.join(0.1)
+
+    expect(thread).to be_alive
+    expect { statement.execute }.to \
+      raise_error(Mysql2::Error, /This connection is in use by/)
+    expect(thread.value).to eq("waited" => 0)
+    expect(statement.execute.first).to eq("value" => 2)
+  end
+
+  it "releases the client after a completed execute error" do
+    @client.query("CREATE TEMPORARY TABLE mysql2_execute_error (id INT PRIMARY KEY)")
+    statement = @client.prepare("INSERT INTO mysql2_execute_error (id) VALUES (?)")
+    statement.execute(1)
+
+    expect { statement.execute(1) }.to raise_error(Mysql2::Error)
+    expect(@client.query("SELECT COUNT(*) AS count FROM mysql2_execute_error").first).to eq("count" => 1)
+  end
+
+  it "keeps string bind bytes stable while GC compacts during setup" do
+    skip "GC compaction is unavailable" unless GC.respond_to?(:auto_compact=)
+
+    statement = @client.prepare("SELECT ? AS first_value, ? AS second_value")
+    old_auto_compact = GC.auto_compact
+    old_stress = GC.stress
+    begin
+      GC.auto_compact = true
+      GC.stress = true
+      result = statement.execute(
+        "é".encode(Encoding::ISO_8859_1),
+        "ß".encode(Encoding::ISO_8859_1),
+      ).first
+    ensure
+      GC.stress = old_stress
+      GC.auto_compact = old_auto_compact
+    end
+
+    expect(result).to eq("first_value" => "é", "second_value" => "ß")
   end
 
   it "should raise an exception without a block" do

--- a/spec/mysql2/statement_spec.rb
+++ b/spec/mysql2/statement_spec.rb
@@ -183,6 +183,7 @@ RSpec.describe Mysql2::Statement do # rubocop:disable Metrics/BlockLength
 
   it "keeps string bind bytes stable while GC compacts during setup" do
     skip "GC compaction is unavailable" unless GC.respond_to?(:auto_compact=)
+    skip "GC stress with auto compaction crashes Ruby 3.0 on Windows" if Gem.win_platform? && RUBY_VERSION.start_with?("3.0.")
 
     statement = @client.prepare("SELECT ? AS bind_one, ? AS bind_two")
     old_auto_compact = GC.auto_compact


### PR DESCRIPTION
## Summary

- claim the client across statement prepare, execute, and close operations
- reject client disposal, deferred statement reaping, and native `Statement`-handle access while a command or streaming result owns the connection
- reserve the internal `QUERYING` state for the text-query / `async_result` lifecycle and mark prepared-statement and next-result handle phases as `COMMAND`
- release claims after completed replies and validation errors, while invalidating a connection after an interruption leaves protocol completion uncertain
- keep encoded bind bytes in call-owned memory through the native `mysql_stmt_execute` call

There are no new Ruby methods or signature changes; concurrent misuse now fails fast. The existing EventMachine cross-Fiber completion path remains supported. Result streaming/lifetime behavior is unchanged and remains separate work.

## Why

A client connection can process one protocol command at a time. `Client#query` and the command methods covered by #1563 already use the active-Fiber claim to reject overlap; prepared-statement operations did not consistently participate in it. #1508 also called out statement execution's missing unwind protection.

This extends the existing fail-fast connection-ownership model to prepared-statement operations. Explicit one-shot async completion delegation remains a separate design discussion in #1602.

## Tests

- full suite: 649 examples, 0 failures, 33 environment-only pendings
- focused ownership, interruption, completed-server-error reuse, bind-buffer lifetime, callback-teardown, and live-stream reaping coverage
- the separate test-only EventMachine compatibility branch passed against this build: 8 examples, 0 failures, including application-Fiber to reactor-Fiber result completion
- the GC-stress/auto-compaction example is skipped only on Ruby 3.0 for Windows, whose VM hits [Ruby #19320](https://bugs.ruby-lang.org/issues/19320) under that combination; it passes on Linux Ruby 3.0 and Windows Ruby 3.4
- `bundle exec rubocop spec/mysql2/client_spec.rb spec/mysql2/statement_spec.rb`


