### PR TITLE
Preserve unsigned DECIMAL precision in field_types

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -656,7 +656,8 @@ static VALUE rb_mysql_result_fetch_field_type(VALUE self, unsigned int idx) {
           https://github.com/mysql/mysql-server/blob/ea7d2e2d16ac03afdd9cb72a972a95981107bf51/sql/field.cc#L2246
         */
         // DECIMAL's max precision is 65 digits, so this narrowing is safe for any field the server actually sent.
-        precision = (int)(field->length - (field->decimals > 0 ? 2 : 1));
+        precision = (int)(field->length - (field->decimals > 0 ? 1 : 0) -
+                          ((field->flags & UNSIGNED_FLAG) ? 0 : 1));
         rb_field_type = rb_sprintf("decimal(%d,%d)", precision, field->decimals);
         break;
       case MYSQL_TYPE_STRING:       // char[]

--- a/spec/mysql2/unsigned_decimal_precision_spec.rb
+++ b/spec/mysql2/unsigned_decimal_precision_spec.rb
@@ -1,0 +1,19 @@
+require 'spec_helper'
+
+RSpec.describe 'unsigned decimal field precision' do
+  [false, true].each do |prepared|
+    it "reports declared signed and unsigned precision with and without a scale (prepared: #{prepared})" do
+      @client.query('CREATE TEMPORARY TABLE decimal_precision (a DECIMAL(10,2) UNSIGNED, b DECIMAL(10,0) UNSIGNED, c DECIMAL(10,2), d DECIMAL(10,0))')
+      sql = 'SELECT * FROM decimal_precision'
+      result = prepared ? @client.prepare(sql).execute : @client.query(sql)
+      expect(result.field_types).to eq(['decimal(10,2)', 'decimal(10,0)', 'decimal(10,2)', 'decimal(10,0)'])
+    end
+
+    it "retains maximum unsigned precision (prepared: #{prepared})" do
+      @client.query('CREATE TEMPORARY TABLE decimal_max_precision (a DECIMAL(65,0) UNSIGNED, b DECIMAL(65,30) UNSIGNED)')
+      sql = 'SELECT * FROM decimal_max_precision'
+      result = prepared ? @client.prepare(sql).execute : @client.query(sql)
+      expect(result.field_types).to eq(['decimal(65,0)', 'decimal(65,30)'])
+    end
+  end
+end


### PR DESCRIPTION
Result#field_types subtracts a sign position even for unsigned DECIMAL columns. DECIMAL(10,2) UNSIGNED and DECIMAL(10,0) UNSIGNED are consequently reported with precision nine instead of ten.

Subtract a decimal point only when the column has a scale, and reserve a sign position only for signed columns (UNSIGNED_FLAG not set).

Two examples, each run through the text and the prepared protocol (four in all), cover signed and unsigned columns with and without a scale, and unsigned columns at the maximum precision of 65 with scale zero and scale 30.

Validated on Ruby 3.3.10 with MySQL/libmysqlclient 9.6.0 on macOS arm64. The focused regressions produce 4 examples with 4 failures on the unmodified baseline and 4 examples with no failures on this change. Full suite: 638 examples, 0 failures, 26 pending. Changed Ruby files pass RuboCop; the patch passes the whitespace check.

Runtime verification covers MySQL 9.6. Signed precision is retained; this change affects metadata descriptions, not numeric value conversion. The other supported Ruby, operating-system, and MySQL/MariaDB combinations have not been run locally.
