### PR TITLE
Preserve successor streams after iteration callbacks

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -2141,6 +2141,9 @@ static VALUE rb_mysql_result_each_(VALUE self,
         }
       } while(row != Qnil);
 
+      /* A callback may have freed this stream and installed its successor. */
+      if (wrapper->resultFreed) return wrapper->rows;
+
       rb_mysql_result_cache_metadata_and_free(self);
       wrapper->streamingComplete = 1;
 

--- a/spec/mysql2/stream_ownership_spec.rb
+++ b/spec/mysql2/stream_ownership_spec.rb
@@ -1,0 +1,40 @@
+require 'spec_helper'
+
+RSpec.describe 'stream ownership after an iteration callback' do
+  def stream_result(sql, prepared)
+    options = { stream: true, cache_rows: false }
+    prepared ? @client.prepare(sql).execute(**options) : @client.query(sql, options)
+  end
+
+  [false, true].each do |prepared|
+    context "with #{prepared ? 'prepared' : 'text'} results" do
+      it 'permits a buffered query inside an each block' do
+        result = stream_result('SELECT 1 AS n UNION ALL SELECT 2', prepared)
+        values = []
+        result.each { values << @client.query('SELECT 3 AS n').first['n'] }
+        expect(values).to eq([3])
+        expect(@client.query('SELECT 4 AS n').first['n']).to eq(4)
+      end
+
+      it 'stops cleanly when the block frees the result' do
+        result = stream_result('SELECT 1 AS n UNION ALL SELECT 2', prepared)
+        result.each { result.free }
+        expect(@client.query('SELECT 4 AS n').first['n']).to eq(4)
+      end
+
+      [false, true].each do |explicit_free|
+        it "preserves a successor stream for the next query (explicit free: #{explicit_free})" do
+          first = stream_result('SELECT 1 AS n UNION ALL SELECT 2', prepared)
+          first.field_types
+          successor = nil
+          first.each do
+            first.free if explicit_free
+            successor = @client.query('SELECT 3 AS n UNION ALL SELECT 4', stream: true, cache_rows: false)
+          end
+          expect(@client.query('SELECT 5 AS n').first['n']).to eq(5)
+          expect { successor.each { |_| } }.to raise_error(Mysql2::Error, /already been freed/)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
A streaming `Result#each` block can issue another query, which releases the old result and may install a successor stream. When the old loop finishes, its cleanup still attempts to cache released metadata and reset the client's stream state. This can raise after a successful nested buffered query or leave the next command unable to drain the successor stream.

Return from the old iteration when its result was already freed by the callback. The existing release path owns that cleanup, and the successor retains its connection state. The guard applies to both text and prepared-statement results.

Validation on macOS arm64, Ruby 3.3.10, MySQL client/server 9.6:

- Eight focused examples pass; six fail against the unmodified base. They cover nested buffered queries, explicit result free, and successor streams with and without an explicit free, for text and prepared results.
- Each scenario verifies that a subsequent query returns the expected value; successor tests also verify that the next query drains the active stream.
- Full suite: 642 examples, 0 failures, 26 pending. Changed Ruby files pass RuboCop.
