### PR TITLE
Keep cached prepared rows usable after Statement#close

### DIFF
--- a/ext/mysql2/result.c
+++ b/ext/mysql2/result.c
@@ -2240,7 +2240,11 @@ static VALUE rb_mysql_result_each(int argc, VALUE * argv, VALUE self) {
 
   GET_RESULT(self);
 
-  if (wrapper->stmt_wrapper && wrapper->stmt_wrapper->closed) {
+  /* A buffered prepared result was materialized by Statement#execute and
+   * replays from its cached rows without the native statement; a stream
+   * still needs it. */
+  if (wrapper->stmt_wrapper && wrapper->stmt_wrapper->closed &&
+      (!wrapper->resultFreed || wrapper->is_streaming)) {
     rb_raise(cMysql2Error, "Statement handle already closed");
   }
 

--- a/spec/mysql2/cached_prepared_rows_spec.rb
+++ b/spec/mysql2/cached_prepared_rows_spec.rb
@@ -1,0 +1,45 @@
+require 'spec_helper'
+
+RSpec.describe 'cached prepared results after statement close' do
+  %i[hash array].each do |shape|
+    it "replays fully materialized #{shape} rows after closing the statement" do
+      statement = @client.prepare('SELECT 1 AS n UNION ALL SELECT 2 ORDER BY n')
+      result = statement.execute(as: shape)
+      statement.close
+      expected = shape == :array ? [[1], [2]] : [{ 'n' => 1 }, { 'n' => 2 }]
+      expect(result.to_a).to eq(expected)
+      expect(result.to_a).to eq(expected)
+      expect(result.first).to eq(expected.first)
+      expect(result.fields).to eq(['n'])
+      # Integer types and display widths differ between servers; an integer
+      # family name is enough to show the cached metadata survived close.
+      expect(result.field_types.first).to match(/int/)
+      expect(result.size).to eq(2)
+      expect(@client.query('SELECT 3 AS n').first['n']).to eq(3)
+    end
+  end
+
+  it 'replays an empty materialized result after closing the statement' do
+    statement = @client.prepare('SELECT 1 AS n WHERE 0')
+    result = statement.execute
+    statement.close
+    expect(result.to_a).to eq([])
+    expect(result.to_a).to eq([])
+    expect(result.size).to eq(0)
+    expect(result.fields).to eq(['n'])
+  end
+
+  %w[unread half-read completed].each do |state|
+    it "still rejects a #{state} prepared stream after closing the statement" do
+      statement = @client.prepare('SELECT 1 AS n UNION ALL SELECT 2 ORDER BY n')
+      result = statement.execute(stream: true, cache_rows: false)
+      case state
+      when 'half-read' then expect(result.first).to eq('n' => 1)
+      when 'completed' then expect(result.to_a).to eq([{ 'n' => 1 }, { 'n' => 2 }])
+      end
+      statement.close
+      expect { result.to_a }.to raise_error(Mysql2::Error, /Statement handle already closed/)
+      expect(@client.query('SELECT 3 AS n').first['n']).to eq(3)
+    end
+  end
+end


### PR DESCRIPTION
A buffered prepared result has already materialized its Ruby rows -- `Statement#execute` iterates the result itself and frees the native result -- yet closing the statement makes a later `Result#to_a` raise "Statement handle already closed". Replaying cached rows never touches the native statement.

Apply the closed-statement guard only while the result still needs the native statement: a stream, or a buffered result that is still being materialized (its native result not yet freed). A buffered result that has already been freed replays through the existing freed-result and cache checks (a non-streaming prepared result always caches its rows: `cache_rows` is forced for prepared statements). A closed statement's stream -- unread, half-read, or completed -- keeps raising "Statement handle already closed".

The six examples cover repeated replay of cached hash and array rows with their field names and type family, an empty cached result, and rejection of an unread, a half-read, and a completed prepared stream after `close` with the original error, each followed by a working query.

Validated on Ruby 3.3.10 with MySQL/libmysqlclient 9.6.0 on macOS arm64: the focused examples give 6 examples, 3 failures on the unmodified baseline and 6 examples, 0 failures with this change; full suite 640 examples, 0 failures, 26 pending. Changed Ruby files pass RuboCop; the patch passes the whitespace check.

This permits replay of fully cached buffered results only; it does not reopen a statement or make streams replayable. Other Ruby, operating-system, and MySQL/MariaDB combinations have not been run locally.
