### PR TITLE
Decode server error messages in the connection encoding

### DIFF
--- a/ext/mysql2/client.c
+++ b/ext/mysql2/client.c
@@ -527,7 +527,17 @@ VALUE rb_raise_mysql2_error(mysql_client_wrapper *wrapper) {
   VALUE rb_sql_state = rb_str_new2(mysql_sqlstate(wrapper->client));
   VALUE e;
 
-  rb_enc_associate(rb_error_msg, rb_utf8_encoding());
+  /* The server converts its error messages to character_set_results, the
+   * connection charset this wrapper tracks. Client-library errors (CR_*,
+   * 2000-2999) are ASCII English with caller-supplied text interpolated as
+   * given, so they keep the UTF-8 tag, as does anything raised before a
+   * charset is set. */
+  unsigned int errno_value = mysql_errno(wrapper->client);
+  if (NIL_P(wrapper->encoding) || (errno_value >= 2000 && errno_value < 3000)) {
+    rb_enc_associate(rb_error_msg, rb_utf8_encoding());
+  } else {
+    rb_enc_associate(rb_error_msg, rb_to_encoding(wrapper->encoding));
+  }
   rb_enc_associate(rb_sql_state, rb_usascii_encoding());
 
   e = rb_funcall(cMysql2Error, intern_new_with_args, 4,

--- a/spec/mysql2/error_encoding_spec.rb
+++ b/spec/mysql2/error_encoding_spec.rb
@@ -1,0 +1,36 @@
+require 'spec_helper'
+
+RSpec.describe 'server error message encoding' do
+  [nil, Encoding::UTF_8].each do |internal|
+    it "decodes latin1 query errors with default_internal #{internal.inspect}" do
+      client = new_client(encoding: 'latin1')
+      with_internal_encoding(internal) do
+        expect { client.query("SELECT missing_é".encode('ISO-8859-1')) }.to raise_error(Mysql2::Error) { |error|
+          expect(error.message.valid_encoding?).to eq(true)
+          expect(error.message.encoding).to eq(internal || Encoding::ISO_8859_1)
+          expect(error.message.encode('UTF-8')).to include('missing_é')
+          expect(error.error_number).to eq(1054)
+          expect(error.sql_state).to eq('42S22')
+        }
+      end
+      expect(client.query('SELECT 3 AS n').first['n']).to eq(3)
+    end
+  end
+
+  it 'keeps client-library errors UTF-8 regardless of the connection charset' do
+    socket = '/nonexistent/mysql2_missing_é.sock'
+    expect { Mysql2::Client.new(socket: socket, host: nil, encoding: 'latin1') }.to raise_error(Mysql2::Error::ConnectionError) { |error|
+      expect(error.error_number).to be_between(2000, 2999)
+      expect(error.message.valid_encoding?).to eq(true)
+      expect(error.message.encoding).to eq(Encoding::UTF_8)
+      expect(error.message).to include('mysql2_missing_é')
+    }
+  end
+
+  it 'preserves UTF-8 errors on a UTF-8 connection' do
+    expect { @client.query('SELECT missing_é') }.to raise_error(Mysql2::Error) { |error|
+      expect(error.message.valid_encoding?).to eq(true)
+      expect(error.message).to include('missing_é')
+    }
+  end
+end


### PR DESCRIPTION
The server sends its error messages in `character_set_results`, the connection charset, but `Client#query` errors are tagged UTF-8 regardless. On a latin1 connection an error naming a non-ASCII identifier -- "Unknown column 'missing_é'" -- is therefore invalid as UTF-8, and `Mysql2::Error`'s cleanup turns the identifier into "missing_?" (or, with no `default_internal`, hands back a UTF-8-tagged string of latin1 bytes). Prepared-statement errors are already tagged with the connection encoding; the client path was not.

Tag a server error with the connection encoding mysql2 tracks (the `encoding` option), as the statement path does, and leave transcoding to `default_internal` where it already happens, in `Mysql2::Error`. Client-library errors -- error numbers 2000-2999, English text with caller-supplied strings such as a socket path interpolated as given -- keep the UTF-8 tag, as does anything raised before a charset is set. SQLSTATE is unchanged.

Four examples cover a latin1 connection's query error with no `default_internal` and with `default_internal` UTF-8 (intact identifier, error number, SQLSTATE, and a working query afterwards), a client-library connection error on a latin1 client with a UTF-8 socket path, and a UTF-8 connection.

Validated on Ruby 3.3.10 with MySQL/libmysqlclient 9.6.0 on macOS arm64: the focused examples give 4 examples, 2 failures on the unmodified baseline (the two latin1 query errors) and 4 examples, 0 failures with this change; full suite 638 examples, 0 failures, 26 pending. Changed Ruby files pass RuboCop; the patch passes the whitespace check.

Limits: this describes MySQL 5.5 and later, which convert error messages to `character_set_results`; for older servers `Mysql2::Error` keeps forcing UTF-8 as before. Like result strings and statement errors, the tag follows the charset mysql2 set at connect time; a later `SET NAMES` or `SET character_set_results` is not tracked (with `character_set_results` NULL or `binary` the server sends UTF-8). mysql2 maps MySQL's latin1 to Ruby's ISO-8859-1, so the cp1252-only code points of MySQL's latin1 are not preserved by that mapping -- unchanged by this fix. Alternate server message languages and pre-handshake errors have not been tested. Other Ruby, operating-system, and MySQL/MariaDB combinations have not been run locally.
