### PR TITLE
Initialize LOCAL INFILE callback state before anything can fail

### DIFF
--- a/ext/mysql2/infile.c
+++ b/ext/mysql2/infile.c
@@ -26,10 +26,13 @@ typedef struct
 static int
 mysql2_local_infile_init(void **ptr, const char *filename, void *userdata)
 {
-  mysql2_local_infile_data *data = malloc(sizeof(mysql2_local_infile_data));
+  mysql2_local_infile_data *data;
+  *ptr = NULL;
+  data = malloc(sizeof(mysql2_local_infile_data));
   if (!data) return 1;
 
   *ptr = data;
+  data->fd = -1;
   data->error[0] = 0;
   data->wrapper = userdata;
 
@@ -39,6 +42,11 @@ mysql2_local_infile_init(void **ptr, const char *filename, void *userdata)
     return 1;
   }
 
+  /* Not retried on EINTR: the whole LOAD DATA LOCAL round trip runs without
+   * the GVL under RUBY_UBF_IO, whose only way to cancel a blocked open or
+   * read is the signal that makes it fail with EINTR. Reporting that failure
+   * lets the client library abandon the transfer and the pending Ruby
+   * exception surface. */
   data->fd = open(filename, O_RDONLY);
   if (data->fd < 0) {
     snprintf(data->error, ERROR_LEN, "%s: %s", strerror(errno), filename);
@@ -61,6 +69,8 @@ mysql2_local_infile_read(void *ptr, char *buf, unsigned int buf_len)
   int count;
   mysql2_local_infile_data *data = (mysql2_local_infile_data *)ptr;
 
+  /* See the open() note in mysql2_local_infile_init: an EINTR here is how a
+   * blocked transfer gets cancelled, so it is reported, not retried. */
   count = (int)read(data->fd, buf, buf_len);
   if (count < 0) {
     snprintf(data->error, ERROR_LEN, "%s: %s", strerror(errno), data->filename);

--- a/spec/mysql2/infile_native_spec.rb
+++ b/spec/mysql2/infile_native_spec.rb
@@ -1,0 +1,33 @@
+require 'spec_helper'
+require 'tmpdir'
+require 'fileutils'
+require 'open3'
+require 'rbconfig'
+require 'shellwords'
+
+RSpec.describe 'LOCAL INFILE native error recovery' do
+  before(:context) do
+    skip 'the native callback fixture requires a POSIX C compiler' if RUBY_PLATFORM =~ /mswin|mingw/
+
+    @native_directory = Dir.mktmpdir('mysql2-infile-regression')
+    @native_binary = File.join(@native_directory, 'infile-regression')
+    source = File.expand_path('../native/infile/regression.c', __dir__)
+    include_dir = File.dirname(source)
+    driver = ENV.fetch('MYSQL2_INFILE_SOURCE', File.expand_path('../../ext/mysql2/infile.c', __dir__))
+    command = Shellwords.split(RbConfig::CONFIG.fetch('CC')) +
+              ['-I', include_dir, "-DMYSQL2_INFILE_SOURCE=\"#{driver}\"", source, '-o', @native_binary]
+    output, status = Open3.capture2e(*command)
+    raise "Cannot compile LOCAL INFILE regression: #{output}" unless status.success?
+  end
+
+  after(:context) do
+    FileUtils.remove_entry(@native_directory) if @native_directory
+  end
+
+  %w[malloc strdup open_eintr open_error read_eintr read_error eof success].each do |scenario|
+    it "handles #{scenario} without touching unrelated descriptors or retrying an interrupted call" do
+      output, status = Open3.capture2e(@native_binary, scenario)
+      expect(status.success?).to eq(true), output
+    end
+  end
+end

--- a/spec/native/infile/mysql2_ext.h
+++ b/spec/native/infile/mysql2_ext.h
@@ -1,0 +1,18 @@
+/* Minimal declarations for testing the real LOCAL INFILE callbacks in isolation. */
+#ifndef MYSQL2_INFILE_TEST_EXT_H
+#define MYSQL2_INFILE_TEST_EXT_H
+#include <stdlib.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdbool.h>
+typedef struct { int unused; } MYSQL;
+typedef struct { int unused; } mysql_client_wrapper;
+#define CR_UNKNOWN_ERROR 2000
+#define CR_OUT_OF_MEMORY 2008
+static void mysql_set_local_infile_handler(MYSQL *mysql,
+    int (*init)(void **, const char *, void *),
+    int (*read_cb)(void *, char *, unsigned int), void (*end)(void *),
+    int (*error)(void *, char *, unsigned int), void *userdata) {
+  (void)mysql; (void)init; (void)read_cb; (void)end; (void)error; (void)userdata;
+}
+#endif

--- a/spec/native/infile/regression.c
+++ b/spec/native/infile/regression.c
@@ -1,0 +1,113 @@
+#include "mysql2_ext.h"
+#include <assert.h>
+#include <errno.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <sys/resource.h>
+
+static int fail_malloc, fail_strdup, interrupt_open, interrupt_read;
+static int fail_open, fail_read, return_eof, closed_count, open_count, read_count;
+static void *test_malloc(size_t size) {
+  void *ptr;
+  if (fail_malloc) { errno = ENOMEM; return NULL; }
+  ptr = malloc(size);
+  if (ptr) memset(ptr, 0, size);
+  return ptr;
+}
+static char *test_strdup(const char *str) {
+  if (fail_strdup) { errno = ENOMEM; return NULL; }
+  return strdup(str);
+}
+static int test_open(const char *filename, int flags) {
+  (void)filename; (void)flags;
+  open_count++;
+  if (interrupt_open > 0) { interrupt_open--; errno = EINTR; return -1; }
+  if (fail_open) { errno = ENOENT; return -1; }
+  return 42;
+}
+static ssize_t test_read(int fd, void *buf, size_t length) {
+  assert(fd == 42);
+  assert(length >= 3);
+  read_count++;
+  if (interrupt_read > 0) { interrupt_read--; errno = EINTR; return -1; }
+  if (fail_read) { errno = EIO; return -1; }
+  if (return_eof) return 0;
+  memcpy(buf, "abc", 3);
+  return 3;
+}
+static int test_close(int fd) { assert(fd == 42); closed_count++; return 0; }
+
+#define malloc test_malloc
+#define strdup test_strdup
+#define open test_open
+#define read test_read
+#define close test_close
+#ifndef MYSQL2_INFILE_SOURCE
+#define MYSQL2_INFILE_SOURCE "../../../ext/mysql2/infile.c"
+#endif
+#include MYSQL2_INFILE_SOURCE
+#undef malloc
+#undef strdup
+#undef open
+#undef read
+#undef close
+
+int main(int argc, char **argv) {
+  void *ptr = (void *)1;
+  char buffer[128];
+  int rc, interrupted = 0;
+  struct rlimit core_limit = {0, 0};
+  setrlimit(RLIMIT_CORE, &core_limit);
+  assert(argc == 2);
+  if (!strcmp(argv[1], "malloc")) {
+    fail_malloc = 1;
+    assert(mysql2_local_infile_init(&ptr, "fixture", NULL) == 1);
+    assert(ptr == NULL);
+    assert(mysql2_local_infile_error(ptr, buffer, sizeof(buffer)) == CR_OUT_OF_MEMORY);
+    mysql2_local_infile_end(ptr);
+    assert(closed_count == 0);
+  } else if (!strcmp(argv[1], "strdup")) {
+    fail_strdup = 1;
+    assert(mysql2_local_infile_init(&ptr, "fixture", NULL) == 1);
+    assert(mysql2_local_infile_error(ptr, buffer, sizeof(buffer)) == CR_UNKNOWN_ERROR);
+    mysql2_local_infile_end(ptr);
+    assert(closed_count == 0);
+  } else if (!strcmp(argv[1], "open_error") || !strcmp(argv[1], "open_eintr")) {
+    /* An interrupted open is reported like any other failure, once: it is
+     * how a cancelled transfer stops. */
+    fail_open = !strcmp(argv[1], "open_error");
+    interrupt_open = !strcmp(argv[1], "open_eintr") ? 1 : 0;
+    assert(mysql2_local_infile_init(&ptr, "fixture", NULL) == 1);
+    assert(open_count == 1);
+    assert(mysql2_local_infile_error(ptr, buffer, sizeof(buffer)) == CR_UNKNOWN_ERROR);
+    assert(strstr(buffer, "fixture") != NULL);
+    mysql2_local_infile_end(ptr);
+    assert(closed_count == 0);
+  } else {
+    assert(mysql2_local_infile_init(&ptr, "fixture", NULL) == 0);
+    assert(open_count == 1);
+    interrupted = !strcmp(argv[1], "read_eintr");
+    interrupt_read = interrupted;
+    fail_read = !strcmp(argv[1], "read_error");
+    return_eof = !strcmp(argv[1], "eof");
+    rc = mysql2_local_infile_read(ptr, buffer, sizeof(buffer));
+    if (fail_read || interrupted) {
+      /* An interrupted read is reported like an I/O error, once. */
+      assert(rc == -1);
+      assert(read_count == 1);
+      assert(mysql2_local_infile_error(ptr, buffer, sizeof(buffer)) == CR_UNKNOWN_ERROR);
+      assert(strstr(buffer, "fixture") != NULL);
+    } else if (return_eof) {
+      assert(rc == 0);
+      assert(read_count == 1);
+    } else {
+      assert(rc == 3);
+      assert(read_count == 1);
+      assert(!memcmp(buffer, "abc", 3));
+    }
+    mysql2_local_infile_end(ptr);
+    assert(closed_count == 1);
+  }
+  puts("passed");
+  return 0;
+}


### PR DESCRIPTION
The LOCAL INFILE init callback leaves two things undefined when an allocation fails: it returns before storing anything through its output pointer (the client library then hands whatever that pointer held to the end and error callbacks), and after a failed `strdup` the descriptor field is uninitialized, so the end callback can `close()` an arbitrary descriptor -- descriptor 0 with a zeroed allocation.

Store NULL through the output pointer before the first allocation and initialize the descriptor to -1 before the second, so a failed init reports "Out of memory" / the strerror text through the existing error callback and the end callback closes nothing that was never opened. Ordinary open/read failures, EOF and successful reads are unchanged.

An interrupted `open` or `read` (EINTR) is deliberately still reported as a failure rather than retried: the whole LOAD DATA LOCAL round trip runs without the GVL under `RUBY_UBF_IO`, whose only way to stop a callback blocked in a syscall -- reading a FIFO that never delivers, for instance -- is the signal that makes the syscall fail with EINTR. Reporting that failure lets the client library abandon the transfer and the pending Ruby exception surface; a retry loop would block again and defer cancellation indefinitely. The two callbacks now say so in comments.

Eight cases compile the real `ext/mysql2/infile.c` into a small fault-injection executable (`spec/native/infile/`, POSIX only, skipped on Windows) with `malloc`, `strdup`, `open`, `read` and `close` stubbed: malloc failure, strdup failure, open failure, interrupted open, read failure, interrupted read, EOF and a successful read, each checking the returned status, the error code and text, and that only the descriptor the callback opened is ever closed. The malloc and strdup cases fail on the unmodified driver; the interrupted cases pin the no-retry contract and pass either way.

Validated on Ruby 3.3.10 with MySQL/libmysqlclient 9.6.0 on macOS arm64: the focused examples give 8 examples, 2 failures on the unmodified baseline and 8 examples, 0 failures with this change; full suite 642 examples, 0 failures, 26 pending. Changed Ruby files pass RuboCop; the patch passes the whitespace check.

This is callback-source fault injection, not a live client-library transfer with injected failures; the local server has LOCAL INFILE disabled, so the four existing live-transfer examples are pending here. Other Ruby, operating-system, and MySQL/MariaDB combinations have not been run locally.
