### PR TITLE
Release detached native statements during connection teardown

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -631,6 +631,13 @@ static void invalidate_socket(mysql_client_wrapper *wrapper)
 
 void mysql2_enqueue_pending_stmt_close(mysql_client_wrapper *wrapper, MYSQL_STMT *stmt, uintptr_t wrapper_key)
 {
+  /* mysql_close detaches statement handles; their remaining cleanup is
+   * local and safe during GC, with no future connection command required. */
+  if (wrapper->closed) {
+    mysql_stmt_close(stmt);
+    return;
+  }
+
   /* Deliberately plain malloc(), not Ruby's xmalloc(): this runs from a
    * dfree callback, which can fire during a GC sweep. xmalloc() may itself
    * try to trigger a GC run on allocation failure, and doing that while a
@@ -669,9 +676,8 @@ void mysql2_reap_pending_stmt_closes(mysql_client_wrapper *wrapper)
   }
 }
 
-/* See client.h: used by Client#close, which deliberately skips the
- * mysql_stmt_close() network round trips above -- the connection is going
- * away regardless -- but still needs the Ruby-visible bookkeeping cleared. */
+/* mysql_close must have detached these handles before they can be freed
+ * without protocol I/O, including when called from a GC callback. */
 void mysql2_drop_pending_stmt_closes(mysql_client_wrapper *wrapper)
 {
   mysql2_pending_stmt_close *node = wrapper->pending_stmt_closes;
@@ -680,7 +686,7 @@ void mysql2_drop_pending_stmt_closes(mysql_client_wrapper *wrapper)
 
   while (node) {
     mysql2_pending_stmt_close *next = node->next;
-    rb_hash_delete(wrapper->prepared_statements, ULL2NUM((unsigned long long)node->wrapper_key));
+    mysql_stmt_close(node->stmt);
     free(node);
     node = next;
   }
@@ -824,30 +830,12 @@ void decr_mysql2_client(mysql_client_wrapper *wrapper)
   }
 #endif
 
-  /* Any statements queued for a deferred close are moot: mysql_close()
-   * below already releases all of this session's prepared statements on
-   * the server, and this may itself be running during a GC sweep, so we
-   * must not touch prepared_statements (a Ruby Hash) or attempt any more
-   * network I/O here -- just drop the list. */
-  {
-    mysql2_pending_stmt_close *node = wrapper->pending_stmt_closes;
-    while (node) {
-      mysql2_pending_stmt_close *next = node->next;
-      free(node); /* plain free(): this too can run during a GC sweep */
-      node = next;
-    }
-    wrapper->pending_stmt_closes = NULL;
-    wrapper->pending_stmt_close_count = 0;
-  }
+  nogvl_close(wrapper);
+  mysql2_drop_pending_stmt_closes(wrapper);
 
-  /* Same reasoning for any not-yet-drained result sets: mysql_close() below
-   * is about to invalidate the connection those MYSQL_RES/MYSQL_STMT
-   * pointers belong to, and this may itself be running during a GC sweep,
-   * so no network I/O and no VM calls -- just drop the list. This does leak
-   * the client-side MYSQL_RES memory, same tradeoff already accepted above
-   * for statement handles -- but only here, where we have no other choice.
-   * The ordinary-Ruby-level Client#close path below does not take this
-   * shortcut: see mysql2_reap_pending_result_frees at that call site. */
+  /* Deferred result cleanup remains separate: the connection has been
+   * invalidated and this may be a GC callback. The ordinary Client#close
+   * path drains these results before disconnecting. */
   {
     mysql2_pending_result_free *node = wrapper->pending_result_frees;
     while (node) {
@@ -859,7 +847,6 @@ void decr_mysql2_client(mysql_client_wrapper *wrapper)
     wrapper->pending_result_free_count = 0;
   }
 
-  nogvl_close(wrapper);
   xfree(wrapper->client);
   xfree(wrapper);
 }
@@ -1288,11 +1275,12 @@ static VALUE rb_mysql_client_close(VALUE self) {
    * safe point, this one was just missing it. */
   mysql2_abandon_active_stream(wrapper);
   mysql2_reap_pending_result_frees(wrapper);
-  mysql2_drop_pending_stmt_closes(wrapper);
 
   if (wrapper->client) {
     rb_thread_call_without_gvl(nogvl_close, wrapper, RUBY_UBF_IO, 0);
   }
+  mysql2_drop_pending_stmt_closes(wrapper);
+  rb_hash_clear(wrapper->prepared_statements);
 
   wrapper->active_fiber = Qnil;
 
@@ -1355,8 +1343,9 @@ static VALUE rb_mysql_client_discard(VALUE self) {
      * tradeoff decr_mysql2_client accepts. */
     mysql2_abandon_active_stream(wrapper);
     mysql2_reap_pending_result_frees(wrapper);
-    mysql2_drop_pending_stmt_closes(wrapper);
     rb_thread_call_without_gvl(nogvl_close, wrapper, RUBY_UBF_IO, 0);
+    mysql2_drop_pending_stmt_closes(wrapper);
+    rb_hash_clear(wrapper->prepared_statements);
   }
 
   return Qnil;

--- a/ext/mysql2/client.h
+++ b/ext/mysql2/client.h
@@ -132,13 +132,9 @@ void mysql2_enqueue_pending_stmt_close(mysql_client_wrapper *wrapper, MYSQL_STMT
  * after a streaming result finishes or is abandoned. */
 void mysql2_reap_pending_stmt_closes(mysql_client_wrapper *wrapper);
 
-/* Also ordinary-Ruby-level-only, like the reap above, but never attempts
- * mysql_stmt_close(): for Client#close, where the connection is about to
- * go away regardless, so there is no point notifying the server for each
- * statement individually -- mysql_close() (or the server's own session
- * teardown) already releases all of them. Still clears the C list and
- * prunes prepared_statements, since this runs in ordinary Ruby context and
- * can safely touch both. */
+/* Call only after mysql_close has detached the native handles. Frees them
+ * without protocol I/O or Ruby VM calls, so this is also safe during GC.
+ * Ordinary callers clear prepared_statements separately. */
 void mysql2_drop_pending_stmt_closes(mysql_client_wrapper *wrapper);
 
 /* Safe to call from a dfree callback (GC sweep context): only touches C

--- a/ext/mysql2/statement.c
+++ b/ext/mysql2/statement.c
@@ -177,9 +177,10 @@ void decr_mysql2_stmt(mysql_stmt_wrapper *stmt_wrapper) {
      * drains it later from ordinary Ruby-level code, once the connection
      * is confirmed idle.
      *
-     * If the GC got to the Client first, client_wrapper is NULL and there
-     * is nothing left to notify -- the connection (and every prepared
-     * statement on it, server-side) is already gone.
+     * This statement owns a native client-wrapper reference until the
+     * decr_mysql2_client call below, even if the Ruby Client was swept
+     * first. An explicitly closed connection has already detached its
+     * handles; enqueue then frees this handle locally instead of queuing.
      */
     if (stmt_wrapper->client_wrapper && stmt_wrapper->stmt) {
       mysql2_enqueue_pending_stmt_close(stmt_wrapper->client_wrapper, stmt_wrapper->stmt,

--- a/spec/mysql2/statement_teardown_spec.rb
+++ b/spec/mysql2/statement_teardown_spec.rb
@@ -91,13 +91,16 @@ RSpec.describe 'prepared statement teardown' do
         output, status = Open3.capture2e(environment, *command)
         expect(status.success?).to eq(true), output
         events = File.exist?(report) ? File.readlines(report, chomp: true) : []
+        # The interposer reports its own failures on the child's stderr, so a
+        # count mismatch must show that output alongside the events.
+        diagnostic = "events: #{events.inspect}\n#{output}"
         checkpoint = events.index('checkpoint')
-        expect(checkpoint).not_to be_nil, output
+        expect(checkpoint).not_to be_nil, diagnostic
         before_checkpoint = events.first(checkpoint)
         # Five prepares per scenario. A zero count means the interposer never
         # took effect, which must not read as "nothing leaked".
-        expect(before_checkpoint.count('init')).to eq(5)
-        expect(before_checkpoint.count('close')).to eq(5)
+        expect(before_checkpoint.count('init')).to eq(5), diagnostic
+        expect(before_checkpoint.count('close')).to eq(5), diagnostic
       end
     end
   end

--- a/spec/mysql2/statement_teardown_spec.rb
+++ b/spec/mysql2/statement_teardown_spec.rb
@@ -62,8 +62,6 @@ RSpec.describe 'prepared statement teardown' do
         script = <<-'RUBY'
           require 'mysql2'
           require 'yaml'
-          require 'fiddle'
-          counter = Fiddle::Function.new(Fiddle::Handle::DEFAULT['mysql2_test_live_statements'], [], Fiddle::TYPE_LONG)
           Thread.new do
             connection = Mysql2::Client.new(YAML.load_file('spec/configuration.yml')['root'])
             5.times do
@@ -82,14 +80,24 @@ RSpec.describe 'prepared statement teardown' do
             nil
           end.join
           GC.start
-          raise "unreleased native statements: #{counter.call}" unless counter.call == 0
+          File.open(ENV.fetch('MYSQL2_STATEMENT_LIFETIME_REPORT'), 'a') { |report| report.puts 'checkpoint' }
         RUBY
         library_file = $LOADED_FEATURES.find { |path| path.end_with?('/lib/mysql2.rb') }
         extension_file = $LOADED_FEATURES.find { |path| path.end_with?('/mysql2/mysql2.bundle') }
+        report = File.join(@probe_directory, "#{mode}.log")
         command = [RbConfig.ruby, "-I#{File.dirname(library_file)}",
                    "-I#{File.dirname(File.dirname(extension_file))}", '-e', script, mode,]
-        output, status = Open3.capture2e({ 'DYLD_INSERT_LIBRARIES' => @probe_library }, *command)
+        environment = { 'DYLD_INSERT_LIBRARIES' => @probe_library, 'MYSQL2_STATEMENT_LIFETIME_REPORT' => report }
+        output, status = Open3.capture2e(environment, *command)
         expect(status.success?).to eq(true), output
+        events = File.exist?(report) ? File.readlines(report, chomp: true) : []
+        checkpoint = events.index('checkpoint')
+        expect(checkpoint).not_to be_nil, output
+        before_checkpoint = events.first(checkpoint)
+        # Five prepares per scenario. A zero count means the interposer never
+        # took effect, which must not read as "nothing leaked".
+        expect(before_checkpoint.count('init')).to eq(5)
+        expect(before_checkpoint.count('close')).to eq(5)
       end
     end
   end

--- a/spec/mysql2/statement_teardown_spec.rb
+++ b/spec/mysql2/statement_teardown_spec.rb
@@ -1,0 +1,96 @@
+require 'spec_helper'
+require 'weakref'
+require 'open3'
+require 'tmpdir'
+require 'shellwords'
+require 'rbconfig'
+
+RSpec.describe 'prepared statement teardown' do
+  it 'clears the closed connection registry and allows discarded statements to be collected' do
+    references = new_thread do
+      Array.new(5) { WeakRef.new(@client.prepare('SELECT 1')) }
+    end.value
+    @client.close
+    expect(@client.prepared_statements).to eq([])
+    GC.start
+    expect(references.none?(&:weakref_alive?)).to eq(true)
+  end
+
+  it 'allows an application-held statement to close after its connection' do
+    statement = @client.prepare('SELECT 1')
+    @client.close
+    expect { statement.close }.not_to raise_error
+    expect(statement.closed?).to eq(true)
+    expect { statement.close }.not_to raise_error
+  end
+
+  it 'clears the statement registry after discarding a connection' do
+    statement = @client.prepare('SELECT 1')
+    @client.discard!
+    expect(@client.prepared_statements).to eq([])
+    expect { statement.close }.not_to raise_error
+  end
+
+  context 'native allocation balance' do
+    before(:context) do
+      skip 'native allocation interposition fixture requires macOS' unless RUBY_PLATFORM.include?('darwin')
+
+      @probe_directory = Dir.mktmpdir('mysql2-statement-lifetime')
+      @probe_library = File.join(@probe_directory, 'statement-lifetime.dylib')
+      config = ENV.fetch('MYSQL_CONFIG', 'mysql_config')
+      flags, flag_status = Open3.capture2e(config, '--cflags')
+      libraries, library_status = Open3.capture2e(config, '--libs')
+      raise 'mysql_config failed for native lifetime fixture' unless flag_status.success? && library_status.success?
+
+      source = File.expand_path('../support/statement_lifetime.c', __dir__)
+      # The dynamic client library resolves its own transitive dependencies.
+      client_libraries = Shellwords.split(libraries).select do |flag|
+        flag.start_with?('-L') || ['-lmysqlclient', '-lmariadb'].include?(flag)
+      end
+      command = Shellwords.split(RbConfig::CONFIG.fetch('CC')) + ['-dynamiclib'] +
+                Shellwords.split(flags) + [source] + client_libraries + ['-o', @probe_library]
+      output, status = Open3.capture2e(*command)
+      raise "Native lifetime fixture build failed: #{output}" unless status.success?
+    end
+
+    after(:context) do
+      FileUtils.remove_entry(@probe_directory) if @probe_directory
+    end
+
+    %w[gc close discard queued].each do |mode|
+      it "releases every native handle after #{mode}" do
+        script = <<-'RUBY'
+          require 'mysql2'
+          require 'yaml'
+          require 'fiddle'
+          counter = Fiddle::Function.new(Fiddle::Handle::DEFAULT['mysql2_test_live_statements'], [], Fiddle::TYPE_LONG)
+          Thread.new do
+            connection = Mysql2::Client.new(YAML.load_file('spec/configuration.yml')['root'])
+            5.times do
+              if ARGV.first == 'queued'
+                begin
+                  connection.prepare('invalid SQL')
+                rescue Mysql2::Error
+                end
+              else
+                connection.prepare('SELECT 1').execute
+              end
+            end
+            GC.start if ARGV.first == 'queued'
+            connection.close if ['close', 'queued'].include?(ARGV.first)
+            connection.discard! if ARGV.first == 'discard'
+            nil
+          end.join
+          GC.start
+          raise "unreleased native statements: #{counter.call}" unless counter.call == 0
+        RUBY
+        library_file = $LOADED_FEATURES.find { |path| path.end_with?('/lib/mysql2.rb') }
+        extension_file = $LOADED_FEATURES.find { |path| path.end_with?('/mysql2/mysql2.bundle') }
+        command = [RbConfig.ruby, "-I#{File.dirname(library_file)}",
+                   "-I#{File.dirname(File.dirname(extension_file))}", '-e', script, mode,]
+        output, status = Open3.capture2e({ 'DYLD_INSERT_LIBRARIES' => @probe_library }, *command)
+        expect(status.success?).to eq(true), output
+      end
+    end
+  end
+end

--- a/spec/support/statement_lifetime.c
+++ b/spec/support/statement_lifetime.c
@@ -1,0 +1,27 @@
+/* macOS interposition fixture: count actual native handle allocations/frees. */
+#include <mysql.h>
+
+static unsigned long created, closed;
+
+static MYSQL_STMT *counted_init(MYSQL *mysql) {
+  MYSQL_STMT *stmt = mysql_stmt_init(mysql);
+  if (stmt) created++;
+  return stmt;
+}
+
+static __typeof__(mysql_stmt_close((MYSQL_STMT *)0)) counted_close(MYSQL_STMT *stmt) {
+  if (stmt) closed++;
+  return mysql_stmt_close(stmt);
+}
+
+unsigned long mysql2_test_live_statements(void) {
+  return created - closed;
+}
+
+__attribute__((used)) static const struct {
+  const void *replacement;
+  const void *original;
+} interposers[] __attribute__((section("__DATA,__interpose"))) = {
+  { (const void *)counted_init, (const void *)mysql_stmt_init },
+  { (const void *)counted_close, (const void *)mysql_stmt_close }
+};

--- a/spec/support/statement_lifetime.c
+++ b/spec/support/statement_lifetime.c
@@ -1,21 +1,57 @@
-/* macOS interposition fixture: count actual native handle allocations/frees. */
+/* macOS interposition fixture: append one line per native statement handle
+ * init and close to the file named by MYSQL2_STATEMENT_LIFETIME_REPORT. The
+ * child appends its own "checkpoint" line, so the parent can balance the two
+ * counts at that exact point in the child's execution. */
 #include <mysql.h>
+#include <errno.h>
+#include <fcntl.h>
+#include <stdlib.h>
+#include <string.h>
+#include <unistd.h>
 
-static unsigned long created, closed;
+static int report_fd = -1;
+
+/* Runs once, before main(), on the single startup thread. */
+__attribute__((constructor)) static void open_report(void) {
+  static const char failure[] = "statement_lifetime: cannot open MYSQL2_STATEMENT_LIFETIME_REPORT\n";
+  const char *path = getenv("MYSQL2_STATEMENT_LIFETIME_REPORT");
+
+  if (!path) return;
+  report_fd = open(path, O_WRONLY | O_APPEND | O_CREAT | O_CLOEXEC, 0644);
+  if (report_fd < 0) (void)write(STDERR_FILENO, failure, sizeof(failure) - 1);
+}
+
+/* write(2) only: mysql_stmt_close can be reached from a GC callback, which
+ * must not re-enter the Ruby VM, and buffered stdio would leave records
+ * unwritten if the process ended abruptly. A record that cannot be written
+ * is reported on stderr so the parent sees a logging failure rather than a
+ * lifecycle imbalance. */
+static void log_event(const char *line) {
+  static const char failure[] = "statement_lifetime: cannot write to the report\n";
+  size_t remaining = strlen(line);
+
+  if (report_fd < 0) return;
+  while (remaining > 0) {
+    ssize_t written = write(report_fd, line, remaining);
+    if (written < 0 && errno == EINTR) continue;
+    if (written <= 0) {
+      (void)write(STDERR_FILENO, failure, sizeof(failure) - 1);
+      return;
+    }
+    line += written;
+    remaining -= (size_t)written;
+  }
+}
 
 static MYSQL_STMT *counted_init(MYSQL *mysql) {
   MYSQL_STMT *stmt = mysql_stmt_init(mysql);
-  if (stmt) created++;
+  if (stmt) log_event("init\n");
   return stmt;
 }
 
 static __typeof__(mysql_stmt_close((MYSQL_STMT *)0)) counted_close(MYSQL_STMT *stmt) {
-  if (stmt) closed++;
+  if (stmt) log_event("close\n");
   return mysql_stmt_close(stmt);
-}
-
-unsigned long mysql2_test_live_statements(void) {
-  return created - closed;
 }
 
 __attribute__((used)) static const struct {


### PR DESCRIPTION
Connection teardown discards queued statement-close records without freeing their native `MYSQL_STMT` handles. `mysql_close` detaches these handles from the connection; releasing the server session does not release each client-side statement allocation. The closed client's registry also continues to retain statement objects.

Close the connection before releasing queued native statements, and immediately free handles collected after the connection has already closed. The native cleanup helper performs no Ruby VM calls. Clear the Ruby registry separately in `Client#close` and `Client#discard!`, while preserving explicit close for statements still held by the application.

Validation on macOS arm64, Ruby 3.3.11, MySQL client/server 9.6:

- Seven focused examples pass; six fail against the unmodified base.
- A macOS interposition fixture logs each native statement init and close; at the post-GC checkpoint, the four scenarios (garbage collection, explicit connection close, discard, and queued failed prepares) show five handles created and none closed before the fix, and all five closed afterward. Each child process joins its worker thread before that final forced GC.
- Full suite: 641 examples, 0 failures, 26 pending. Changed Ruby files pass RuboCop.

The native fixture uses macOS interposition and skips on other platforms. MySQL and MariaDB Connector/C teardown implementations were checked for detached-handle cleanup; runtime validation used MySQL 9.6 only. This change addresses statement handles; it does not claim to fix every deferred-result allocation.

