### PR TITLE
Test EventMachine async completion across Fibers

### DIFF
--- a/ext/mysql2/extconf.rb
+++ b/ext/mysql2/extconf.rb
@@ -298,7 +298,7 @@ wishlist = [
 ]
 
 usable_flags = wishlist.select do |flag|
-  try_link('int main() {return 0;}',  "-Werror #{flag}")
+  try_link('int main() {return 0;}', "-Werror #{flag}")
 end
 
 $CFLAGS << ' ' << usable_flags.join(' ')
@@ -312,13 +312,13 @@ case sanitizers
 when true
   # Try them all, turn on whatever we can
   enabled_sanitizers = %w[address cfi integer memory thread undefined].select do |s|
-    try_link('int main() {return 0;}',  "-Werror -fsanitize=#{s}")
+    try_link('int main() {return 0;}', "-Werror -fsanitize=#{s}")
   end
   abort "-----\nCould not enable any sanitizers!\n-----" if enabled_sanitizers.empty?
 when String
   # Figure out which sanitizers are supported
   enabled_sanitizers, disabled_sanitizers = sanitizers.split(',').partition do |s|
-    try_link('int main() {return 0;}',  "-Werror -fsanitize=#{s}")
+    try_link('int main() {return 0;}', "-Werror -fsanitize=#{s}")
   end
 end
 

--- a/spec/em/em_spec.rb
+++ b/spec/em/em_spec.rb
@@ -4,6 +4,75 @@ begin
   require 'mysql2/em'
 
   RSpec.describe Mysql2::EM::Client do
+    let(:fiber_tracking_client_class) do
+      Class.new(described_class) do
+        attr_reader :async_result_fiber
+
+        def async_result
+          @async_result_fiber = Fiber.current
+          super
+        end
+      end
+    end
+
+    it "should consume plain async query results on the reactor Fiber" do
+      client = nil
+      query_fiber = nil
+      result = nil
+      error = nil
+
+      EM.run do
+        query_fiber = Fiber.current
+        client = fiber_tracking_client_class.new DatabaseCredentials['root']
+        deferred = client.query "SELECT 1 AS plain_query"
+        deferred.callback do |value|
+          result = value.first
+          client.close
+          EM.stop_event_loop
+        end
+        deferred.errback do |value|
+          error = value
+          client.close
+          EM.stop_event_loop
+        end
+      end
+
+      raise error if error
+
+      expect(client.async_result_fiber).to equal(query_fiber)
+      expect(result).to eq('plain_query' => 1)
+    end
+
+    it "should complete a Fiber-issued query from the reactor Fiber" do
+      client = nil
+      query_fiber = nil
+      outcome = nil
+
+      EM.run do
+        Fiber.new do
+          query_fiber = Fiber.current
+          client = fiber_tracking_client_class.new DatabaseCredentials['root']
+          deferred = client.query "SELECT 1 AS fiber_query"
+
+          # This is the handoff used by Fiber wrappers such as em-synchrony:
+          # the application Fiber yields until the reactor callback resumes it.
+          deferred.callback { |value| query_fiber.resume([:success, value]) }
+          deferred.errback { |error| query_fiber.resume([:failure, error]) }
+          outcome = Fiber.yield
+
+          client.close
+          EM.stop_event_loop
+        end.resume
+      end
+
+      status, value = outcome
+      raise value if status == :failure
+
+      expect(status).to eq(:success)
+      expect(client.async_result_fiber).not_to equal(query_fiber)
+      expect(value.first).to eq('fiber_query' => 1)
+    end
+
     it "should support async queries" do
       results = []
       EM.run do

--- a/spec/em/em_spec.rb
+++ b/spec/em/em_spec.rb
@@ -21,26 +21,30 @@ begin
       result = nil
       error = nil
 
-      EM.run do
-        query_fiber = Fiber.current
-        client = fiber_tracking_client_class.new DatabaseCredentials['root']
-        deferred = client.query "SELECT 1 AS plain_query"
-        deferred.callback do |value|
-          result = value.first
-          client.close
-          EM.stop_event_loop
+      begin
+        EM.run do
+          query_fiber = Fiber.current
+          client = fiber_tracking_client_class.new DatabaseCredentials['root']
+          deferred = client.query "SELECT 1 AS plain_query"
+          deferred.callback do |value|
+            result = value.first
+            client.close
+            EM.stop_event_loop
+          end
+          deferred.errback do |value|
+            error = value
+            client.close
+            EM.stop_event_loop
+          end
         end
-        deferred.errback do |value|
-          error = value
-          client.close
-          EM.stop_event_loop
-        end
+
+        raise error if error
+
+        expect(client.async_result_fiber).to equal(query_fiber)
+        expect(result).to eq('plain_query' => 1)
+      ensure
+        client.close if client && !client.closed?
       end
-
-      raise error if error
-
-      expect(client.async_result_fiber).to equal(query_fiber)
-      expect(result).to eq('plain_query' => 1)
     end
 
     it "should complete a Fiber-issued query from the reactor Fiber" do
@@ -48,29 +52,41 @@ begin
       query_fiber = nil
       outcome = nil
 
-      EM.run do
-        Fiber.new do
-          query_fiber = Fiber.current
-          client = fiber_tracking_client_class.new DatabaseCredentials['root']
-          deferred = client.query "SELECT 1 AS fiber_query"
+      begin
+        # The reactor runs on a disposable thread: the cross-Fiber resume below
+        # suspends the reactor's root Fiber deep inside the reactor, and on some
+        # Rubies conservative GC keeps scanning that stale stack region for the
+        # rest of the process, pinning unrelated objects created by later specs
+        # (client_spec's dangling-connections GC spec finds their leaked
+        # connections). A disposable thread takes that stack with it.
+        Thread.new do
+          EM.run do
+            Fiber.new do
+              query_fiber = Fiber.current
+              client = fiber_tracking_client_class.new DatabaseCredentials['root']
+              deferred = client.query "SELECT 1 AS fiber_query"
 
-          # This is the handoff used by Fiber wrappers such as em-synchrony:
-          # the application Fiber yields until the reactor callback resumes it.
-          deferred.callback { |value| query_fiber.resume([:success, value]) }
-          deferred.errback { |error| query_fiber.resume([:failure, error]) }
-          outcome = Fiber.yield
+              # This is the handoff used by Fiber wrappers such as em-synchrony:
+              # the application Fiber yields until the reactor callback resumes it.
+              deferred.callback { |value| query_fiber.resume([:success, value]) }
+              deferred.errback { |error| query_fiber.resume([:failure, error]) }
+              outcome = Fiber.yield
 
-          client.close
-          EM.stop_event_loop
-        end.resume
+              client.close
+              EM.stop_event_loop
+            end.resume
+          end
+        end.join
+
+        status, value = outcome
+        raise value if status == :failure
+
+        expect(status).to eq(:success)
+        expect(client.async_result_fiber).not_to equal(query_fiber)
+        expect(value.first).to eq('fiber_query' => 1)
+      ensure
+        client.close if client && !client.closed?
       end
-
-      status, value = outcome
-      raise value if status == :failure
-
-      expect(status).to eq(:success)
-      expect(client.async_result_fiber).not_to equal(query_fiber)
-      expect(value.first).to eq('fiber_query' => 1)
     end
 
     it "should support async queries" do


### PR DESCRIPTION
## Summary

- make the Fiber context used by ordinary EventMachine query completion explicit
- cover the Synchrony-style handoff where an application Fiber issues a query, yields, and is resumed after the reactor Fiber consumes the result
- keep the coverage self-contained without adding an em-synchrony dependency

## Why

The README points asynchronous Active Record users to em-synchrony. That integration issues a query from an application Fiber, then relies on EventMachine's watcher to collect the result on the reactor Fiber before resuming the application Fiber.

The existing EventMachine specs cover ordinary callbacks, where query issue and result consumption both happen on the reactor Fiber. This adds the complementary cross-Fiber compatibility case so ownership changes do not inadvertently break the README-documented em-synchrony topology.

This PR changes no production behavior. It is independent of the prepared-statement guard in #1603 and of the explicit delegation API design discussion in #1602.

## Tests

- `bundle exec rspec spec/em/em_spec.rb`
- `bundle exec rubocop spec/em/em_spec.rb`
