### PR TITLE
Allow unused prepared statements to be garbage collected

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -20,7 +20,8 @@ VALUE cMysql2Client;
 extern VALUE mMysql2, cMysql2Error, cMysql2ConnectionError, cMysql2TimeoutError;
 static VALUE sym_id, sym_version, sym_header_version, sym_async, sym_symbolize_keys, sym_as, sym_array, sym_stream;
 static ID intern_brackets, intern_merge, intern_merge_bang, intern_new_with_args,
-  intern_current_query_options, intern_read_timeout, intern_values;
+  intern_current_query_options, intern_read_timeout, intern_values, intern_getobj;
+static VALUE cWeakRefError;
 
 #define REQUIRE_INITIALIZED(wrapper) \
   if (!wrapper->initialized) { \
@@ -2728,18 +2729,37 @@ static VALUE rb_mysql_client_prepare_statement(VALUE self, VALUE sql) {
   return stmt;
 }
 
+static VALUE rb_mysql_client_weak_statement(VALUE reference) {
+  return rb_funcall(reference, intern_getobj, 0);
+}
+
+static VALUE rb_mysql_client_collected_statement(VALUE unused, VALUE error) {
+  return Qnil;
+}
+
 /* call-seq:
  *    client.prepared_statements
  *
- * Returns an array of prepared statement objects.
+ * Returns an array of live prepared statement objects without flushing
+ * deferred native cleanup.
  */
 static VALUE rb_mysql_client_prepared_statements_read(VALUE self) {
+  VALUE references, statements;
+  long i;
   GET_CLIENT(self);
 
-  mysql2_reap_pending_result_frees(wrapper);
-  mysql2_reap_pending_stmt_closes(wrapper);
-
-  return rb_funcall(wrapper->prepared_statements, intern_values, 0);
+  /* Introspection may run while an async query or stream owns the socket;
+   * only a later protocol-safe command may reap the collected handles. */
+  references = rb_funcall(wrapper->prepared_statements, intern_values, 0);
+  statements = rb_ary_new2(RARRAY_LEN(references));
+  for (i = 0; i < RARRAY_LEN(references); i++) {
+    VALUE statement = rb_rescue2(rb_mysql_client_weak_statement, rb_ary_entry(references, i),
+                                rb_mysql_client_collected_statement, Qnil, cWeakRefError, (VALUE)0);
+    if (!NIL_P(statement)) rb_ary_push(statements, statement);
+    RB_GC_GUARD(statement);
+  }
+  RB_GC_GUARD(references);
+  return statements;
 }
 
 /* call-seq:
@@ -2881,6 +2901,9 @@ void init_mysql2_client(void) {
   intern_current_query_options = rb_intern("@current_query_options");
   intern_read_timeout = rb_intern("@read_timeout");
   intern_values = rb_intern("values");
+  intern_getobj = rb_intern("__getobj__");
+  cWeakRefError = rb_const_get(rb_const_get(rb_cObject, rb_intern("WeakRef")), rb_intern("RefError"));
+  rb_global_variable(&cWeakRefError);
 
 #ifdef CLIENT_LONG_PASSWORD
   rb_const_set(cMysql2Client, rb_intern("LONG_PASSWORD"),

--- a/ext/mysql2/client.h
+++ b/ext/mysql2/client.h
@@ -45,7 +45,7 @@ typedef struct mysql2_pending_result_free {
 typedef struct {
   VALUE encoding;
   VALUE active_fiber; /* rb_fiber_current() or Qnil */
-  VALUE prepared_statements;
+  VALUE prepared_statements; /* native wrapper address => WeakRef to Statement */
   /* The Mysql2::Result for the currently open streaming cursor (state ==
    * MYSQL2_CLIENT_STREAMING), or Qnil. pending_result_frees only ever gets
    * populated once GC has actually collected an abandoned streaming

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -3,7 +3,8 @@
 #include <string.h>
 
 extern VALUE mMysql2, cMysql2Error;
-static VALUE cMysql2Statement, cBigDecimal, cDateTime, cDate;
+static VALUE cMysql2Statement, cBigDecimal, cDateTime, cDate, cWeakRef;
+static ID intern_new;
 static VALUE sym_stream, sym_size, intern_new_with_args, intern_each, intern_to_s, intern_merge_bang;
 static VALUE intern_sec_fraction, intern_usec, intern_sec, intern_min, intern_hour, intern_day, intern_month, intern_year,
   intern_query_options, intern_mul, intern_truncate;
@@ -309,16 +310,12 @@ VALUE rb_mysql_stmt_new(VALUE rb_client, VALUE sql) {
     }
   }
 
-  // Stash a reference to this statement handle into the Client to prevent
-  // premature garbage collection.
-  //
-  // A statement can either be free explicitly or when the client object is
-  // torn down. Freeing a statement handle at any other time causes protocol
-  // traffic that might happen while the connection state is set for another
-  // operation.
+  /* Native closes are deferred by dfree; the registry must not keep
+   * otherwise unreachable statements alive until the connection closes. */
   {
+    VALUE reference = rb_funcall(cWeakRef, intern_new, 1, rb_stmt);
     GET_CLIENT(rb_client);
-    rb_hash_aset(wrapper->prepared_statements, ULL2NUM((unsigned long long)stmt_wrapper), rb_stmt);
+    rb_hash_aset(wrapper->prepared_statements, ULL2NUM((unsigned long long)stmt_wrapper), reference);
   }
 
   return rb_stmt;
@@ -938,6 +935,10 @@ static VALUE rb_mysql_stmt_closed_p(VALUE self) {
 }
 
 void init_mysql2_statement(void) {
+  cWeakRef = rb_const_get(rb_cObject, rb_intern("WeakRef"));
+  rb_global_variable(&cWeakRef);
+  intern_new = rb_intern("new");
+
   cDate = rb_const_get(rb_cObject, rb_intern("Date"));
   rb_global_variable(&cDate);
 

--- a/lib/mysql2.rb
+++ b/lib/mysql2.rb
@@ -1,5 +1,6 @@
 require 'date'
 require 'bigdecimal'
+require 'weakref'
 
 # Load libmariadb.dll before requiring mysql2/mysql2.so
 # This gives a chance to be flexible about the load path

--- a/spec/mysql2/statement_gc_spec.rb
+++ b/spec/mysql2/statement_gc_spec.rb
@@ -1,0 +1,62 @@
+require 'spec_helper'
+require 'weakref'
+
+RSpec.describe 'prepared statement collection' do
+  it 'collects discarded statements and closes their server handles at the next safe command' do
+    before = @client.query("SHOW SESSION STATUS LIKE 'Com_stmt_close'").first['Value'].to_i
+    new_thread do
+      12.times { @client.prepare('SELECT 1 AS n').execute }
+      nil
+    end.join
+    GC.start
+    expect(@client.prepared_statements).to eq([])
+    @client.ping
+    expect(@client.pending_prepared_statement_closes).to eq(0)
+    after = @client.query("SHOW SESSION STATUS LIKE 'Com_stmt_close'").first['Value'].to_i
+    expect(after - before).to eq(12)
+  end
+
+  it 'preserves application-owned statements through collection and compaction' do
+    statement = @client.prepare('SELECT 7 AS n')
+    GC.start
+    GC.verify_compaction_references(expand_heap: true, toward: :empty) if GC.respond_to?(:verify_compaction_references) && RUBY_VERSION >= '3.2'
+    expect(@client.prepared_statements).to eq([statement])
+    expect(statement.execute.first).to eq('n' => 7)
+    statement.close
+    expect(@client.prepared_statements).to eq([])
+  end
+
+  it 'keeps a statement alive while its result is still referenced' do
+    result, reference = new_thread do
+      statement = @client.prepare('SELECT 8 AS n')
+      [statement.execute, WeakRef.new(statement)]
+    end.value
+    GC.start
+    expect(reference.weakref_alive?).to be_truthy
+    expect(result.to_a).to eq([{ 'n' => 8 }])
+    expect(@client.prepared_statements).to eq([reference.__getobj__])
+  end
+
+  it 'does not flush collected handles when inspected during an async query' do
+    ready = Queue.new
+    release = Queue.new
+    worker = new_thread do
+      statements = Array.new(5) { @client.prepare('SELECT 1') }
+      ready << statements.length
+      release.pop
+      statements.clear
+      nil
+    end
+    expect(ready.pop).to eq(5)
+    @client.query('SELECT SLEEP(0.05) AS n', async: true)
+    release << true
+    worker.join
+    GC.start
+    pending = @client.pending_prepared_statement_closes
+    expect(pending).to be > 0
+    expect(@client.prepared_statements).to eq([])
+    expect(@client.pending_prepared_statement_closes).to eq(pending)
+    expect(@client.async_result.first).to eq('n' => 0)
+    expect(@client.query('SELECT 3 AS n').first['n']).to eq(3)
+  end
+end

--- a/spec/mysql2/statement_gc_spec.rb
+++ b/spec/mysql2/statement_gc_spec.rb
@@ -38,6 +38,7 @@ RSpec.describe 'prepared statement collection' do
   end
 
   it 'does not flush collected handles when inspected during an async query' do
+    skip 'async: true is synchronous on Windows -- see rb_mysql_query in client.c' if RUBY_PLATFORM =~ /mingw|mswin/
     ready = Queue.new
     release = Queue.new
     worker = new_thread do


### PR DESCRIPTION
The client's prepared-statement registry holds strong references to every open statement. Applications that discard temporary statements therefore retain their Ruby objects and native handles for the lifetime of a reachable client, even though the driver already defers native closes to safe connection operations.

Store weak references in the registry and return only live statements from `Client#prepared_statements`. Application-held statements remain usable, and the existing result-to-statement reference continues to keep a statement alive while its result is referenced. `Client#prepared_statements` inspection no longer drains deferred cleanup, so inspecting a client during an asynchronous query cannot send statement-close traffic on that connection.

Validation on macOS arm64, Ruby 3.3.10, MySQL client/server 9.6:

- Four focused examples pass; two fail against the unmodified base. They cover collection, live references, compaction, result ownership, and inspection during an asynchronous query.
- Twelve discarded statements are collected, and the session's `Com_stmt_close` counter confirms twelve server-side closes by the subsequent `ping`.
- Full suite: 638 examples, 0 failures, 26 pending. Changed Ruby files pass RuboCop.

This fixes retention while the connection remains in use. Releasing detached native handles during connection teardown is addressed separately. No throughput or RSS improvement is claimed.



Relationship to #1603: that PR guards this same reader by claiming the connection (`mysql2_client_check_idle`, then the `COMMAND` state) before it reaps deferred closes, so the two conflict textually in `rb_mysql_client_prepared_statements_read` and differ on inspection during an asynchronous query: #1603 raises "This connection is still waiting for a result", while this branch currently returns the live statements without touching the connection. If #1603 lands first, this branch will be rebased onto it: keep the weak registry, apply the live-statement mapping inside `do_prepared_statements_read`, and change the async-inspection example to expect that error.
